### PR TITLE
fix: restore npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -88,6 +89,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/doc/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/RELEASE-AUTOMATION-SETUP.md
@@ -76,6 +76,12 @@ After the workflows are live:
 3. run a stable dry-run
 4. run one real stable publish
 
+Implementation detail:
+
+- the release workflow uses `actions/setup-node` with `registry-url: https://registry.npmjs.org`
+- package publish runs through `npm publish --provenance`
+- `pnpm` is still used for install/build/test, but not for the final registry publish step
+
 Only after that should you remove old token-based access.
 
 ## 3. Remove Legacy npm Tokens
@@ -96,6 +102,8 @@ Create two environments in the GitHub repository:
 
 - `npm-canary`
 - `npm-stable`
+
+Both environments must exist before the full release pipeline is considered ready. A missing `npm-stable` environment will not break canaries, but it will block or weaken the stable approval path.
 
 Path:
 
@@ -257,7 +265,8 @@ Check:
 1. the workflow filename on GitHub exactly matches the filename configured in npm
 2. the package has the trusted publisher entry for the correct repository
 3. the job has `id-token: write`
-4. the job is running from the expected repository, not a fork
+4. `actions/setup-node` sets `registry-url: https://registry.npmjs.org`
+5. the job is running from the expected repository, not a fork
 
 ### Stable workflow runs but never asks for approval
 

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -67,7 +67,7 @@ It:
 
 - verifies the pushed commit
 - computes the canary version for the current UTC date
-- publishes under npm dist-tag `canary`
+- publishes under npm dist-tag `canary` with `npm publish --provenance`
 - creates a git tag `canary/vYYYY.MDD.P-canary.N`
 
 Users install canaries with:
@@ -111,7 +111,7 @@ The workflow:
 
 - re-verifies the exact source ref
 - computes the next stable patch slot for the chosen UTC date
-- publishes `YYYY.MDD.P` under npm dist-tag `latest`
+- publishes `YYYY.MDD.P` under npm dist-tag `latest` with `npm publish --provenance`
 - creates git tag `vYYYY.MDD.P`
 - creates or updates the GitHub Release from `releases/vYYYY.MDD.P.md`
 
@@ -165,6 +165,12 @@ Stable GitHub Releases are now formalized with these rules:
 5. the release notes should follow [`releases/TEMPLATE.md`](../releases/TEMPLATE.md)
 
 This keeps the GitHub release surface deterministic and machine-repeatable.
+
+The publish jobs rely on npm trusted publishing from GitHub Actions. In practice that means:
+
+- `actions/setup-node` must set `registry-url: https://registry.npmjs.org`
+- the publish job must keep `id-token: write`
+- the release script must publish through the npm CLI, not `pnpm publish`
 
 The repo intentionally does not run this through GitHub Actions because:
 

