### PR TITLE
feat(AGE-40): Goal hub rollup service + UI

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,6 +18,7 @@ import { issueRoutes } from "./routes/issues.js";
 import { routineRoutes } from "./routes/routines.js";
 import { executionWorkspaceRoutes } from "./routes/execution-workspaces.js";
 import { goalRoutes } from "./routes/goals.js";
+import { goalsHubRoutes } from "./routes/goals-hub.js";
 import { approvalRoutes } from "./routes/approvals.js";
 import { secretRoutes } from "./routes/secrets.js";
 import { costRoutes } from "./routes/costs.js";
@@ -202,6 +203,8 @@ export async function createApp(
   api.use(routineRoutes(db));
   api.use(executionWorkspaceRoutes(db));
   api.use(goalRoutes(db));
+  // AgentDash: Goal hub rollup (AGE-40)
+  api.use(goalsHubRoutes(db));
   api.use(approvalRoutes(db));
   api.use(secretRoutes(db));
   api.use(costRoutes(db));

--- a/server/src/routes/goals-hub.ts
+++ b/server/src/routes/goals-hub.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import type { Db } from "@agentdash/db";
+import { goalsHubService } from "../services/index.js";
+import { assertCompanyAccess } from "./authz.js";
+
+// AgentDash: Goal hub rollup endpoint — one call returns agent roster, plan,
+// work, spend/budget, KPIs, and activity timeline for a goal.
+export function goalsHubRoutes(db: Db) {
+  const router = Router();
+  const svc = goalsHubService(db);
+
+  router.get("/companies/:companyId/goals/:goalId/hub", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const goalId = req.params.goalId as string;
+    assertCompanyAccess(req, companyId);
+    const rollup = await svc.getRollup(companyId, goalId);
+    res.json(rollup);
+  });
+
+  return router;
+}

