### PR TITLE
Add Agent Factory Research integration

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -42,6 +42,7 @@ import { hubspotRoutes } from "./routes/hubspot.js";
 import { actionProposalRoutes } from "./routes/action-proposals.js";
 import { pipelineRoutes } from "./routes/pipelines.js";
 import { feedRoutes } from "./routes/feed.js";
+import { agentResearchRoutes } from "./routes/agent-research.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -177,6 +178,7 @@ export async function createApp(
   api.use(budgetExtendedRoutes(db));
   api.use(skillsRegistryRoutes(db));
   api.use(autoresearchRoutes(db));
+  api.use(agentResearchRoutes(db));
   api.use(onboardingRoutes(db));
   api.use(crmRoutes(db));
   api.use(hubspotRoutes(db));

--- a/server/src/routes/agent-research.ts
+++ b/server/src/routes/agent-research.ts
@@ -1,0 +1,97 @@
+/**
+ * AgentDash Integration: Agent Research Routes
+ *
+ * Copy this file to: agentdash/server/src/routes/agent-research.ts
+ *
+ * Then register in app.ts:
+ *   import { agentResearchRoutes } from "./routes/agent-research.js";
+ *   api.use(agentResearchRoutes(db));
+ */
+
+import { Router } from "express";
+import type { Db } from "@agentdash/db";
+import { companies, companyContext } from "@agentdash/db";
+import { eq } from "drizzle-orm";
+import { agentResearchService } from "../services/agent-research.js";
+import { assertBoard, assertCompanyAccess } from "./authz.js";
+
+export function agentResearchRoutes(db: Db) {
+  const router = Router();
+  const svc = agentResearchService(db);
+
+  // POST /companies/:companyId/agent-research — trigger assessment
+  router.post("/companies/:companyId/agent-research", async (req, res) => {
+    try {
+      assertBoard(req);
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+
+      const [company] = await db
+        .select()
+        .from(companies)
+        .where(eq(companies.id, companyId))
+        .limit(1);
+
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+
+      // Pull existing context for richer input
+      const contextRows = await db
+        .select()
+        .from(companyContext)
+        .where(eq(companyContext.companyId, companyId));
+
+      const ctxMap = Object.fromEntries(
+        contextRows.map((r) => [r.key, r.value]),
+      );
+
+      const input = {
+        companyName: company.name,
+        industry: ctxMap.domain ?? req.body.industry ?? "Technology",
+        description: company.description ?? "",
+        companyUrl: req.body.companyUrl,
+        employeeRange: req.body.employeeRange,
+        revenueRange: req.body.revenueRange,
+        currentSystems: ctxMap.tech_stack ?? req.body.currentSystems,
+        automationLevel: req.body.automationLevel,
+        challenges: ctxMap.pain_point ?? req.body.challenges,
+        selectedFunctions: req.body.selectedFunctions,
+        primaryGoal: req.body.primaryGoal ?? "Both",
+        targets: req.body.targets,
+        timeline: req.body.timeline,
+        budgetRange: req.body.budgetRange,
+      };
+
+      const result = await svc.requestAssessment(companyId, input);
+      res.status(200).json(result);
+    } catch (err: unknown) {
+      const status = (err as { statusCode?: number }).statusCode ?? 500;
+      const message = err instanceof Error ? err.message : "Internal server error";
+      res.status(status).json({ error: message });
+    }
+  });
+
+  // GET /companies/:companyId/agent-research — get stored assessment
+  router.get("/companies/:companyId/agent-research", async (req, res) => {
+    try {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+
+      const result = await svc.getAssessment(companyId);
+      if (!result) {
+        res.status(404).json({ error: "No assessment found. Run one first." });
+        return;
+      }
+
+      res.status(200).json(result);
+    } catch (err: unknown) {
+      const status = (err as { statusCode?: number }).statusCode ?? 500;
+      const message = err instanceof Error ? err.message : "Internal server error";
+      res.status(status).json({ error: message });
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/agent-research.ts
+++ b/server/src/services/agent-research.ts
@@ -1,0 +1,152 @@
+/**
+ * AgentDash Integration: Agent Research Service
+ *
+ * Copy this file to: agentdash/server/src/services/agent-research.ts
+ *
+ * Then register the route in app.ts:
+ *   import { agentResearchRoutes } from "./routes/agent-research.js";
+ *   api.use(agentResearchRoutes(db));
+ *
+ * Required env vars:
+ *   RESEARCH_APP_URL=https://your-research-app.vercel.app
+ *   RESEARCH_APP_API_KEY=ark_...
+ */
+
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@agentdash/db";
+import { companyContext } from "@agentdash/db";
+import { logger } from "../middleware/logger.js";
+
+const RESEARCH_APP_URL = process.env.RESEARCH_APP_URL ?? "";
+const RESEARCH_APP_API_KEY = process.env.RESEARCH_APP_API_KEY ?? "";
+
+interface AssessmentInput {
+  companyName: string;
+  industry: string;
+  industrySlug?: string;
+  description?: string;
+  companyUrl?: string;
+  employeeRange?: string;
+  revenueRange?: string;
+  currentSystems?: string;
+  automationLevel?: string;
+  challenges?: string;
+  selectedFunctions?: string[];
+  primaryGoal?: string;
+  targets?: string;
+  timeline?: string;
+  budgetRange?: string;
+}
+
+interface AssessmentResult {
+  id: string | null;
+  companyName: string;
+  industry: string;
+  status: string;
+  outputMarkdown: string;
+  durationMs: number;
+  createdAt: string;
+}
+
+function toSlug(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+export function agentResearchService(db: Db) {
+  return {
+    async requestAssessment(
+      companyId: string,
+      input: AssessmentInput,
+    ): Promise<AssessmentResult> {
+      if (!RESEARCH_APP_URL || !RESEARCH_APP_API_KEY) {
+        throw Object.assign(
+          new Error("Agent Research app not configured. Set RESEARCH_APP_URL and RESEARCH_APP_API_KEY."),
+          { statusCode: 503 },
+        );
+      }
+
+      const res = await fetch(`${RESEARCH_APP_URL}/api/assess`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${RESEARCH_APP_API_KEY}`,
+        },
+        body: JSON.stringify({
+          ...input,
+          industrySlug: input.industrySlug ?? toSlug(input.industry),
+          externalRef: companyId,
+          format: "json",
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "unknown error");
+        logger.error({ status: res.status, body }, "Agent Research API error");
+        throw Object.assign(
+          new Error(`Research API returned ${res.status}: ${body}`),
+          { statusCode: 502 },
+        );
+      }
+
+      const result: AssessmentResult = await res.json();
+
+      // Store in company_context
+      await db
+        .insert(companyContext)
+        .values({
+          companyId,
+          contextType: "agent_research",
+          key: "readiness-assessment",
+          value: result.outputMarkdown,
+          confidence: "0.95",
+        })
+        .onConflictDoUpdate({
+          target: [companyContext.companyId, companyContext.contextType, companyContext.key],
+          set: {
+            value: result.outputMarkdown,
+            confidence: "0.95",
+            updatedAt: new Date(),
+          },
+        });
+
+      if (result.id) {
+        await db
+          .insert(companyContext)
+          .values({
+            companyId,
+            contextType: "agent_research",
+            key: "assessment-id",
+            value: result.id,
+            confidence: "0.99",
+          })
+          .onConflictDoUpdate({
+            target: [companyContext.companyId, companyContext.contextType, companyContext.key],
+            set: { value: result.id, updatedAt: new Date() },
+          });
+      }
+
+      return result;
+    },
+
+    async getAssessment(companyId: string): Promise<{ markdown: string; assessmentId: string | null } | null> {
+      const rows = await db
+        .select()
+        .from(companyContext)
+        .where(
+          and(
+            eq(companyContext.companyId, companyId),
+            eq(companyContext.contextType, "agent_research"),
+          ),
+        );
+
+      const markdownRow = rows.find((r) => r.key === "readiness-assessment");
+      const idRow = rows.find((r) => r.key === "assessment-id");
+
+      if (!markdownRow) return null;
+      return { markdown: markdownRow.value, assessmentId: idRow?.value ?? null };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `agent-research` service that calls the Agent Factory Research app's `/api/assess` endpoint
- Adds Express routes for `POST/GET /companies/:companyId/agent-research`
- Stores assessment results in `company_context` table with `contextType: "agent_research"`
- Wired into `app.ts` route registration

## Setup
1. Set `RESEARCH_APP_URL` and `RESEARCH_APP_API_KEY` env vars
2. Generate API key from the research app at https://washington-smoky.vercel.app

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Test POST endpoint triggers assessment and stores result
- [ ] Test GET endpoint retrieves stored assessment
- [ ] Verify CORS headers allow cross-origin requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)