--- a/releases/v2026.401.0.md
+++ b/releases/v2026.401.0.md
@@ -1,0 +1,40 @@
+# v2026.401.0
+
+> Released: 2026-04-01
+
+## Summary
+
+This release turns AgentDash into a cleaner public package and a more usable operator platform. It folds in the AgentDash rebrand, working CRM workflow actions, stronger run orchestration primitives, and a formal release pipeline for canary and stable promotion.
+
+## Highlights
+
+- AgentDash is now packaged and branded consistently for commercial use, including the `agentdash` CLI, `@agentdash/*` package namespace, updated customer-facing copy, and third-party notices.
+- CRM and pipeline workflows are now operable instead of read-only, with working create flows for accounts, leads, deals, partners, and HubSpot connect or sync actions.
+- The orchestration core now supports richer company skill metadata, relevant-skill selection per run, delegated child runs and child issues, issue plan artifacts, and approval-gated execution.
+- Release automation is now formalized around `agentdash-main`, automatic canaries, manual stable promotion, stable release notes, and GitHub Releases sourced from versioned notes files.
+
+## Operator Impact
+
+- Board operators and reviewers now get more deterministic agent behavior because runs receive only relevant skills instead of the full company skill inventory.
+- Issue detail now supports plan review and explicit approval gating before governed execution resumes.
+- CRM operators can create and sync pipeline records directly from the product instead of using dead-end buttons.
+- Self-hosted and npm consumers should use `agentdash` and `@agentdash/*` going forward. The repo keeps compatibility-oriented `paperclip` internals where they are part of the upstream runtime contract.
+- No manual migration steps are expected beyond the normal server migration path, but this release does include additive database changes for skill metadata, run lineage, and issue plan approval support.
+
+## Fixes
+
+- Removed the non-commercial CodeSandbox/Nodebox editor dependency path from the shipped UI package.
+- Tightened release publishing to use npm trusted publishing through the npm CLI with registry-aware GitHub Actions setup.
+- Fixed multiple CRM route and tenancy issues so create/update flows are company-scoped and user-visible actions return proper errors.
+- Improved inbox, workspace runtime, worktree, and onboarding reliability with follow-up fixes shipped throughout the release line.
+
+## Verification
+
+- `pnpm -r typecheck`
+- `pnpm test:run`
+- `pnpm build`
+
+## Notes
+
+- Stable publishing expects both GitHub environments, `npm-canary` and `npm-stable`, to exist. `npm-stable` should be protected with reviewer approval in the canonical repo.
+- The stable publish path now relies on npm trusted publishing with `npm publish --provenance`; the release workflow should not be converted back to token-only publishing unless npm OIDC is unavailable.

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -296,8 +296,17 @@ require_npm_publish_auth() {
   fi
 
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    release_info "  ✓ npm publish auth will be provided by GitHub Actions trusted publishing"
-    return
+    if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+      release_info "  ✓ npm publish auth will be provided by GitHub Actions trusted publishing"
+      return
+    fi
+
+    if [ -n "${NODE_AUTH_TOKEN:-}" ] || [ -n "${NPM_TOKEN:-}" ]; then
+      release_info "  ✓ npm publish auth will be provided by GitHub Actions token-based npm auth"
+      return
+    fi
+
+    release_fail "GitHub Actions release job is missing npm publish auth. Configure OIDC trusted publishing or provide NODE_AUTH_TOKEN/NPM_TOKEN."
   fi
 
   release_fail "npm publish auth is not available. Use 'npm login' locally or run from GitHub Actions with trusted publishing."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -244,7 +244,7 @@ if [ "$dry_run" = true ]; then
     [ -z "$pkg_dir" ] && continue
     release_info "  --- $pkg_dir ---"
     cd "$REPO_ROOT/$pkg_dir"
-    pnpm publish --dry-run --no-git-checks --tag "$DIST_TAG" 2>&1 | tail -3
+    npm publish --dry-run --tag "$DIST_TAG" 2>&1 | tail -3
   done <<< "$VERSIONED_PACKAGE_INFO"
   release_info "  [dry-run] Would create git tag $tag_name on $CURRENT_SHA"
 else
@@ -253,7 +253,7 @@ else
     [ -z "$pkg_dir" ] && continue
     release_info "  Publishing $pkg_name@$pkg_version"
     cd "$REPO_ROOT/$pkg_dir"
-    pnpm publish --no-git-checks --tag "$DIST_TAG" --access public
+    npm publish --provenance --tag "$DIST_TAG" --access public
   done <<< "$VERSIONED_PACKAGE_INFO"
   release_info "  ✓ Published all packages under dist-tag $DIST_TAG"
 fi


### PR DESCRIPTION
## Thinking Path

> - Paperclip, now branded as AgentDash in this fork, ships as a public npm package and relies on GitHub Actions for release automation.
> - The release subsystem owns canary and stable npm publishes, git tags, and GitHub Releases from `agentdash-main`.
> - The latest canary workflow was already passing verification but failing at publish time with `npm ERR! code ENEEDAUTH`.
> - The repo was configured for GitHub OIDC trusted publishing, but the workflow and script path still behaved like a plain CLI auth flow.
> - This pull request switches the publish path onto npm's trusted-publishing-friendly flow, makes the workflow registry-aware, and adds the next stable notes file.
> - The benefit is that automatic canaries can publish again and stable promotion has a clean, documented path.

## What Changed

- Added `registry-url: https://registry.npmjs.org` to the canary and stable publish jobs in [`.github/workflows/release.yml`](./.github/workflows/release.yml).
- Switched `scripts/release.sh` from `pnpm publish` to `npm publish --provenance` for real publishes and `npm publish --dry-run` for previews.
- Tightened `scripts/release-lib.sh` so GitHub Actions only claims trusted publishing auth when OIDC or token auth is actually present.
- Updated [`doc/RELEASING.md`](./doc/RELEASING.md) and [`doc/RELEASE-AUTOMATION-SETUP.md`](./doc/RELEASE-AUTOMATION-SETUP.md) to match the live trusted publishing path and note that both `npm-canary` and `npm-stable` environments must exist.
- Added stable release notes at [`releases/v2026.401.0.md`](./releases/v2026.401.0.md).
- Created the missing `npm-stable` GitHub environment in `thetangstr/agentdash` so stable promotion is available once this lands.

## Verification

- `pnpm -r typecheck`
- `pnpm build`
- `./scripts/release.sh stable --date 2026-04-01 --dry-run --skip-verify`
- `pnpm test:run`
- `pnpm vitest run server/src/__tests__/agent-instructions-routes.test.ts`
- `pnpm vitest run server/src/__tests__/agent-permissions-routes.test.ts`

`pnpm test:run` hit unrelated local flakes in `agent-instructions-routes.test.ts` and `agent-permissions-routes.test.ts`; both passed when rerun directly.

## Risks

- Low risk in product behavior; this only touches release infrastructure, release docs, and the stable notes artifact.
- The remaining external risk is npm-side trusted publisher configuration. If any package is missing the trusted publisher entry in npm, publish will still fail even with this fix.
- `npm-stable` exists now, but best practice is still to add reviewer protection on that environment before using it for live stable publishes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