--- a/server/src/services/__tests__/goals-hub.test.ts
+++ b/server/src/services/__tests__/goals-hub.test.ts
@@ -1,0 +1,368 @@
+// AgentDash: goals-hub service tests.
+//
+// Pure functions (computeKpiProgress) are exercised directly. The rollup
+// assembly is tested with a routing mock DB: we capture the base drizzle table
+// object used by each `db.select().from(table)` call and return a pre-seeded
+// row array keyed on table name. This gives us full coverage of the rollup
+// math (spend / revenue / KPI progress / work counts) without a live Postgres.
+
+import { describe, it, expect } from "vitest";
+import { computeKpiProgress, goalsHubService } from "../goals-hub.js";
+
+describe("computeKpiProgress", () => {
+  it("reports 50% progress when halfway between baseline and target", () => {
+    const r = computeKpiProgress(
+      { metric: "m", baseline: 0, target: 10, unit: "count", horizonDays: 30 },
+      5,
+    );
+    expect(r.progressPercent).toBe(50);
+    expect(r.onTrack).toBe(true);
+    expect(r.deltaToTarget).toBe(5);
+  });
+
+  it("clamps progress to 0 when current is below baseline", () => {
+    const r = computeKpiProgress(
+      { metric: "m", baseline: 10, target: 20, unit: "count", horizonDays: 30 },
+      0,
+    );
+    expect(r.progressPercent).toBe(0);
+    expect(r.onTrack).toBe(false);
+  });
+
+  it("clamps progress to 200 when current overshoots target", () => {
+    const r = computeKpiProgress(
+      { metric: "m", baseline: 0, target: 10, unit: "count", horizonDays: 30 },
+      100,
+    );
+    expect(r.progressPercent).toBe(200);
+    expect(r.onTrack).toBe(true);
+  });
+
+  it("handles cost-down goals where target < baseline", () => {
+    // baseline 100, target 50, current 75 → halfway reduction = 50% progress
+    const r = computeKpiProgress(
+      { metric: "m", baseline: 100, target: 50, unit: "cents", horizonDays: 30 },
+      75,
+    );
+    expect(r.progressPercent).toBe(50);
+    expect(r.onTrack).toBe(true);
+    expect(r.deltaToTarget).toBe(-25);
+  });
+
+  it("treats zero-span KPI as on-track only when current >= target", () => {
+    const kpi = { metric: "m", baseline: 5, target: 5, unit: "count", horizonDays: 30 };
+    expect(computeKpiProgress(kpi, 5).onTrack).toBe(true);
+    expect(computeKpiProgress(kpi, 4).onTrack).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rollup integration via mock DB
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+// We identify seed rows by a synthetic `__table` marker. The mock select()
+// walks `from(table)` and returns the matching rows.
+interface Seed {
+  goal?: Row[];
+  agentGoalsJoin?: Row[]; // rows returned from agentGoals join agents select
+  agentPlans?: Row[];
+  issuesAgg?: Row[]; // rows for grouped issues status
+  routinesAgg?: Row[];
+  pipelinesAgg?: Row[];
+  costTotal?: number;
+  revenueTotal?: number;
+  budgetPolicy?: Row | null;
+  issuesList?: Row[];
+  activityLog?: Row[];
+  heartbeatRuns?: Row[];
+}
+
+function buildMockDb(seed: Seed) {
+  // Each select() call creates a fresh chain. We track which "logical target"
+  // the caller is hitting by the order: the service's select sequence is
+  // stable because it's driven by Promise.all and sequential awaits.
+  let selectCalls = 0;
+
+  const thenable = (rows: unknown) => {
+    const chain: Record<string, unknown> = {};
+    chain.from = (_tbl: unknown) => chain;
+    chain.innerJoin = () => chain;
+    chain.where = () => chain;
+    chain.groupBy = () => chain;
+    chain.orderBy = () => chain;
+    chain.limit = () => chain;
+    chain.then = (onFulfilled: (v: unknown) => unknown) =>
+      Promise.resolve(onFulfilled(rows));
+    return chain;
+  };
+
+  // Returns the right payload for the Nth select() call in the
+  // deterministic sequence the service makes.
+  const sequence: unknown[] = [
+    seed.goal ?? [], // 0: assertGoalInCompany
+    (seed.agentGoalsJoin ?? []).map((r) => ({ ...r })), // 1: loadRoster
+    seed.agentPlans ?? [], // 2: loadOriginatingPlan
+    seed.issuesAgg ?? [], // 3: loadWork -> issues
+    seed.routinesAgg ?? [], // 4: loadWork -> routines
+    seed.pipelinesAgg ?? [], // 5: loadWork -> pipelines
+    [{ total: seed.costTotal ?? 0 }], // 6: spend - costs
+    [{ total: seed.revenueTotal ?? 0 }], // 7: spend - revenue
+    seed.budgetPolicy ? [seed.budgetPolicy] : [], // 8: budget
+    seed.issuesList ?? [], // 9: activity - issue ids
+    seed.activityLog ?? [], // 10: activity log
+    seed.heartbeatRuns ?? [], // 11: heartbeat runs
+  ];
+
+  const db = {
+    select: () => {
+      const idx = selectCalls++;
+      const payload = sequence[idx] ?? [];
+      return thenable(payload);
+    },
+    insert: () => thenable([]),
+    update: () => thenable([]),
+  };
+  return db;
+}
+
+describe("goalsHubService.getRollup", () => {
+  const companyId = "00000000-0000-0000-0000-000000000001";
+  const goalId = "00000000-0000-0000-0000-000000000002";
+  const now = new Date("2026-04-20T12:00:00.000Z");
+
+  it("throws when goal is not found for the company", async () => {
+    const db = buildMockDb({ goal: [] });
+    const svc = goalsHubService(db as unknown as Parameters<typeof goalsHubService>[0]);
+    await expect(svc.getRollup(companyId, goalId, { now })).rejects.toThrow(/not found/i);
+  });
+
+  it("aggregates roster, work, spend and KPI rollup for a goal", async () => {
+    const plan = {
+      id: "plan-1",
+      companyId,
+      goalId,
+      status: "expanded",
+      archetype: "revenue",
+      rationale: "Drive outbound pipeline",
+      decisionNote: "Approved",
+      proposalPayload: {
+        archetype: "revenue",
+        rationale: "Drive outbound pipeline",
+        proposedAgents: [],
+        proposedPlaybooks: [],
+        budget: { monthlyCapUsd: 500, killSwitchAtPct: 100, warnAtPct: 80 },
+        kpis: [
+          {
+            metric: "meetings_booked",
+            baseline: 0,
+            target: 10,
+            unit: "count",
+            horizonDays: 30,
+          },
+          {
+            metric: "monthly_spend_cents",
+            baseline: 0,
+            target: 50_000,
+            unit: "cents",
+            horizonDays: 30,
+          },
+        ],
+      },
+      proposedByUserId: "user-1",
+      approvedByUserId: "user-1",
+      approvedAt: new Date("2026-04-15T00:00:00.000Z"),
+      rejectedAt: null,
+      createdAt: new Date("2026-04-10T00:00:00.000Z"),
+    };
+
+    const db = buildMockDb({
+      goal: [{ id: goalId, companyId, title: "Q2 Revenue" }],
+      agentGoalsJoin: [
+        {
+          agentId: "agent-1",
+          name: "Outbound SDR",
+          role: "sdr",
+          status: "idle",
+          adapterType: "process",
+          budgetMonthlyCents: 20_000,
+          spendMonthlyCents: 7_500,
+          linkedAt: new Date("2026-04-15T00:00:00.000Z"),
+        },
+        {
+          agentId: "agent-2",
+          name: "Researcher",
+          role: "researcher",
+          status: "idle",
+          adapterType: "process",
+          budgetMonthlyCents: 10_000,
+          spendMonthlyCents: 2_000,
+          linkedAt: new Date("2026-04-16T00:00:00.000Z"),
+        },
+      ],
+      agentPlans: [plan],
+      issuesAgg: [
+        { status: "backlog", count: 3 },
+        { status: "in_progress", count: 2 },
+        { status: "done", count: 5 },
+      ],
+      routinesAgg: [
+        { status: "active", count: 1 },
+        { status: "paused", count: 1 },
+      ],
+      pipelinesAgg: [
+        { status: "active", count: 2 },
+        { status: "archived", count: 1 },
+      ],
+      costTotal: 9_500,
+      revenueTotal: 25_000,
+      budgetPolicy: { id: "bp-1", amount: 50_000, isActive: true },
+      issuesList: [{ id: "issue-1" }],
+      activityLog: [
+        {
+          id: "al-1",
+          createdAt: new Date("2026-04-18T00:00:00.000Z"),
+          action: "issue.created",
+          actorType: "user",
+          actorId: "user-1",
+          entityType: "issue",
+          entityId: "issue-1",
+          agentId: null,
+        },
+      ],
+      heartbeatRuns: [
+        {
+          id: "run-1",
+          createdAt: new Date("2026-04-19T10:00:00.000Z"),
+          startedAt: new Date("2026-04-19T10:01:00.000Z"),
+          status: "succeeded",
+          agentId: "agent-1",
+          issueId: "issue-1",
+        },
+      ],
+    });
+
+    const svc = goalsHubService(db as unknown as Parameters<typeof goalsHubService>[0]);
+    const rollup = await svc.getRollup(companyId, goalId, { now });
+
+    // Roster
+    expect(rollup.agents).toHaveLength(2);
+    expect(rollup.agents[0].agentId).toBe("agent-1");
+    expect(rollup.agents[0].spendMonthlyCents).toBe(7_500);
+
+    // Plan summary
+    expect(rollup.plan?.id).toBe("plan-1");
+    expect(rollup.plan?.status).toBe("expanded");
+    expect(rollup.plan?.archetype).toBe("revenue");
+
+    // Work
+    expect(rollup.work.openIssueCount).toBe(5); // backlog + in_progress
+    expect(rollup.work.activeRoutineCount).toBe(1);
+    expect(rollup.work.activePipelineCount).toBe(2);
+    expect(rollup.work.issuesByStatus.done).toBe(5);
+
+    // Spend
+    expect(rollup.spend.spendCents).toBe(9_500);
+    expect(rollup.spend.revenueCents).toBe(25_000);
+    expect(rollup.spend.netCents).toBe(15_500);
+    expect(rollup.spend.budgetCents).toBe(50_000);
+    expect(rollup.spend.percentOfBudget).toBe(19); // 9500/50000 = 19%
+
+    // KPIs — meetings_booked stays at baseline; monthly_spend_cents uses spend
+    const meetings = rollup.kpis.find((k) => k.metric === "meetings_booked");
+    const spendKpi = rollup.kpis.find((k) => k.metric === "monthly_spend_cents");
+    expect(meetings?.current).toBe(0);
+    expect(meetings?.deltaToTarget).toBe(10);
+    expect(meetings?.onTrack).toBe(false);
+    expect(spendKpi?.current).toBe(9_500);
+    expect(spendKpi?.progressPercent).toBe(19);
+
+    // Activity — interleaved and sorted desc by occurredAt
+    expect(rollup.activity.length).toBeGreaterThanOrEqual(2);
+    expect(rollup.activity[0].kind).toBe("heartbeat_run"); // 2026-04-19 > 2026-04-18
+    expect(rollup.activity[1].kind).toBe("activity_log");
+  });
+
+  it("returns empty-state rollup when no plan, no agents, no spend", async () => {
+    const db = buildMockDb({
+      goal: [{ id: goalId, companyId, title: "Unassigned" }],
+      agentGoalsJoin: [],
+      agentPlans: [],
+      issuesAgg: [],
+      routinesAgg: [],
+      pipelinesAgg: [],
+      costTotal: 0,
+      revenueTotal: 0,
+      budgetPolicy: null,
+      issuesList: [],
+      activityLog: [],
+      heartbeatRuns: [],
+    });
+
+    const svc = goalsHubService(db as unknown as Parameters<typeof goalsHubService>[0]);
+    const rollup = await svc.getRollup(companyId, goalId, { now });
+
+    expect(rollup.agents).toEqual([]);
+    expect(rollup.plan).toBeNull();
+    expect(rollup.work.openIssueCount).toBe(0);
+    expect(rollup.spend.spendCents).toBe(0);
+    expect(rollup.spend.revenueCents).toBe(0);
+    expect(rollup.spend.budgetCents).toBeNull();
+    expect(rollup.spend.percentOfBudget).toBeNull();
+    expect(rollup.kpis).toEqual([]);
+    expect(rollup.activity).toEqual([]);
+  });
+
+  it("prefers the expanded plan over proposed/rejected", async () => {
+    const expanded = {
+      id: "plan-expanded",
+      companyId,
+      goalId,
+      status: "expanded",
+      archetype: "revenue",
+      rationale: "r1",
+      decisionNote: null,
+      proposalPayload: {
+        archetype: "revenue",
+        rationale: "r1",
+        proposedAgents: [],
+        proposedPlaybooks: [],
+        budget: { monthlyCapUsd: 100, killSwitchAtPct: 100, warnAtPct: 80 },
+        kpis: [],
+      },
+      proposedByUserId: null,
+      approvedByUserId: "u1",
+      approvedAt: new Date("2026-04-10T00:00:00.000Z"),
+      rejectedAt: null,
+      createdAt: new Date("2026-04-05T00:00:00.000Z"),
+    };
+    const proposed = {
+      ...expanded,
+      id: "plan-proposed",
+      status: "proposed",
+      approvedByUserId: null,
+      approvedAt: null,
+      createdAt: new Date("2026-04-19T00:00:00.000Z"),
+    };
+
+    const db = buildMockDb({
+      goal: [{ id: goalId, companyId, title: "G" }],
+      agentGoalsJoin: [],
+      agentPlans: [proposed, expanded],
+      issuesAgg: [],
+      routinesAgg: [],
+      pipelinesAgg: [],
+      costTotal: 0,
+      revenueTotal: 0,
+      budgetPolicy: null,
+      issuesList: [],
+      activityLog: [],
+      heartbeatRuns: [],
+    });
+
+    const svc = goalsHubService(db as unknown as Parameters<typeof goalsHubService>[0]);
+    const rollup = await svc.getRollup(companyId, goalId, { now });
+    expect(rollup.plan?.id).toBe("plan-expanded");
+  });
+});

--- a/server/src/services/goals-hub.ts
+++ b/server/src/services/goals-hub.ts
@@ -1,0 +1,543 @@
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
+import type { Db } from "@agentdash/db";
+import {
+  activityLog,
+  agentGoals,
+  agentPipelines,
+  agentPlans,
+  agents,
+  budgetPolicies,
+  costEvents,
+  financeEvents,
+  goals,
+  heartbeatRuns,
+  issues,
+  routines,
+} from "@agentdash/db";
+import type { AgentTeamPlanPayload, ProposedKpi } from "@agentdash/shared";
+import { notFound } from "../errors.js";
+
+// AgentDash: Goal hub rollup. Single round-trip that backs the Goal detail page.
+// Aggregates agent roster, originating plan, open work, spend/revenue vs budget,
+// KPI progress, and a combined activity timeline for a business goal.
+//
+// All reads are scoped by (companyId, goalId). Indexes added in AGE-30 cover the
+// join predicates so this endpoint stays cheap on large companies.
+
+export interface GoalHubAgentSummary {
+  agentId: string;
+  name: string;
+  role: string;
+  status: string;
+  adapterType: string;
+  budgetMonthlyCents: number;
+  spendMonthlyCents: number;
+  linkedAt: string;
+}
+
+export interface GoalHubPlanSummary {
+  id: string;
+  archetype: string;
+  status: string;
+  rationale: string | null;
+  decisionNote: string | null;
+  approvedAt: string | null;
+  rejectedAt: string | null;
+  proposedByUserId: string | null;
+  approvedByUserId: string | null;
+  createdAt: string;
+}
+
+export interface GoalHubWorkSummary {
+  openIssueCount: number;
+  issuesByStatus: Record<string, number>;
+  activeRoutineCount: number;
+  routinesByStatus: Record<string, number>;
+  activePipelineCount: number;
+  pipelinesByStatus: Record<string, number>;
+}
+
+export interface GoalHubSpendSummary {
+  windowStart: string;
+  windowEnd: string;
+  spendCents: number;
+  revenueCents: number;
+  netCents: number;
+  budgetCents: number | null;
+  budgetPolicyId: string | null;
+  percentOfBudget: number | null;
+}
+
+export interface GoalHubKpiRow {
+  metric: string;
+  baseline: number;
+  target: number;
+  current: number;
+  unit: string;
+  horizonDays: number;
+  deltaToTarget: number;
+  progressPercent: number;
+  onTrack: boolean;
+}
+
+export interface GoalHubActivityEntry {
+  id: string;
+  kind: "activity_log" | "heartbeat_run";
+  occurredAt: string;
+  summary: string;
+  actorType?: string;
+  actorId?: string;
+  agentId?: string | null;
+  entityType?: string;
+  entityId?: string;
+  status?: string;
+}
+
+export interface GoalHubRollup {
+  goal: typeof goals.$inferSelect;
+  plan: GoalHubPlanSummary | null;
+  agents: GoalHubAgentSummary[];
+  work: GoalHubWorkSummary;
+  spend: GoalHubSpendSummary;
+  kpis: GoalHubKpiRow[];
+  activity: GoalHubActivityEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function startOfCurrentMonth(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+}
+
+function endOfCurrentMonth(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+}
+
+function coerceNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+function toIso(value: Date | string | null | undefined): string {
+  if (!value) return new Date(0).toISOString();
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
+}
+
+function extractKpis(payload: unknown): ProposedKpi[] {
+  if (!payload || typeof payload !== "object") return [];
+  const maybe = (payload as { kpis?: unknown }).kpis;
+  if (!Array.isArray(maybe)) return [];
+  return maybe.filter((k): k is ProposedKpi => {
+    return (
+      !!k && typeof k === "object" &&
+      typeof (k as ProposedKpi).metric === "string" &&
+      typeof (k as ProposedKpi).baseline === "number" &&
+      typeof (k as ProposedKpi).target === "number"
+    );
+  });
+}
+
+/**
+ * Compute KPI progress vs target.
+ * - progressPercent = (current - baseline) / (target - baseline) * 100
+ *   clamped to [0, 200]. Direction-agnostic: if target < baseline (cost-down
+ *   goal), we flip the sign so reduction still registers as progress.
+ * - onTrack: progressPercent >= expected linear pace. For MVP we use 50%
+ *   (i.e. we're on-track if we're at least halfway to target). Horizon-based
+ *   pacing (elapsed/horizonDays) can come in a follow-up once the plan carries
+ *   a createdAt/window anchor — defaulting to 50% keeps the UI meaningful.
+ */
+export function computeKpiProgress(
+  kpi: ProposedKpi,
+  current: number,
+): Pick<GoalHubKpiRow, "deltaToTarget" | "progressPercent" | "onTrack"> {
+  const span = kpi.target - kpi.baseline;
+  if (span === 0) {
+    const onTrack = current >= kpi.target;
+    return { deltaToTarget: kpi.target - current, progressPercent: onTrack ? 100 : 0, onTrack };
+  }
+  const raw = ((current - kpi.baseline) / span) * 100;
+  const progressPercent = Math.max(0, Math.min(200, Number.isFinite(raw) ? raw : 0));
+  const deltaToTarget = kpi.target - current;
+  const onTrack = progressPercent >= 50;
+  return {
+    deltaToTarget,
+    progressPercent: Math.round(progressPercent * 100) / 100,
+    onTrack,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export function goalsHubService(db: Db) {
+  async function assertGoalInCompany(companyId: string, goalId: string) {
+    const goal = await db
+      .select()
+      .from(goals)
+      .where(and(eq(goals.id, goalId), eq(goals.companyId, companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!goal) throw notFound("Goal not found in company");
+    return goal;
+  }
+
+  async function loadRoster(companyId: string, goalId: string): Promise<GoalHubAgentSummary[]> {
+    const rows = await db
+      .select({
+        agentId: agents.id,
+        name: agents.name,
+        role: agents.role,
+        status: agents.status,
+        adapterType: agents.adapterType,
+        budgetMonthlyCents: agents.budgetMonthlyCents,
+        spendMonthlyCents: agents.spentMonthlyCents,
+        linkedAt: agentGoals.createdAt,
+      })
+      .from(agentGoals)
+      .innerJoin(agents, eq(agents.id, agentGoals.agentId))
+      .where(and(eq(agentGoals.companyId, companyId), eq(agentGoals.goalId, goalId)));
+
+    return rows.map((r) => ({
+      agentId: r.agentId as string,
+      name: r.name as string,
+      role: r.role as string,
+      status: r.status as string,
+      adapterType: r.adapterType as string,
+      budgetMonthlyCents: coerceNumber(r.budgetMonthlyCents),
+      spendMonthlyCents: coerceNumber(r.spendMonthlyCents),
+      linkedAt: toIso(r.linkedAt as Date | string),
+    }));
+  }
+
+  async function loadOriginatingPlan(
+    companyId: string,
+    goalId: string,
+  ): Promise<{ row: typeof agentPlans.$inferSelect | null; summary: GoalHubPlanSummary | null }> {
+    // Prefer the most-recently-expanded plan (that's what spawned the agents);
+    // fall back to the most recent proposed/rejected plan so the card still
+    // tells the user what was considered.
+    const rows = await db
+      .select()
+      .from(agentPlans)
+      .where(and(eq(agentPlans.companyId, companyId), eq(agentPlans.goalId, goalId)));
+
+    if (rows.length === 0) return { row: null, summary: null };
+
+    const priority: Record<string, number> = {
+      expanded: 4,
+      approved: 3,
+      proposed: 2,
+      rejected: 1,
+    };
+    const sorted = [...rows].sort((a, b) => {
+      const pa = priority[a.status as string] ?? 0;
+      const pb = priority[b.status as string] ?? 0;
+      if (pa !== pb) return pb - pa;
+      const da = new Date(a.createdAt as Date).getTime();
+      const dc = new Date(b.createdAt as Date).getTime();
+      return dc - da;
+    });
+    const chosen = sorted[0];
+
+    return {
+      row: chosen,
+      summary: {
+        id: chosen.id as string,
+        archetype: chosen.archetype as string,
+        status: chosen.status as string,
+        rationale: (chosen.rationale as string | null) ?? null,
+        decisionNote: (chosen.decisionNote as string | null) ?? null,
+        approvedAt: chosen.approvedAt ? toIso(chosen.approvedAt as Date) : null,
+        rejectedAt: chosen.rejectedAt ? toIso(chosen.rejectedAt as Date) : null,
+        proposedByUserId: (chosen.proposedByUserId as string | null) ?? null,
+        approvedByUserId: (chosen.approvedByUserId as string | null) ?? null,
+        createdAt: toIso(chosen.createdAt as Date),
+      },
+    };
+  }
+
+  async function loadWork(companyId: string, goalId: string): Promise<GoalHubWorkSummary> {
+    const [issueRows, routineRows, pipelineRows] = await Promise.all([
+      db
+        .select({ status: issues.status, count: sql<number>`count(*)::int` })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.goalId, goalId)))
+        .groupBy(issues.status),
+      db
+        .select({ status: routines.status, count: sql<number>`count(*)::int` })
+        .from(routines)
+        .where(and(eq(routines.companyId, companyId), eq(routines.goalId, goalId)))
+        .groupBy(routines.status),
+      db
+        .select({ status: agentPipelines.status, count: sql<number>`count(*)::int` })
+        .from(agentPipelines)
+        .where(and(eq(agentPipelines.companyId, companyId), eq(agentPipelines.goalId, goalId)))
+        .groupBy(agentPipelines.status),
+    ]);
+
+    const OPEN_ISSUE = new Set(["backlog", "todo", "in_progress", "in_review", "blocked"]);
+    const ACTIVE_ROUTINE = new Set(["active"]);
+    const ACTIVE_PIPELINE = new Set(["active", "draft"]);
+
+    const issuesByStatus: Record<string, number> = {};
+    let openIssueCount = 0;
+    for (const row of issueRows) {
+      const status = String(row.status ?? "unknown");
+      const count = coerceNumber(row.count);
+      issuesByStatus[status] = (issuesByStatus[status] ?? 0) + count;
+      if (OPEN_ISSUE.has(status)) openIssueCount += count;
+    }
+
+    const routinesByStatus: Record<string, number> = {};
+    let activeRoutineCount = 0;
+    for (const row of routineRows) {
+      const status = String(row.status ?? "unknown");
+      const count = coerceNumber(row.count);
+      routinesByStatus[status] = (routinesByStatus[status] ?? 0) + count;
+      if (ACTIVE_ROUTINE.has(status)) activeRoutineCount += count;
+    }
+
+    const pipelinesByStatus: Record<string, number> = {};
+    let activePipelineCount = 0;
+    for (const row of pipelineRows) {
+      const status = String(row.status ?? "unknown");
+      const count = coerceNumber(row.count);
+      pipelinesByStatus[status] = (pipelinesByStatus[status] ?? 0) + count;
+      if (ACTIVE_PIPELINE.has(status)) activePipelineCount += count;
+    }
+
+    return {
+      openIssueCount,
+      issuesByStatus,
+      activeRoutineCount,
+      routinesByStatus,
+      activePipelineCount,
+      pipelinesByStatus,
+    };
+  }
+
+  async function loadSpend(
+    companyId: string,
+    goalId: string,
+    now: Date,
+  ): Promise<GoalHubSpendSummary> {
+    const windowStart = startOfCurrentMonth(now);
+    const windowEnd = endOfCurrentMonth(now);
+
+    const [costRows, revenueRows, budgetRow] = await Promise.all([
+      db
+        .select({ total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int` })
+        .from(costEvents)
+        .where(
+          and(
+            eq(costEvents.companyId, companyId),
+            eq(costEvents.goalId, goalId),
+            gte(costEvents.occurredAt, windowStart),
+          ),
+        ),
+      db
+        .select({
+          total: sql<number>`coalesce(sum(case when ${financeEvents.direction} = 'credit' then ${financeEvents.amountCents} else 0 end), 0)::int`,
+        })
+        .from(financeEvents)
+        .where(
+          and(
+            eq(financeEvents.companyId, companyId),
+            eq(financeEvents.goalId, goalId),
+            gte(financeEvents.occurredAt, windowStart),
+          ),
+        ),
+      db
+        .select()
+        .from(budgetPolicies)
+        .where(
+          and(
+            eq(budgetPolicies.companyId, companyId),
+            eq(budgetPolicies.goalId, goalId),
+            eq(budgetPolicies.isActive, true),
+          ),
+        )
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    const spendCents = coerceNumber(costRows[0]?.total ?? 0);
+    const revenueCents = coerceNumber(revenueRows[0]?.total ?? 0);
+    const budgetCents =
+      budgetRow && typeof budgetRow.amount === "number" ? budgetRow.amount : null;
+    const percentOfBudget =
+      budgetCents && budgetCents > 0
+        ? Math.round((spendCents / budgetCents) * 10000) / 100
+        : null;
+
+    return {
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      spendCents,
+      revenueCents,
+      netCents: revenueCents - spendCents,
+      budgetCents,
+      budgetPolicyId: (budgetRow?.id as string | undefined) ?? null,
+      percentOfBudget,
+    };
+  }
+
+  async function loadKpis(
+    planRow: typeof agentPlans.$inferSelect | null,
+    spend: GoalHubSpendSummary,
+  ): Promise<GoalHubKpiRow[]> {
+    if (!planRow) return [];
+    const kpis = extractKpis(planRow.proposalPayload as AgentTeamPlanPayload);
+
+    return kpis.map((kpi) => {
+      // Best-effort "current" readout. Without a time-series store, we can
+      // fill a few well-known metrics from the spend rollup; everything else
+      // starts at baseline so the UI shows baseline → target with a zero delta.
+      let current = kpi.baseline;
+      const metricKey = kpi.metric.toLowerCase();
+      if (metricKey === "monthly_spend_cents" || metricKey === "spend_cents") {
+        current = spend.spendCents;
+      } else if (metricKey === "monthly_revenue_cents" || metricKey === "revenue_cents") {
+        current = spend.revenueCents;
+      } else if (metricKey === "net_cents" || metricKey === "net_monthly_cents") {
+        current = spend.netCents;
+      }
+      const progress = computeKpiProgress(kpi, current);
+      return {
+        metric: kpi.metric,
+        baseline: kpi.baseline,
+        target: kpi.target,
+        current,
+        unit: kpi.unit,
+        horizonDays: kpi.horizonDays,
+        ...progress,
+      };
+    });
+  }
+
+  async function loadActivity(
+    companyId: string,
+    goalId: string,
+    agentIds: string[],
+    limit: number,
+  ): Promise<GoalHubActivityEntry[]> {
+    // Issue ids for this goal — used to rollup heartbeat_runs + activity_log.
+    const issueRows = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.goalId, goalId)));
+    const issueIds = issueRows.map((r) => r.id as string);
+
+    const activityPromise = db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          sql`(
+            (${activityLog.entityType} = 'goal' and ${activityLog.entityId} = ${goalId})
+            ${issueIds.length > 0
+              ? sql`or (${activityLog.entityType} = 'issue' and ${activityLog.entityId} in (${sql.join(issueIds.map((id) => sql`${id}`), sql`, `)}))`
+              : sql``}
+          )`,
+        ),
+      )
+      .orderBy(sql`${activityLog.createdAt} desc`)
+      .limit(limit);
+
+    const heartbeatPromise =
+      issueIds.length > 0 || agentIds.length > 0
+        ? db
+            .select()
+            .from(heartbeatRuns)
+            .where(
+              and(
+                eq(heartbeatRuns.companyId, companyId),
+                issueIds.length > 0 && agentIds.length > 0
+                  ? sql`(${heartbeatRuns.issueId} in (${sql.join(issueIds.map((id) => sql`${id}`), sql`, `)}) or ${heartbeatRuns.agentId} in (${sql.join(agentIds.map((id) => sql`${id}`), sql`, `)}))`
+                  : issueIds.length > 0
+                  ? inArray(heartbeatRuns.issueId, issueIds)
+                  : inArray(heartbeatRuns.agentId, agentIds),
+              ),
+            )
+            .orderBy(sql`${heartbeatRuns.createdAt} desc`)
+            .limit(limit)
+        : Promise.resolve([] as (typeof heartbeatRuns.$inferSelect)[]);
+
+    const [activityRows, runRows] = await Promise.all([activityPromise, heartbeatPromise]);
+
+    const entries: GoalHubActivityEntry[] = [];
+    for (const row of activityRows) {
+      entries.push({
+        id: row.id as string,
+        kind: "activity_log",
+        occurredAt: toIso(row.createdAt as Date),
+        summary: `${row.action as string}`,
+        actorType: row.actorType as string,
+        actorId: row.actorId as string,
+        agentId: (row.agentId as string | null) ?? null,
+        entityType: row.entityType as string,
+        entityId: row.entityId as string,
+      });
+    }
+    for (const row of runRows) {
+      entries.push({
+        id: row.id as string,
+        kind: "heartbeat_run",
+        occurredAt: toIso((row.startedAt as Date | null) ?? (row.createdAt as Date)),
+        summary: `heartbeat ${row.status as string}`,
+        agentId: (row.agentId as string | null) ?? null,
+        entityType: row.issueId ? "issue" : "agent",
+        entityId: (row.issueId as string | null) ?? (row.agentId as string),
+        status: row.status as string,
+      });
+    }
+
+    entries.sort((a, b) => (a.occurredAt < b.occurredAt ? 1 : a.occurredAt > b.occurredAt ? -1 : 0));
+    return entries.slice(0, limit);
+  }
+
+  return {
+    getRollup: async (
+      companyId: string,
+      goalId: string,
+      options: { now?: Date; activityLimit?: number } = {},
+    ): Promise<GoalHubRollup> => {
+      const goal = await assertGoalInCompany(companyId, goalId);
+      const now = options.now ?? new Date();
+      const activityLimit = options.activityLimit ?? 25;
+
+      const [roster, planResult, work, spend] = await Promise.all([
+        loadRoster(companyId, goalId),
+        loadOriginatingPlan(companyId, goalId),
+        loadWork(companyId, goalId),
+        loadSpend(companyId, goalId, now),
+      ]);
+
+      const kpis = await loadKpis(planResult.row, spend);
+      const activity = await loadActivity(
+        companyId,
+        goalId,
+        roster.map((r) => r.agentId),
+        activityLimit,
+      );
+
+      return {
+        goal,
+        plan: planResult.summary,
+        agents: roster,
+        work,
+        spend,
+        kpis,
+        activity,
+      };
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -40,3 +40,4 @@ export { pipelineOrchestratorService, validatePipelineDag } from "./pipeline-orc
 export { pipelineRunnerService } from "./pipeline-runner.js";
 export { pipelineSelfHealService } from "./pipeline-self-heal.js";
 export { agentPlansService } from "./agent-plans.js";
+export { goalsHubService } from "./goals-hub.js";

--- a/tests/e2e/goal-hub.spec.ts
+++ b/tests/e2e/goal-hub.spec.ts
@@ -1,0 +1,82 @@
+// AgentDash: Goal hub rollup E2E (AGE-40).
+// Verifies /companies/:companyId/goals/:goalId hub tab renders all rollup
+// cards (agents, plan, work, spend, KPIs, activity) and that the hub API
+// responds with the expected rollup shape.
+
+import { test, expect, navigateAndWait } from "./fixtures/test-helpers";
+
+test.describe("AGE-40: Goal hub rollup", () => {
+  test("hub API returns rollup shape for a seeded goal", async ({ page, company }) => {
+    const goalsRes = await page.request.get(`/api/companies/${company.id}/goals`);
+    expect(goalsRes.ok()).toBe(true);
+    const goals = await goalsRes.json();
+    if (goals.length === 0) {
+      test.skip();
+      return;
+    }
+
+    const hubRes = await page.request.get(
+      `/api/companies/${company.id}/goals/${goals[0].id}/hub`,
+    );
+    expect(hubRes.ok()).toBe(true);
+    const rollup = await hubRes.json();
+
+    // Must include every rollup slice (empty-state friendly)
+    expect(rollup).toHaveProperty("goal");
+    expect(rollup).toHaveProperty("plan");
+    expect(rollup).toHaveProperty("agents");
+    expect(rollup).toHaveProperty("work");
+    expect(rollup).toHaveProperty("spend");
+    expect(rollup).toHaveProperty("kpis");
+    expect(rollup).toHaveProperty("activity");
+
+    expect(rollup.goal.id).toBe(goals[0].id);
+    expect(Array.isArray(rollup.agents)).toBe(true);
+    expect(Array.isArray(rollup.kpis)).toBe(true);
+    expect(Array.isArray(rollup.activity)).toBe(true);
+    expect(rollup.work).toHaveProperty("openIssueCount");
+    expect(rollup.work).toHaveProperty("activeRoutineCount");
+    expect(rollup.work).toHaveProperty("activePipelineCount");
+    expect(rollup.spend).toHaveProperty("spendCents");
+    expect(rollup.spend).toHaveProperty("revenueCents");
+    expect(rollup.spend).toHaveProperty("netCents");
+  });
+
+  test("goal detail page renders hub tab with all rollup cards", async ({
+    page,
+    company,
+    prefix,
+  }) => {
+    const goalsRes = await page.request.get(`/api/companies/${company.id}/goals`);
+    expect(goalsRes.ok()).toBe(true);
+    const goals = await goalsRes.json();
+    if (goals.length === 0) {
+      test.skip();
+      return;
+    }
+
+    await navigateAndWait(page, `/goals/${goals[0].id}`, prefix);
+
+    // Hub is the default tab
+    const hub = page.locator('[data-testid="goal-hub"]');
+    await expect(hub).toBeVisible({ timeout: 15_000 });
+
+    // All six rollup cards render (empty-state friendly)
+    await expect(page.locator('[data-testid="goal-hub-agents-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="goal-hub-plan-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="goal-hub-work-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="goal-hub-spend-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="goal-hub-kpi-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="goal-hub-activity-card"]')).toBeVisible();
+
+    // Work card surfaces the three counters
+    await expect(page.locator('[data-testid="work-open-issues"]')).toBeVisible();
+    await expect(page.locator('[data-testid="work-active-routines"]')).toBeVisible();
+    await expect(page.locator('[data-testid="work-active-pipelines"]')).toBeVisible();
+
+    // Spend card surfaces the key money metrics
+    await expect(page.locator('[data-testid="spend-amount"]')).toBeVisible();
+    await expect(page.locator('[data-testid="revenue-amount"]')).toBeVisible();
+    await expect(page.locator('[data-testid="net-amount"]')).toBeVisible();
+  });
+});

--- a/ui/src/api/goals.ts
+++ b/ui/src/api/goals.ts
@@ -1,6 +1,87 @@
 import type { Goal } from "@agentdash/shared";
 import { api } from "./client";
 
+// AgentDash: Goal hub rollup shape (AGE-40). Mirrors server
+// GoalHubRollup in server/src/services/goals-hub.ts.
+export interface GoalHubAgentSummary {
+  agentId: string;
+  name: string;
+  role: string;
+  status: string;
+  adapterType: string;
+  budgetMonthlyCents: number;
+  spendMonthlyCents: number;
+  linkedAt: string;
+}
+
+export interface GoalHubPlanSummary {
+  id: string;
+  archetype: string;
+  status: string;
+  rationale: string | null;
+  decisionNote: string | null;
+  approvedAt: string | null;
+  rejectedAt: string | null;
+  proposedByUserId: string | null;
+  approvedByUserId: string | null;
+  createdAt: string;
+}
+
+export interface GoalHubWorkSummary {
+  openIssueCount: number;
+  issuesByStatus: Record<string, number>;
+  activeRoutineCount: number;
+  routinesByStatus: Record<string, number>;
+  activePipelineCount: number;
+  pipelinesByStatus: Record<string, number>;
+}
+
+export interface GoalHubSpendSummary {
+  windowStart: string;
+  windowEnd: string;
+  spendCents: number;
+  revenueCents: number;
+  netCents: number;
+  budgetCents: number | null;
+  budgetPolicyId: string | null;
+  percentOfBudget: number | null;
+}
+
+export interface GoalHubKpiRow {
+  metric: string;
+  baseline: number;
+  target: number;
+  current: number;
+  unit: string;
+  horizonDays: number;
+  deltaToTarget: number;
+  progressPercent: number;
+  onTrack: boolean;
+}
+
+export interface GoalHubActivityEntry {
+  id: string;
+  kind: "activity_log" | "heartbeat_run";
+  occurredAt: string;
+  summary: string;
+  actorType?: string;
+  actorId?: string;
+  agentId?: string | null;
+  entityType?: string;
+  entityId?: string;
+  status?: string;
+}
+
+export interface GoalHubRollup {
+  goal: Goal;
+  plan: GoalHubPlanSummary | null;
+  agents: GoalHubAgentSummary[];
+  work: GoalHubWorkSummary;
+  spend: GoalHubSpendSummary;
+  kpis: GoalHubKpiRow[];
+  activity: GoalHubActivityEntry[];
+}
+
 export const goalsApi = {
   list: (companyId: string) => api.get<Goal[]>(`/companies/${companyId}/goals`),
   get: (id: string) => api.get<Goal>(`/goals/${id}`),
@@ -8,4 +89,7 @@ export const goalsApi = {
     api.post<Goal>(`/companies/${companyId}/goals`, data),
   update: (id: string, data: Record<string, unknown>) => api.patch<Goal>(`/goals/${id}`, data),
   remove: (id: string) => api.delete<Goal>(`/goals/${id}`),
+  // AgentDash: Goal hub rollup (AGE-40)
+  getHub: (companyId: string, goalId: string) =>
+    api.get<GoalHubRollup>(`/companies/${companyId}/goals/${goalId}/hub`),
 };

--- a/ui/src/components/GoalHub.tsx
+++ b/ui/src/components/GoalHub.tsx
@@ -1,0 +1,372 @@
+// AgentDash: Goal hub rollup (AGE-40).
+// Single-call view of the goal's agent roster, originating plan, open work,
+// spend/budget, KPI progress, and activity timeline.
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity as ActivityIcon,
+  AlertTriangle,
+  CheckCircle2,
+  ClipboardList,
+  DollarSign,
+  Target,
+  Users,
+  Workflow,
+} from "lucide-react";
+import { goalsApi, type GoalHubAgentSummary, type GoalHubKpiRow, type GoalHubRollup } from "../api/goals";
+import { queryKeys } from "../lib/queryKeys";
+import { timeAgo } from "../lib/timeAgo";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface GoalHubProps {
+  companyId: string;
+  goalId: string;
+}
+
+function centsToUsd(cents: number): string {
+  return (cents / 100).toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+}
+
+function percentLabel(p: number | null): string {
+  if (p == null) return "—";
+  return `${p.toFixed(p >= 10 ? 0 : 1)}%`;
+}
+
+export function GoalHub({ companyId, goalId }: GoalHubProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.goals.hub(companyId, goalId),
+    queryFn: () => goalsApi.getHub(companyId, goalId),
+    enabled: !!companyId && !!goalId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="goal-hub-loading">
+        <div className="h-24 bg-muted/40 animate-pulse" />
+        <div className="h-24 bg-muted/40 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        Failed to load goal hub: {(error as Error).message}
+      </p>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="goal-hub">
+      <AgentsCard agents={data.agents} />
+      <PlanCard plan={data.plan} />
+      <WorkCard work={data.work} />
+      <SpendCard spend={data.spend} />
+      <div className="lg:col-span-2">
+        <KpiCard kpis={data.kpis} />
+      </div>
+      <div className="lg:col-span-2">
+        <ActivityCard activity={data.activity} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cards
+// ---------------------------------------------------------------------------
+
+function AgentsCard({ agents }: { agents: GoalHubAgentSummary[] }) {
+  return (
+    <Card data-testid="goal-hub-agents-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-4 w-4" />
+          Agents ({agents.length})
+        </CardTitle>
+        <CardDescription>Roster serving this goal and their monthly spend.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {agents.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No agents assigned yet. Propose a team from this goal to hire agents.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {agents.map((a) => {
+              const pct =
+                a.budgetMonthlyCents > 0
+                  ? Math.round((a.spendMonthlyCents / a.budgetMonthlyCents) * 100)
+                  : null;
+              return (
+                <li key={a.agentId} className="flex items-center justify-between py-2">
+                  <div>
+                    <p className="text-sm font-medium">{a.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {a.role} · {a.adapterType} · {a.status}
+                    </p>
+                  </div>
+                  <div className="text-right text-xs text-muted-foreground">
+                    <div>
+                      <span data-testid="agent-spend">{centsToUsd(a.spendMonthlyCents)}</span>
+                      {" / "}
+                      {centsToUsd(a.budgetMonthlyCents)}
+                    </div>
+                    {pct != null && <div>{pct}% of budget</div>}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlanCard({ plan }: { plan: GoalHubRollup["plan"] }) {
+  return (
+    <Card data-testid="goal-hub-plan-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ClipboardList className="h-4 w-4" />
+          Plan
+        </CardTitle>
+        <CardDescription>The agent-team plan that spawned this goal's roster.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {!plan ? (
+          <p className="text-sm text-muted-foreground">
+            No plan has been proposed for this goal yet.
+          </p>
+        ) : (
+          <>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="capitalize">
+                {plan.archetype}
+              </Badge>
+              <Badge variant={plan.status === "expanded" ? "default" : "outline"} className="capitalize">
+                {plan.status}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                created {timeAgo(plan.createdAt)}
+              </span>
+            </div>
+            {plan.rationale && <p className="text-sm">{plan.rationale}</p>}
+            {plan.decisionNote && (
+              <p className="text-sm italic text-muted-foreground">
+                Decision note: {plan.decisionNote}
+              </p>
+            )}
+            {plan.approvedAt && (
+              <p className="text-xs text-muted-foreground">
+                Approved {timeAgo(plan.approvedAt)}
+                {plan.approvedByUserId ? ` by ${plan.approvedByUserId}` : ""}
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function WorkCard({ work }: { work: GoalHubRollup["work"] }) {
+  return (
+    <Card data-testid="goal-hub-work-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Workflow className="h-4 w-4" />
+          Work
+        </CardTitle>
+        <CardDescription>Open issues, routines and playbooks assigned to this goal.</CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-3 gap-3">
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Open issues</p>
+          <p className="text-2xl font-semibold" data-testid="work-open-issues">
+            {work.openIssueCount}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Active routines</p>
+          <p className="text-2xl font-semibold" data-testid="work-active-routines">
+            {work.activeRoutineCount}
+          </p>
+        </div>
+        <div className="border border-border p-3">
+          <p className="text-xs text-muted-foreground">Active playbooks</p>
+          <p className="text-2xl font-semibold" data-testid="work-active-pipelines">
+            {work.activePipelineCount}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SpendCard({ spend }: { spend: GoalHubRollup["spend"] }) {
+  const overBudget = spend.percentOfBudget != null && spend.percentOfBudget >= 100;
+  return (
+    <Card data-testid="goal-hub-spend-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <DollarSign className="h-4 w-4" />
+          Impact &amp; ROI
+        </CardTitle>
+        <CardDescription>
+          Monthly window: {new Date(spend.windowStart).toLocaleDateString()} — current
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <p className="text-xs text-muted-foreground">Spend</p>
+            <p className="text-lg font-semibold" data-testid="spend-amount">
+              {centsToUsd(spend.spendCents)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Revenue</p>
+            <p className="text-lg font-semibold" data-testid="revenue-amount">
+              {centsToUsd(spend.revenueCents)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Net</p>
+            <p
+              className={`text-lg font-semibold ${
+                spend.netCents >= 0 ? "text-emerald-600" : "text-destructive"
+              }`}
+              data-testid="net-amount"
+            >
+              {centsToUsd(spend.netCents)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Budget</p>
+            <p className="text-lg font-semibold" data-testid="budget-amount">
+              {spend.budgetCents == null ? "No policy" : centsToUsd(spend.budgetCents)}
+            </p>
+          </div>
+        </div>
+        {spend.budgetCents != null && (
+          <div className="space-y-1">
+            <div className="h-2 w-full bg-muted">
+              <div
+                className={`h-2 ${overBudget ? "bg-destructive" : "bg-primary"}`}
+                style={{
+                  width: `${Math.min(100, spend.percentOfBudget ?? 0)}%`,
+                }}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {percentLabel(spend.percentOfBudget)} of budget used
+              {overBudget && (
+                <span className="ml-2 inline-flex items-center gap-1 text-destructive">
+                  <AlertTriangle className="h-3 w-3" /> over budget
+                </span>
+              )}
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function KpiCard({ kpis }: { kpis: GoalHubKpiRow[] }) {
+  return (
+    <Card data-testid="goal-hub-kpi-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Target className="h-4 w-4" />
+          KPIs
+        </CardTitle>
+        <CardDescription>Baseline -&gt; current -&gt; target, with on-track indicator.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {kpis.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No KPIs defined. Approve a plan with KPIs to track impact.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {kpis.map((k) => (
+              <li key={k.metric} className="py-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{k.metric}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {k.baseline} -&gt; <span data-testid={`kpi-current-${k.metric}`}>{k.current}</span> -&gt; {k.target} {k.unit} ({k.horizonDays}d horizon)
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold">
+                      {k.progressPercent.toFixed(0)}%
+                    </span>
+                    {k.onTrack ? (
+                      <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                    ) : (
+                      <AlertTriangle className="h-4 w-4 text-amber-500" />
+                    )}
+                  </div>
+                </div>
+                <div className="mt-2 h-1.5 w-full bg-muted">
+                  <div
+                    className={`h-1.5 ${k.onTrack ? "bg-emerald-500" : "bg-amber-500"}`}
+                    style={{ width: `${Math.min(100, k.progressPercent)}%` }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ActivityCard({ activity }: { activity: GoalHubRollup["activity"] }) {
+  return (
+    <Card data-testid="goal-hub-activity-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ActivityIcon className="h-4 w-4" />
+          Activity
+        </CardTitle>
+        <CardDescription>Recent heartbeats and audit-log entries touching this goal.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {activity.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No activity yet. Work assigned to this goal will show up here.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border text-sm">
+            {activity.map((entry) => (
+              <li key={`${entry.kind}-${entry.id}`} className="flex items-center justify-between py-2">
+                <div>
+                  <p className="font-medium">{entry.summary}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {entry.kind === "heartbeat_run" ? "heartbeat" : "audit"}
+                    {entry.entityType ? ` · ${entry.entityType}` : ""}
+                    {entry.actorId ? ` · ${entry.actorId}` : ""}
+                  </p>
+                </div>
+                <span className="text-xs text-muted-foreground">{timeAgo(entry.occurredAt)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -75,6 +75,8 @@ export const queryKeys = {
   goals: {
     list: (companyId: string) => ["goals", companyId] as const,
     detail: (id: string) => ["goals", "detail", id] as const,
+    // AgentDash: goal hub rollup (AGE-40)
+    hub: (companyId: string, goalId: string) => ["goals", "hub", companyId, goalId] as const,
   },
   crm: {
     pipeline: (companyId: string) => ["crm", companyId, "pipeline"] as const,

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -10,6 +10,7 @@ import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { GoalProperties } from "../components/GoalProperties";
+import { GoalHub } from "../components/GoalHub";
 import { GoalTree } from "../components/GoalTree";
 import { StatusBadge } from "../components/StatusBadge";
 import { InlineEditor } from "../components/InlineEditor";
@@ -145,8 +146,10 @@ export function GoalDetail() {
         />
       </div>
 
-      <Tabs defaultValue="children">
+      <Tabs defaultValue="hub">
         <TabsList>
+          {/* AgentDash: Goal hub rollup tab (AGE-40) */}
+          <TabsTrigger value="hub">Hub</TabsTrigger>
           <TabsTrigger value="children">
             Sub-Goals ({childGoals.length})
           </TabsTrigger>
@@ -154,6 +157,15 @@ export function GoalDetail() {
             Projects ({linkedProjects.length})
           </TabsTrigger>
         </TabsList>
+
+        {/* AgentDash: Goal hub rollup tab content (AGE-40) */}
+        <TabsContent value="hub" className="mt-4">
+          {resolvedCompanyId && goalId ? (
+            <GoalHub companyId={resolvedCompanyId} goalId={goalId} />
+          ) : (
+            <p className="text-sm text-muted-foreground">Loading goal hub...</p>
+          )}
+        </TabsContent>
 
         <TabsContent value="children" className="mt-4 space-y-3">
           <div className="flex items-center justify-start">


### PR DESCRIPTION
## Summary
- New `goalsHubService` plus `GET /companies/:companyId/goals/:goalId/hub` return a single rollup: agent roster with monthly spend, originating plan + approval state, open issues/routines/pipelines, month-to-date spend/revenue/net vs budget policy, KPI baseline -> current -> target progress, and merged activity_log + heartbeat_runs timeline.
- New `GoalHub` React component is the default tab on goal detail, with six empty-state-friendly cards (Agents, Plan, Work, Spend/ROI, KPIs, Activity) wired through React Query. Sub-Goals and Projects tabs remain.
- Follows the memory directive that Pipelines are not a top-level concept - everything rolls up to business Goals with impact/ROI on the goal page.

## Files touched
- `server/src/services/goals-hub.ts` (new)
- `server/src/routes/goals-hub.ts` (new)
- `server/src/services/__tests__/goals-hub.test.ts` (new, 9 tests)
- `server/src/app.ts`, `server/src/services/index.ts` (wiring)
- `ui/src/api/goals.ts`, `ui/src/lib/queryKeys.ts` (client types + query keys)
- `ui/src/components/GoalHub.tsx` (new)
- `ui/src/pages/GoalDetail.tsx` (adds Hub as default tab)
- `tests/e2e/goal-hub.spec.ts` (new)

## Test plan
- [x] `pnpm -r typecheck` - all packages green
- [x] `pnpm test:run goals-hub` - 9/9 unit tests pass
- [x] `pnpm test:run` - 1530 pass, 3 skipped, 4 failures in **pre-existing unrelated suites** (`autoresearch-routes`, `billing-routes`, `billing-routes-extended`, `security-routes`). None touch goals-hub code.
- [x] `pnpm build` - server, ui, cli all build
- [ ] Playwright `tests/e2e/goal-hub.spec.ts` - to be run by @tester against live dev server

## Acceptance
- [x] Hub layout on `/companies/:companyId/goals/:goalId` (new default tab)
- [x] Agents card from `agent_goals` x `agents` with monthly spend
- [x] Plan card from `agent_plans` with approval state + decision note
- [x] Work card: open issues + active routines + active pipelines
- [x] Spend rollup: `cost_events` + `finance_events` over current UTC month window, vs `budget_policies.amount`
- [x] KPI rollup from `agent_plan.proposalPayload.kpis`, baseline -> current -> target, delta, on-track flag
- [x] Activity timeline merging `heartbeat_runs` and `activity_log`
- [x] All queries scoped by companyId + goalId; empty states for every card

Generated with Claude Code (Opus 4.7)