### PR TITLE
feat(goals): creation-only Goals page (AGE-43)

### DIFF
--- a/tests/e2e/goals.spec.ts
+++ b/tests/e2e/goals.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * AGE-43: Goals page is a creation-only entry point.
+ *
+ * Asserts:
+ *   - /goals renders the "New Goal" CTA
+ *   - /goals does NOT render a GoalTree / list of existing goals, even when
+ *     the company already has goals
+ *   - Clicking "New Goal" opens the NewGoalDialog with the parent-goal
+ *     selector hidden (hideParentSelector: true on this launch path)
+ *   - /goals/:id remains accessible by direct URL
+ */
+
+interface Company { id: string; name: string; issuePrefix: string }
+interface Goal { id: string; title: string; level: string }
+
+async function createCompany(
+  page: import("@playwright/test").Page,
+  suffix?: string,
+): Promise<Company> {
+  const ts = Date.now();
+  const name = `E2E-Goals-${suffix ?? ts}`;
+  const prefix = `G${ts.toString().slice(-5)}`;
+  const res = await page.request.post("/api/companies", {
+    data: { name, issuePrefix: prefix },
+  });
+  expect(res.ok(), `create company failed: ${await res.text()}`).toBe(true);
+  return res.json();
+}
+
+async function createGoal(
+  page: import("@playwright/test").Page,
+  companyId: string,
+  title: string,
+  level = "company",
+): Promise<Goal> {
+  const res = await page.request.post(`/api/companies/${companyId}/goals`, {
+    data: { title, level },
+  });
+  expect(res.ok(), `create goal "${title}" failed: ${await res.text()}`).toBe(true);
+  return res.json();
+}
+
+async function gotoGoals(page: import("@playwright/test").Page, prefix: string) {
+  await page.goto(`/${prefix}/goals`);
+  await page.locator("nav").first().waitFor({ state: "visible", timeout: 15_000 });
+}
+
+test.describe("AGE-43: /goals creation-only entry point", () => {
+  test("shows New Goal CTA and does NOT render GoalTree list", async ({ page }) => {
+    const company = await createCompany(page, "cta");
+    // Seed existing goals so the list would normally render if we hadn't
+    // removed it. This is the regression guard for AGE-43.
+    await createGoal(page, company.id, "Existing goal alpha");
+    await createGoal(page, company.id, "Existing goal beta");
+
+    await gotoGoals(page, company.issuePrefix);
+
+    // Empty-state CTA copy is visible.
+    await expect(
+      page.locator("text=Start a new goal to drive focused work"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // "New Goal" CTA button is visible and clickable.
+    const newGoalBtn = page.locator("button", { hasText: "New Goal" });
+    await expect(newGoalBtn).toBeVisible({ timeout: 5_000 });
+
+    // Existing goal titles MUST NOT appear in a list on /goals.
+    await expect(page.locator("text=Existing goal alpha")).toHaveCount(0);
+    await expect(page.locator("text=Existing goal beta")).toHaveCount(0);
+  });
+
+  test("New Goal dialog hides parent-goal selector when launched from /goals", async ({ page }) => {
+    const company = await createCompany(page, "parent");
+    // Pre-create a goal so the parent selector would have something to show
+    // if it were rendered.
+    await createGoal(page, company.id, "Candidate parent goal");
+
+    await gotoGoals(page, company.issuePrefix);
+
+    const newGoalBtn = page.locator("button", { hasText: "New Goal" });
+    await expect(newGoalBtn).toBeVisible({ timeout: 10_000 });
+    await newGoalBtn.click();
+
+    // The NewGoalDialog header appears (Dialog uses the title "New goal").
+    await expect(
+      page.locator("text=/Describe your goal|new goal/i").first(),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The "Parent goal" trigger must NOT be present on this launch path.
+    await expect(page.locator("button", { hasText: "Parent goal" })).toHaveCount(0);
+  });
+
+  test("GoalDetail (/goals/:id) remains accessible by direct URL", async ({ page }) => {
+    const company = await createCompany(page, "detail");
+    const goal = await createGoal(page, company.id, "Direct-link goal");
+
+    await page.goto(`/${company.issuePrefix}/goals/${goal.id}`);
+    await page.locator("nav").first().waitFor({ state: "visible", timeout: 15_000 });
+
+    // The goal title should render somewhere on the detail page.
+    await expect(page.locator(`text=${goal.title}`).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -233,37 +233,39 @@ export function NewGoalDialog() {
           </Popover>
 
           {/* Parent goal */}
-          <Popover open={parentOpen} onOpenChange={setParentOpen}>
-            <PopoverTrigger asChild>
-              <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent/50 transition-colors">
-                <Target className="h-3 w-3 text-muted-foreground" />
-                {currentParent ? currentParent.title : "Parent goal"}
-              </button>
-            </PopoverTrigger>
-            <PopoverContent className="w-48 p-1" align="start">
-              <button
-                className={cn(
-                  "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50",
-                  !appliedParentId && "bg-accent"
-                )}
-                onClick={() => { setParentId(""); setParentOpen(false); }}
-              >
-                No parent
-              </button>
-              {(goals ?? []).map((g) => (
-                <button
-                  key={g.id}
-                  className={cn(
-                    "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 truncate",
-                    g.id === appliedParentId && "bg-accent"
-                  )}
-                  onClick={() => { setParentId(g.id); setParentOpen(false); }}
-                >
-                  {g.title}
+          {!newGoalDefaults.hideParentSelector && (
+            <Popover open={parentOpen} onOpenChange={setParentOpen}>
+              <PopoverTrigger asChild>
+                <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent/50 transition-colors">
+                  <Target className="h-3 w-3 text-muted-foreground" />
+                  {currentParent ? currentParent.title : "Parent goal"}
                 </button>
-              ))}
-            </PopoverContent>
-          </Popover>
+              </PopoverTrigger>
+              <PopoverContent className="w-48 p-1" align="start">
+                <button
+                  className={cn(
+                    "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50",
+                    !appliedParentId && "bg-accent"
+                  )}
+                  onClick={() => { setParentId(""); setParentOpen(false); }}
+                >
+                  No parent
+                </button>
+                {(goals ?? []).map((g) => (
+                  <button
+                    key={g.id}
+                    className={cn(
+                      "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 truncate",
+                      g.id === appliedParentId && "bg-accent"
+                    )}
+                    onClick={() => { setParentId(g.id); setParentOpen(false); }}
+                  >
+                    {g.title}
+                  </button>
+                ))}
+              </PopoverContent>
+            </Popover>
+          )}
         </div>
 
         {/* Footer */}

--- a/ui/src/context/DialogContext.tsx
+++ b/ui/src/context/DialogContext.tsx
@@ -12,6 +12,7 @@ interface NewIssueDefaults {
 
 interface NewGoalDefaults {
   parentId?: string;
+  hideParentSelector?: boolean;
 }
 
 interface OnboardingOptions {

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -1,15 +1,9 @@
 import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { goalsApi } from "../api/goals";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
-import { queryKeys } from "../lib/queryKeys";
-import { GoalTree } from "../components/GoalTree";
 import { EmptyState } from "../components/EmptyState";
-import { PageSkeleton } from "../components/PageSkeleton";
-import { Button } from "@/components/ui/button";
-import { Target, Plus } from "lucide-react";
+import { Target } from "lucide-react";
 
 export function Goals() {
   const { selectedCompanyId } = useCompany();
@@ -20,44 +14,18 @@ export function Goals() {
     setBreadcrumbs([{ label: "Goals" }]);
   }, [setBreadcrumbs]);
 
-  const { data: goals, isLoading, error } = useQuery({
-    queryKey: queryKeys.goals.list(selectedCompanyId!),
-    queryFn: () => goalsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
-  });
-
   if (!selectedCompanyId) {
     return <EmptyState icon={Target} message="Select a company to view goals." />;
   }
 
-  if (isLoading) {
-    return <PageSkeleton variant="list" />;
-  }
-
   return (
     <div className="space-y-4">
-      {error && <p className="text-sm text-destructive">{error.message}</p>}
-
-      {goals && goals.length === 0 && (
-        <EmptyState
-          icon={Target}
-          message="No goals yet."
-          action="Add Goal"
-          onAction={() => openNewGoal()}
-        />
-      )}
-
-      {goals && goals.length > 0 && (
-        <>
-          <div className="flex items-center justify-start">
-            <Button size="sm" variant="outline" onClick={() => openNewGoal()}>
-              <Plus className="h-3.5 w-3.5 mr-1.5" />
-              New Goal
-            </Button>
-          </div>
-          <GoalTree goals={goals} goalLink={(goal) => `/goals/${goal.id}`} />
-        </>
-      )}
+      <EmptyState
+        icon={Target}
+        message="Start a new goal to drive focused work across your agents and teams."
+        action="New Goal"
+        onAction={() => openNewGoal({ hideParentSelector: true })}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Goals page (`/goals`) no longer renders the `GoalTree` of existing goals; it now always shows the "New Goal" CTA as its empty/creation state.
- `NewGoalDialog` accepts a `hideParentSelector` option. Launches from the Goals page pass it so the existing-goal parent picker is suppressed.
- Schema and API untouched. `GoalDetail` (`/goals/:id`) remains reachable via direct URL for existing links.

Linear: AGE-43 (XS, 1pt)

## Test plan
- [x] `pnpm -r typecheck` — all packages pass
- [x] `pnpm test:run` — 1521 passed, 4 failed (pre-existing on agentdash-main: company-import-export-e2e, agent-skills-routes, agentdash-cuj-routes agent templates 404, billing-routes-extended stripe webhook; none touch UI/goals)
- [x] `pnpm build` — all packages build
- [ ] Chrome CUJ: `/goals` shows only the New Goal CTA; clicking it opens the dialog without a parent-goal selector; creating a goal redirects/updates correctly; `/goals/:id` direct URL still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)