### PR TITLE
feat(assistant): rewire chat to Chief of Staff agent (AGE-44)

### DIFF
--- a/packages/db/src/migrations/0077_backfill_assistant_conversations_cos.sql
+++ b/packages/db/src/migrations/0077_backfill_assistant_conversations_cos.sql
@@ -1,0 +1,13 @@
+-- AgentDash (AGE-44): Backfill assistant_conversations.assistant_agent_id to the company's
+-- Chief of Staff agent (role='chief_of_staff'). Legacy role='assistant' agent rows stay in
+-- place; only the pointer on existing conversations is updated so chat traffic is now
+-- attributed to the CoS agent.
+UPDATE "assistant_conversations" AS ac
+SET "assistant_agent_id" = cos."id"
+FROM (
+  SELECT DISTINCT ON ("company_id") "id", "company_id"
+  FROM "agents"
+  WHERE "role" = 'chief_of_staff'
+  ORDER BY "company_id", "created_at" ASC
+) AS cos
+WHERE cos."company_id" = ac."company_id";

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1776738020523,
       "tag": "0076_sudden_moonstone",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1777000000000,
+      "tag": "0077_backfill_assistant_conversations_cos",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/assistant-cos-prompt.test.ts
+++ b/server/src/__tests__/assistant-cos-prompt.test.ts
@@ -1,0 +1,306 @@
+/**
+ * AGE-44: Unit tests for the Chief of Staff system-prompt resolver and the
+ * backfill migration that re-points existing assistant_conversations at the
+ * company's role='chief_of_staff' agent.
+ */
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  agents,
+  assistantConversations,
+  companies,
+  createDb,
+} from "@agentdash/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  formatInstructionsBundleAsSystemPrompt,
+  loadDefaultAgentInstructionsBundle,
+} from "../services/default-agent-instructions.ts";
+import { resolveChiefOfStaffSystemPrompt } from "../services/assistant-llm.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres assistant-cos-prompt tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describe("formatInstructionsBundleAsSystemPrompt", () => {
+  it("concatenates SOUL, AGENTS, HEARTBEAT, TOOLS in canonical order", () => {
+    const prompt = formatInstructionsBundleAsSystemPrompt({
+      "TOOLS.md": "TOOLS body",
+      "SOUL.md": "SOUL body",
+      "HEARTBEAT.md": "HEARTBEAT body",
+      "AGENTS.md": "AGENTS body",
+    });
+    const indexOf = (needle: string) => prompt.indexOf(needle);
+    expect(indexOf("SOUL body")).toBeGreaterThanOrEqual(0);
+    expect(indexOf("SOUL body")).toBeLessThan(indexOf("AGENTS body"));
+    expect(indexOf("AGENTS body")).toBeLessThan(indexOf("HEARTBEAT body"));
+    expect(indexOf("HEARTBEAT body")).toBeLessThan(indexOf("TOOLS body"));
+    expect(prompt).toContain("# SOUL.md");
+  });
+
+  it("skips empty/whitespace files", () => {
+    const prompt = formatInstructionsBundleAsSystemPrompt({
+      "SOUL.md": "SOUL body",
+      "AGENTS.md": "   ",
+      "HEARTBEAT.md": "HEARTBEAT body",
+    });
+    expect(prompt).toContain("SOUL body");
+    expect(prompt).toContain("HEARTBEAT body");
+    expect(prompt).not.toContain("AGENTS body");
+  });
+});
+
+describe("loadDefaultAgentInstructionsBundle", () => {
+  it("returns the CoS bundle when called with (db, agent)", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle({} as never, {
+      id: randomUUID(),
+      role: "chief_of_staff",
+    });
+    expect(Object.keys(bundle).sort()).toEqual(
+      ["AGENTS.md", "HEARTBEAT.md", "SOUL.md", "TOOLS.md"].sort(),
+    );
+    expect(bundle["SOUL.md"].length).toBeGreaterThan(0);
+  });
+
+  it("falls back to default bundle for unknown role", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle({} as never, {
+      id: randomUUID(),
+      role: "engineer",
+    });
+    expect(Object.keys(bundle)).toEqual(["AGENTS.md"]);
+  });
+
+  it("still supports the legacy role-only signature", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle("chief_of_staff");
+    expect(bundle["SOUL.md"].length).toBeGreaterThan(0);
+  });
+});
+
+describeEmbeddedPostgres("resolveChiefOfStaffSystemPrompt", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-assistant-cos-prompt-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(assistantConversations);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("returns null systemPrompt when the company has no chief_of_staff agent", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "AcmeCo",
+      issuePrefix: `AC${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const resolution = await resolveChiefOfStaffSystemPrompt(db, companyId);
+    expect(resolution.agent).toBeNull();
+    expect(resolution.systemPrompt).toBeNull();
+  });
+
+  it("returns the CoS agent + SOUL-led system prompt when one exists", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "AcmeCo",
+      issuePrefix: `AC${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const cosId = randomUUID();
+    await db.insert(agents).values({
+      id: cosId,
+      companyId,
+      name: "Chief of Staff",
+      role: "chief_of_staff",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const resolution = await resolveChiefOfStaffSystemPrompt(db, companyId);
+    expect(resolution.agent?.id).toBe(cosId);
+    expect(resolution.agent?.role).toBe("chief_of_staff");
+    expect(resolution.systemPrompt).not.toBeNull();
+
+    // Confirm the prompt actually contains the bundled SOUL.md content.
+    const soulContent = await readFile(
+      fileURLToPath(
+        new URL("../onboarding-assets/chief_of_staff/SOUL.md", import.meta.url),
+      ),
+      "utf8",
+    );
+    const soulSample = soulContent.trim().slice(0, 40);
+    expect(resolution.systemPrompt!).toContain(soulSample);
+  });
+
+  it("ignores chief_of_staff agents from other companies", async () => {
+    const companyA = randomUUID();
+    const companyB = randomUUID();
+    for (const id of [companyA, companyB]) {
+      await db.insert(companies).values({
+        id,
+        name: `Company-${id.slice(0, 4)}`,
+        issuePrefix: `CP${id.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+    }
+
+    await db.insert(agents).values({
+      id: randomUUID(),
+      companyId: companyB,
+      name: "B Chief of Staff",
+      role: "chief_of_staff",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const resolution = await resolveChiefOfStaffSystemPrompt(db, companyA);
+    expect(resolution.agent).toBeNull();
+  });
+});
+
+describeEmbeddedPostgres("AGE-44 backfill migration", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let migrationSql!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-assistant-backfill-");
+    db = createDb(tempDb.connectionString);
+    migrationSql = await readFile(
+      fileURLToPath(
+        new URL(
+          "../../../packages/db/src/migrations/0077_backfill_assistant_conversations_cos.sql",
+          import.meta.url,
+        ),
+      ),
+      "utf8",
+    );
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(assistantConversations);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("repoints existing conversations at the company's chief_of_staff agent", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "AcmeCo",
+      issuePrefix: `AC${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Legacy role='assistant' agent that pre-existing conversations currently point at.
+    const legacyAssistantId = randomUUID();
+    await db.insert(agents).values({
+      id: legacyAssistantId,
+      companyId,
+      name: "Legacy Assistant",
+      role: "assistant",
+      status: "active",
+      adapterType: "assistant",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const cosId = randomUUID();
+    await db.insert(agents).values({
+      id: cosId,
+      companyId,
+      name: "Chief of Staff",
+      role: "chief_of_staff",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const convoId = randomUUID();
+    await db.insert(assistantConversations).values({
+      id: convoId,
+      companyId,
+      userId: "user-1",
+      assistantAgentId: legacyAssistantId,
+      status: "active",
+    });
+
+    for (const statement of migrationSql.split(/;\s*$/m).map((s) => s.trim()).filter(Boolean)) {
+      await db.execute(sql.raw(statement));
+    }
+
+    const [row] = await db
+      .select({ assistantAgentId: assistantConversations.assistantAgentId })
+      .from(assistantConversations);
+    expect(row.assistantAgentId).toBe(cosId);
+
+    // Legacy row must still exist -- migration is non-destructive.
+    const legacyRows = await db.select().from(agents);
+    expect(legacyRows.some((r) => r.id === legacyAssistantId)).toBe(true);
+  });
+
+  it("leaves conversations alone for companies with no chief_of_staff agent", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "AcmeCo",
+      issuePrefix: `AC${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const convoId = randomUUID();
+    await db.insert(assistantConversations).values({
+      id: convoId,
+      companyId,
+      userId: "user-1",
+      assistantAgentId: null,
+      status: "active",
+    });
+
+    for (const statement of migrationSql.split(/;\s*$/m).map((s) => s.trim()).filter(Boolean)) {
+      await db.execute(sql.raw(statement));
+    }
+
+    const [row] = await db
+      .select({ assistantAgentId: assistantConversations.assistantAgentId })
+      .from(assistantConversations);
+    expect(row.assistantAgentId).toBeNull();
+  });
+});

--- a/server/src/services/assistant-llm.ts
+++ b/server/src/services/assistant-llm.ts
@@ -3,6 +3,15 @@
  * V1: Anthropic Messages API (Claude) with streaming + function-calling.
  */
 
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@agentdash/db";
+import { agents } from "@agentdash/db";
+import { logger } from "../middleware/logger.js";
+import {
+  loadDefaultAgentInstructionsBundle,
+  formatInstructionsBundleAsSystemPrompt,
+} from "./default-agent-instructions.js";
+
 // ── Types ──────────────────────────────────────────────────────────────
 
 export interface AssistantLLMConfig {
@@ -48,6 +57,54 @@ export type AssistantChunk =
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
   | { type: "error"; code: string; message: string }
   | { type: "done"; usage: { inputTokens: number; outputTokens: number } };
+
+// ── Chief of Staff Resolution ──────────────────────────────────────────
+
+export interface ChiefOfStaffAgent {
+  id: string;
+  role: string;
+  name: string;
+  companyId: string;
+}
+
+export interface ChiefOfStaffPromptResolution {
+  agent: ChiefOfStaffAgent | null;
+  systemPrompt: string | null;
+}
+
+// AgentDash: Resolve the company's role='chief_of_staff' agent and build its
+// system prompt by concatenating SOUL.md + AGENTS.md + HEARTBEAT.md + TOOLS.md.
+// Returns { agent: null, systemPrompt: null } if no CoS agent exists; callers
+// must log a warning and fall back to the generic prompt. Never crashes.
+export async function resolveChiefOfStaffSystemPrompt(
+  db: Db,
+  companyId: string,
+): Promise<ChiefOfStaffPromptResolution> {
+  const rows = await db
+    .select({
+      id: agents.id,
+      role: agents.role,
+      name: agents.name,
+      companyId: agents.companyId,
+    })
+    .from(agents)
+    .where(and(eq(agents.companyId, companyId), eq(agents.role, "chief_of_staff")))
+    .limit(1);
+
+  if (rows.length === 0) {
+    return { agent: null, systemPrompt: null };
+  }
+
+  const cosAgent = rows[0];
+  try {
+    const bundle = await loadDefaultAgentInstructionsBundle(db, cosAgent);
+    const systemPrompt = formatInstructionsBundleAsSystemPrompt(bundle);
+    return { agent: cosAgent, systemPrompt };
+  } catch (err) {
+    logger.warn({ err, companyId, agentId: cosAgent.id }, "failed to load chief_of_staff instructions bundle");
+    return { agent: cosAgent, systemPrompt: null };
+  }
+}
 
 // ── Config Resolution ──────────────────────────────────────────────────
 

--- a/server/src/services/assistant.ts
+++ b/server/src/services/assistant.ts
@@ -5,11 +5,12 @@
  */
 import { eq, and, desc } from "drizzle-orm";
 import type { Db } from "@agentdash/db";
-import { assistantConversations, assistantMessages, agents, companyContext } from "@agentdash/db";
+import { assistantConversations, assistantMessages, companyContext } from "@agentdash/db";
 import { logger } from "../middleware/logger.js";
 import {
   streamChat,
   resolveAssistantConfig,
+  resolveChiefOfStaffSystemPrompt,
   type AssistantChunk,
   type AssistantMessage,
   type ContentBlock,
@@ -25,39 +26,15 @@ import { logActivity } from "./activity-log.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
-async function getOrCreateAssistant(
-  db: Db,
-  userId: string,
-  companyId: string,
-  userName: string,
-) {
-  const existing = await db
-    .select()
-    .from(agents)
-    .where(and(eq(agents.companyId, companyId), eq(agents.ownerUserId, userId), eq(agents.role, "assistant")))
-    .limit(1);
-
-  if (existing.length > 0) return existing[0];
-
-  const inserted = await db
-    .insert(agents)
-    .values({
-      companyId,
-      ownerUserId: userId,
-      name: `${userName}'s Assistant`,
-      role: "assistant",
-      adapterType: "assistant",
-    })
-    .returning();
-
-  return inserted[0];
-}
-
+// AgentDash (AGE-44): Assistant conversations are attributed to the company's
+// role='chief_of_staff' agent. We no longer auto-create a per-user role='assistant'
+// agent. If no CoS agent exists, `assistantAgentId` is left null and the caller
+// uses the legacy generic prompt (with a warning).
 async function getOrCreateConversation(
   db: Db,
   userId: string,
   companyId: string,
-  assistantAgentId: string,
+  assistantAgentId: string | null,
 ) {
   const existing = await db
     .select()
@@ -158,8 +135,19 @@ export async function* chat(
 ): AsyncGenerator<AssistantChunk & { conversationId?: string }> {
   const { userId, companyId, message, userName, companyName = "your company", toolContext } = params;
 
-  // 1. Get or create the assistant agent
-  const assistant = await getOrCreateAssistant(db, userId, companyId, userName);
+  // AgentDash (AGE-44): Resolve the company's Chief of Staff agent. Its id is the
+  // assistantAgentId on new conversations and the actor for activity-log entries.
+  // If no CoS agent exists we fall back to the legacy generic prompt and log a warning.
+  const cosResolution = await resolveChiefOfStaffSystemPrompt(db, companyId);
+  const cosAgentId = cosResolution.agent?.id ?? null;
+  if (!cosAgentId) {
+    logger.warn({ companyId }, "assistant.chat: no chief_of_staff agent found — falling back to generic prompt");
+  }
+
+  // Activity-log actor: attribute chat actions to the CoS agent when available.
+  const logActor: { actorType: "agent" | "user"; actorId: string } = cosAgentId
+    ? { actorType: "agent", actorId: cosAgentId }
+    : { actorType: "user", actorId: userId };
 
   // 2. Get or create conversation
   let conversation: typeof assistantConversations.$inferSelect;
@@ -175,12 +163,12 @@ export async function* chat(
       )
       .limit(1);
     if (found.length === 0) {
-      conversation = await getOrCreateConversation(db, userId, companyId, assistant.id);
+      conversation = await getOrCreateConversation(db, userId, companyId, cosAgentId);
     } else {
       conversation = found[0];
     }
   } else {
-    conversation = await getOrCreateConversation(db, userId, companyId, assistant.id);
+    conversation = await getOrCreateConversation(db, userId, companyId, cosAgentId);
   }
 
   const conversationId = conversation.id;
@@ -188,15 +176,17 @@ export async function* chat(
   // 3. Save user message
   await saveMessage(db, conversationId, "user", message);
 
-  // Telemetry: log user message
+  // Telemetry: log user message (attributed to CoS agent when available).
   try {
     await logActivity(db, {
       companyId,
-      actorType: "user",
-      actorId: userId,
+      actorType: logActor.actorType,
+      actorId: logActor.actorId,
+      agentId: cosAgentId,
       action: "assistant.message",
       entityType: "conversation",
       entityId: conversationId,
+      details: { userId },
     });
   } catch (err) {
     logger.warn({ err }, "assistant.message telemetry failed");
@@ -212,12 +202,17 @@ export async function* chat(
   // 5. Load company profile
   const companyProfile = await loadCompanyProfile(db, companyId);
 
-  // 6. Build system prompt
+  // 6. Build system prompt.
+  // If a Chief of Staff agent exists, use its SOUL/AGENTS/HEARTBEAT/TOOLS bundle
+  // as the system prompt. Otherwise, fall back to the legacy interview / standard
+  // prompts so behavior is preserved for companies without a CoS agent.
   const metadata = (conversation.metadata as Record<string, unknown> | null) ?? {};
   const interviewComplete = Boolean(metadata.interviewComplete);
 
   let systemPrompt: string;
-  if (!interviewComplete) {
+  if (cosResolution.systemPrompt) {
+    systemPrompt = cosResolution.systemPrompt;
+  } else if (!interviewComplete) {
     systemPrompt = buildInterviewSystemPrompt(companyProfile, userName, companyName);
   } else {
     systemPrompt = buildStandardSystemPrompt(companyProfile, userName, companyName);
@@ -339,16 +334,17 @@ export async function* chat(
         tu.input,
       );
 
-      // Telemetry: log tool call
+      // Telemetry: log tool call (attributed to CoS agent when available).
       try {
         await logActivity(db, {
           companyId,
-          actorType: "user",
-          actorId: userId,
+          actorType: logActor.actorType,
+          actorId: logActor.actorId,
+          agentId: cosAgentId,
           action: "assistant.tool_call",
           entityType: "conversation",
           entityId: conversationId,
-          details: { toolName: tu.name },
+          details: { toolName: tu.name, userId },
         });
       } catch (err) {
         logger.warn({ err }, "assistant.tool_call telemetry failed");
@@ -359,11 +355,13 @@ export async function* chat(
         try {
           await logActivity(db, {
             companyId,
-            actorType: "user",
-            actorId: userId,
+            actorType: logActor.actorType,
+            actorId: logActor.actorId,
+            agentId: cosAgentId,
             action: "assistant.interview_complete",
             entityType: "conversation",
             entityId: conversationId,
+            details: { userId },
           });
         } catch (err) {
           logger.warn({ err }, "assistant.interview_complete telemetry failed");

--- a/server/src/services/default-agent-instructions.ts
+++ b/server/src/services/default-agent-instructions.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import type { Db } from "@agentdash/db";
 
 const DEFAULT_AGENT_BUNDLE_FILES = {
   default: ["AGENTS.md"],
@@ -7,11 +8,39 @@ const DEFAULT_AGENT_BUNDLE_FILES = {
 
 type DefaultAgentBundleRole = keyof typeof DEFAULT_AGENT_BUNDLE_FILES;
 
+export interface AgentLike {
+  id?: string;
+  role: string;
+}
+
 function resolveDefaultAgentBundleUrl(role: DefaultAgentBundleRole, fileName: string) {
   return new URL(`../onboarding-assets/${role}/${fileName}`, import.meta.url);
 }
 
-export async function loadDefaultAgentInstructionsBundle(role: DefaultAgentBundleRole): Promise<Record<string, string>> {
+// AgentDash: Overloaded loader.
+// - `loadDefaultAgentInstructionsBundle("chief_of_staff")` returns the bundle by role (legacy call site).
+// - `loadDefaultAgentInstructionsBundle(db, agent)` resolves the role from the agent record and returns
+//   the bundle. `db` is accepted for future expansion (e.g. per-agent overrides) but unused today.
+export async function loadDefaultAgentInstructionsBundle(
+  role: DefaultAgentBundleRole,
+): Promise<Record<string, string>>;
+export async function loadDefaultAgentInstructionsBundle(
+  db: Db,
+  agent: AgentLike,
+): Promise<Record<string, string>>;
+export async function loadDefaultAgentInstructionsBundle(
+  roleOrDb: DefaultAgentBundleRole | Db,
+  agent?: AgentLike,
+): Promise<Record<string, string>> {
+  let role: DefaultAgentBundleRole;
+  if (typeof roleOrDb === "string") {
+    role = roleOrDb;
+  } else {
+    if (!agent) {
+      throw new Error("loadDefaultAgentInstructionsBundle(db, agent) requires an agent argument");
+    }
+    role = resolveDefaultAgentInstructionsBundleRole(agent.role);
+  }
   const fileNames = DEFAULT_AGENT_BUNDLE_FILES[role];
   const entries = await Promise.all(
     fileNames.map(async (fileName) => {
@@ -24,4 +53,28 @@ export async function loadDefaultAgentInstructionsBundle(role: DefaultAgentBundl
 
 export function resolveDefaultAgentInstructionsBundleRole(role: string): DefaultAgentBundleRole {
   return role === "chief_of_staff" ? "chief_of_staff" : "default";
+}
+
+// AgentDash: Flatten a loaded instruction bundle into a single system-prompt string.
+// Files are emitted in canonical order (SOUL, AGENTS, HEARTBEAT, TOOLS) each prefixed by a header
+// so the model sees explicit section boundaries.
+const BUNDLE_ORDER = ["SOUL.md", "AGENTS.md", "HEARTBEAT.md", "TOOLS.md"] as const;
+
+export function formatInstructionsBundleAsSystemPrompt(bundle: Record<string, string>): string {
+  const seen = new Set<string>();
+  const sections: string[] = [];
+  for (const fileName of BUNDLE_ORDER) {
+    const content = bundle[fileName];
+    if (typeof content === "string" && content.trim().length > 0) {
+      sections.push(`# ${fileName}\n\n${content.trim()}`);
+      seen.add(fileName);
+    }
+  }
+  for (const [fileName, content] of Object.entries(bundle)) {
+    if (seen.has(fileName)) continue;
+    if (typeof content === "string" && content.trim().length > 0) {
+      sections.push(`# ${fileName}\n\n${content.trim()}`);
+    }
+  }
+  return sections.join("\n\n");
 }


### PR DESCRIPTION
## Summary

- Resolves the company's `role='chief_of_staff'` agent and loads its `SOUL.md + AGENTS.md + HEARTBEAT.md + TOOLS.md` bundle as the assistant chat system prompt.
- New `assistant_conversations.assistantAgentId` now points at the CoS agent id; `activity_log` entries for chat actions attribute the CoS agent as actor.
- Migration `0077_backfill_assistant_conversations_cos.sql` re-points existing conversations at the company's CoS agent. Legacy `role='assistant'` rows are left in place.
- Graceful fallback: if a company has no CoS agent, logs a warning and falls back to the legacy generic prompt. No crash.

Fixes AGE-44.

## Test plan
- [x] `pnpm -r typecheck`
- [x] `pnpm build`
- [x] `pnpm test:run` — new unit tests for prompt resolution + backfill migration pass. Pre-existing flakes unrelated to this change: embedded-postgres parallel init (feedback-service, heartbeat-comment-wake-batching), billing-routes-extended, activity-routes, client.test timeout.
- [ ] Manual: seed new company, chat via assistant, verify CoS persona and `author_agent_id` on `assistant_messages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)