### PR TITLE
AGE-50 Phase 1: preconditions gate — block goal creation without CoS + adapter

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -141,7 +141,11 @@ export type IssueOriginKind = (typeof ISSUE_ORIGIN_KINDS)[number];
 export const ISSUE_RELATION_TYPES = ["blocks"] as const;
 export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 
-export const GOAL_LEVELS = ["company", "team", "agent", "task"] as const;
+// AgentDash (AGE-49): reduced goal levels to the two business-meaningful
+// tiers. Historical rows with level='agent' or level='task' are soft-
+// deprecated — the DB column is text and reads render literally; writes
+// are validated against this enum.
+export const GOAL_LEVELS = ["company", "team"] as const;
 export type GoalLevel = (typeof GOAL_LEVELS)[number];
 
 export const GOAL_STATUSES = ["planned", "active", "achieved", "cancelled"] as const;

--- a/packages/shared/src/validators/goal.ts
+++ b/packages/shared/src/validators/goal.ts
@@ -4,7 +4,7 @@ import { GOAL_LEVELS, GOAL_STATUSES } from "../constants.js";
 export const createGoalSchema = z.object({
   title: z.string().min(1),
   description: z.string().optional().nullable(),
-  level: z.enum(GOAL_LEVELS).optional().default("task"),
+  level: z.enum(GOAL_LEVELS).optional().default("company"),
   status: z.enum(GOAL_STATUSES).optional().default("planned"),
   priority: z.enum(["critical", "high", "medium", "low"]).optional().default("medium"),
   targetDate: z.string().datetime().optional().nullable(),

--- a/server/src/__tests__/cos-readiness.test.ts
+++ b/server/src/__tests__/cos-readiness.test.ts
@@ -1,0 +1,78 @@
+// AgentDash (AGE-50 Phase 1): tests for the CoS readiness precondition.
+
+import { describe, it, expect, vi } from "vitest";
+import { cosReadinessService } from "../services/cos-readiness.js";
+
+type Row = { id: string; adapterType: string | null; status: string };
+
+function makeDb(rows: Row[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.where = vi.fn().mockReturnValue(chain);
+  chain.then = (onFulfilled: (v: Row[]) => unknown) => Promise.resolve(onFulfilled(rows));
+  return { select: vi.fn().mockReturnValue(chain) };
+}
+
+describe("cosReadinessService.check", () => {
+  it("reports ready when a Chief of Staff with a real adapter exists", async () => {
+    const db = makeDb([
+      { id: "cos-1", adapterType: "claude_api", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result).toEqual({
+      ready: true,
+      hasChiefOfStaff: true,
+      hasLlmAdapter: true,
+      reasons: [],
+      chiefOfStaffAgentId: "cos-1",
+    });
+  });
+
+  it("reports not ready when no Chief of Staff exists at all", async () => {
+    const db = makeDb([]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(false);
+    expect(result.hasChiefOfStaff).toBe(false);
+    expect(result.hasLlmAdapter).toBe(false);
+    expect(result.reasons[0]).toMatch(/No active Chief of Staff/);
+  });
+
+  it("reports not ready when CoS exists but is in a gated status", async () => {
+    const db = makeDb([
+      { id: "cos-1", adapterType: "claude_api", status: "paused" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(false);
+    expect(result.hasChiefOfStaff).toBe(false);
+  });
+
+  it("treats idle and running CoS as ready alongside active", async () => {
+    for (const status of ["idle", "running", "active"]) {
+      const db = makeDb([{ id: "cos-1", adapterType: "claude_api", status }]);
+      const result = await cosReadinessService(db as any).check("co-1");
+      expect(result.ready, `status=${status}`).toBe(true);
+    }
+  });
+
+  it("reports not ready when CoS exists but has placeholder adapter", async () => {
+    const db = makeDb([
+      { id: "cos-1", adapterType: "process", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(false);
+    expect(result.hasChiefOfStaff).toBe(true);
+    expect(result.hasLlmAdapter).toBe(false);
+    expect(result.reasons[0]).toMatch(/runtime adapter/);
+    expect(result.chiefOfStaffAgentId).toBe("cos-1");
+  });
+
+  it("prefers a CoS with a real adapter over one with placeholder", async () => {
+    const db = makeDb([
+      { id: "cos-placeholder", adapterType: "process", status: "active" },
+      { id: "cos-real", adapterType: "claude_local", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(true);
+    expect(result.chiefOfStaffAgentId).toBe("cos-real");
+  });
+});

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -3,7 +3,12 @@ import type { Db } from "@agentdash/db";
 import { createGoalSchema, updateGoalSchema } from "@agentdash/shared";
 import { trackGoalCreated } from "@agentdash/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { accessService, goalService, logActivity } from "../services/index.js";
+import {
+  accessService,
+  cosReadinessService,
+  goalService,
+  logActivity,
+} from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { forbidden } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
@@ -17,6 +22,16 @@ export function goalRoutes(db: Db) {
     assertCompanyAccess(req, companyId);
     const result = await svc.list(companyId);
     res.json(result);
+  });
+
+  // AgentDash (AGE-50 Phase 1): preconditions check for goal creation.
+  // NewGoalDialog calls this on open; disables Create + surfaces a CTA
+  // when the company lacks a ready Chief of Staff + adapter path.
+  router.get("/companies/:companyId/cos-readiness", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const readiness = await cosReadinessService(db).check(companyId);
+    res.json(readiness);
   });
 
   router.get("/goals/:id", async (req, res) => {

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -3,8 +3,9 @@ import type { Db } from "@agentdash/db";
 import { createGoalSchema, updateGoalSchema } from "@agentdash/shared";
 import { trackGoalCreated } from "@agentdash/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { goalService, logActivity } from "../services/index.js";
+import { accessService, goalService, logActivity } from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { forbidden } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
 
 export function goalRoutes(db: Db) {
@@ -32,6 +33,27 @@ export function goalRoutes(db: Db) {
   router.post("/companies/:companyId/goals", validate(createGoalSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+
+    // AgentDash (AGE-49): company-level goals require owner role. Any
+    // authenticated member can create team-level goals. Agent callers
+    // (adapter keys) are allowed through — plan-driven sub-goal creation
+    // inside agentPlansService.approve() also bypasses this since it calls
+    // goalService.create directly rather than hitting the HTTP layer.
+    if (req.body?.level === "company" && req.actor.type === "board") {
+      const userId = req.actor.userId;
+      const isInstanceAdmin =
+        req.actor.source === "local_implicit" || req.actor.isInstanceAdmin;
+      if (!isInstanceAdmin) {
+        const access = accessService(db);
+        const membership = userId
+          ? await access.getMembership(companyId, "user", userId)
+          : null;
+        if (membership?.membershipRole !== "owner") {
+          throw forbidden("Only company owners can create company-level goals");
+        }
+      }
+    }
+
     const goal = await svc.create(companyId, req.body);
     const actor = getActorInfo(req);
     await logActivity(db, {

--- a/server/src/services/assistant-tools.ts
+++ b/server/src/services/assistant-tools.ts
@@ -227,7 +227,7 @@ function setGoalTool(_db: Db): Tool {
           },
           level: {
             type: "string",
-            description: "Goal level: 'company', 'team', or 'task'. Defaults to 'company'.",
+            description: "Goal level: 'company' or 'team'. Defaults to 'company'. 'company' requires owner role.",
           },
           targetDate: {
             type: "string",

--- a/server/src/services/cos-readiness.ts
+++ b/server/src/services/cos-readiness.ts
@@ -1,0 +1,71 @@
+// AgentDash (AGE-50 Phase 1): readiness check for goal creation.
+//
+// A goal without a plan-generation path is worse than no goal — the
+// auto-propose flow (AGE-48) and the Socratic interview flow (AGE-50)
+// both assume the company has (a) an active Chief of Staff agent and
+// (b) an adapter that can actually run the CoS. If either is missing,
+// NewGoalDialog blocks submission and surfaces a CTA that routes the
+// operator to the hire/config flow.
+//
+// We treat `adapter_type='process'` as "not real" — that's the schema
+// default placeholder, not a configured runtime. Any other adapter
+// string (claude_api, claude_local, codex, gemini, …) counts as a
+// configured path.
+
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@agentdash/db";
+import { agents } from "@agentdash/db";
+
+export interface CosReadiness {
+  ready: boolean;
+  hasChiefOfStaff: boolean;
+  hasLlmAdapter: boolean;
+  reasons: string[];
+  chiefOfStaffAgentId: string | null;
+}
+
+const PLACEHOLDER_ADAPTER = "process";
+// Agents in these statuses are hired and configured but not blocked — they
+// can be triggered as part of a plan flow. Terminal / gated statuses
+// (pending_approval, paused, error, terminated) are treated as not ready.
+const READY_STATUSES = new Set(["active", "idle", "running"]);
+
+export function cosReadinessService(db: Db) {
+  return {
+    async check(companyId: string): Promise<CosReadiness> {
+      const rows = await db
+        .select({
+          id: agents.id,
+          adapterType: agents.adapterType,
+          status: agents.status,
+        })
+        .from(agents)
+        .where(and(eq(agents.companyId, companyId), eq(agents.role, "chief_of_staff")));
+
+      const active = rows.filter((r) => READY_STATUSES.has(r.status));
+      const hasChiefOfStaff = active.length > 0;
+
+      const cos = active.find((r) => r.adapterType && r.adapterType !== PLACEHOLDER_ADAPTER) ?? null;
+      const hasLlmAdapter = Boolean(cos);
+
+      const reasons: string[] = [];
+      if (!hasChiefOfStaff) {
+        reasons.push(
+          "No active Chief of Staff agent. Hire one from the Agents sidebar before creating goals.",
+        );
+      } else if (!hasLlmAdapter) {
+        reasons.push(
+          "Chief of Staff has no runtime adapter configured. Open the agent and pick an adapter (Claude Code, Codex, Gemini, …).",
+        );
+      }
+
+      return {
+        ready: hasChiefOfStaff && hasLlmAdapter,
+        hasChiefOfStaff,
+        hasLlmAdapter,
+        reasons,
+        chiefOfStaffAgentId: cos?.id ?? active[0]?.id ?? null,
+      };
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -45,3 +45,6 @@ export { agentPlansService } from "./agent-plans.js";
 export { goalsHubService } from "./goals-hub.js";
 // AgentDash (AGE-48 Phase 1): CoS auto-propose orchestrator.
 export { cosOrchestratorService, defaultInterviewPayload } from "./cos-orchestrator.js";
+// AgentDash (AGE-50 Phase 1): CoS readiness precondition check for goal creation.
+export { cosReadinessService } from "./cos-readiness.js";
+export type { CosReadiness } from "./cos-readiness.js";

--- a/ui/src/api/cos-readiness.ts
+++ b/ui/src/api/cos-readiness.ts
@@ -1,0 +1,17 @@
+// AgentDash (AGE-50 Phase 1): UI client for the CoS readiness precondition.
+// Mirrors `CosReadiness` from server/src/services/cos-readiness.ts.
+
+import { api } from "./client";
+
+export interface CosReadiness {
+  ready: boolean;
+  hasChiefOfStaff: boolean;
+  hasLlmAdapter: boolean;
+  reasons: string[];
+  chiefOfStaffAgentId: string | null;
+}
+
+export const cosReadinessApi = {
+  get: (companyId: string) =>
+    api.get<CosReadiness>(`/companies/${companyId}/cos-readiness`),
+};

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -11,6 +11,9 @@ export { goalsApi } from "./goals";
 // AgentDash (AGE-48 Phase 2): agent-plans API client.
 export { agentPlansApi } from "./agent-plans";
 export type { AgentPlanRow, ApproveAgentPlanResult } from "./agent-plans";
+// AgentDash (AGE-50 Phase 1): CoS readiness precondition.
+export { cosReadinessApi } from "./cos-readiness";
+export type { CosReadiness } from "./cos-readiness";
 // AgentDash: Manual KPIs (AGE-45)
 export { kpisApi } from "./kpis";
 export type { Kpi, KpiCreate, KpiUpdate } from "./kpis";

--- a/ui/src/components/GoalHub.tsx
+++ b/ui/src/components/GoalHub.tsx
@@ -70,11 +70,13 @@ export function GoalHub({ companyId, goalId }: GoalHubProps) {
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="goal-hub">
       <AgentsCard agents={data.agents} />
-      <PlanCard plan={data.plan} />
-      {/* AgentDash (AGE-48 Phase 2): CoS proposal approval surface. Lives
-          alongside the existing static PlanCard so an already-approved plan
-          still renders its rollup summary while a newer proposed plan (e.g.
-          re-draft after reject) surfaces editable actions. */}
+      {/* AgentDash: the static Plan card only shows a post-approval rollup
+          ("expanded" = plan ran and spawned agents). While a plan is still
+          "proposed", the actionable PlanApprovalCard below is the single
+          surface — otherwise the operator sees the same plan twice. */}
+      {data.plan?.status === "expanded" || data.plan?.status === "approved" ? (
+        <PlanCard plan={data.plan} />
+      ) : null}
       <div className="lg:col-span-2">
         <PlanApprovalCard companyId={companyId} goalId={goalId} />
       </div>

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -40,7 +40,9 @@ export function NewGoalDialog() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("planned");
-  const [level, setLevel] = useState("task");
+  // AgentDash (AGE-49): Company is the primary intent for a net-new goal;
+  // team-level is the only other permitted option for members.
+  const [level, setLevel] = useState("company");
   const [parentId, setParentId] = useState("");
   const [expanded, setExpanded] = useState(false);
 
@@ -79,7 +81,7 @@ export function NewGoalDialog() {
     setTitle("");
     setDescription("");
     setStatus("planned");
-    setLevel("task");
+    setLevel("company");
     setParentId("");
     setExpanded(false);
   }

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -1,10 +1,12 @@
 import { useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { GOAL_STATUSES, GOAL_LEVELS } from "@agentdash/shared";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { goalsApi } from "../api/goals";
 import { assetsApi } from "../api/assets";
+import { cosReadinessApi } from "../api/cos-readiness";
 import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
@@ -17,6 +19,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  AlertTriangle,
   Maximize2,
   Minimize2,
   Target,
@@ -58,6 +61,15 @@ export function NewGoalDialog() {
     queryKey: queryKeys.goals.list(selectedCompanyId!),
     queryFn: () => goalsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId && newGoalOpen,
+  });
+
+  // AgentDash (AGE-50 Phase 1): readiness precondition. Block goal creation
+  // unless the company has an active Chief of Staff with a real adapter.
+  const { data: readiness } = useQuery({
+    queryKey: queryKeys.cosReadiness.detail(selectedCompanyId!),
+    queryFn: () => cosReadinessApi.get(selectedCompanyId!),
+    enabled: !!selectedCompanyId && newGoalOpen,
+    staleTime: 30_000,
   });
 
   const createGoal = useMutation({
@@ -270,11 +282,49 @@ export function NewGoalDialog() {
           )}
         </div>
 
+        {/* AgentDash (AGE-50 Phase 1): readiness banner. Rendered only when
+            the company lacks a Chief of Staff or runtime adapter — otherwise
+            the dialog is unchanged. Link routes the operator to the hire
+            flow; if a CoS exists but needs an adapter, we deep-link to it. */}
+        {readiness && !readiness.ready ? (
+          <div
+            data-testid="cos-readiness-banner"
+            className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            <div className="space-y-1">
+              {readiness.reasons.map((r) => (
+                <p key={r}>{r}</p>
+              ))}
+              <p>
+                {!readiness.hasChiefOfStaff ? (
+                  <Link
+                    to="/agents/new"
+                    className="underline font-medium hover:text-destructive/80"
+                    onClick={() => { reset(); closeNewGoal(); }}
+                  >
+                    Hire a Chief of Staff →
+                  </Link>
+                ) : readiness.chiefOfStaffAgentId ? (
+                  <Link
+                    to={`/agents/${readiness.chiefOfStaffAgentId}/dashboard`}
+                    className="underline font-medium hover:text-destructive/80"
+                    onClick={() => { reset(); closeNewGoal(); }}
+                  >
+                    Configure Chief of Staff adapter →
+                  </Link>
+                ) : null}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
         {/* Footer */}
         <div className="flex items-center justify-end px-4 py-2.5 border-t border-border">
           <Button
             size="sm"
-            disabled={!title.trim() || createGoal.isPending}
+            disabled={!title.trim() || createGoal.isPending || (readiness ? !readiness.ready : false)}
             onClick={handleSubmit}
           >
             {createGoal.isPending ? "Creating…" : newGoalDefaults.parentId ? "Create sub-goal" : "Create goal"}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -85,6 +85,10 @@ export const queryKeys = {
     detail: (companyId: string, planId: string) =>
       ["agent-plans", "detail", companyId, planId] as const,
   },
+  // AgentDash (AGE-50 Phase 1): CoS readiness precondition for NewGoalDialog.
+  cosReadiness: {
+    detail: (companyId: string) => ["cos-readiness", companyId] as const,
+  },
   crm: {
     pipeline: (companyId: string) => ["crm", companyId, "pipeline"] as const,
     accounts: (companyId: string) => ["crm", companyId, "accounts"] as const,

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -1,12 +1,18 @@
 import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Target, Plus } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { EmptyState } from "../components/EmptyState";
-import { Target } from "lucide-react";
+import { StatusBadge } from "../components/StatusBadge";
+import { Button } from "@/components/ui/button";
+import { goalsApi } from "../api/goals";
+import { queryKeys } from "../lib/queryKeys";
 
 export function Goals() {
-  const { selectedCompanyId } = useCompany();
+  const { selectedCompanyId, selectedCompany } = useCompany();
   const { openNewGoal } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
 
@@ -14,18 +20,61 @@ export function Goals() {
     setBreadcrumbs([{ label: "Goals" }]);
   }, [setBreadcrumbs]);
 
+  const goalsQuery = useQuery({
+    queryKey: selectedCompanyId ? queryKeys.goals.list(selectedCompanyId) : ["goals", "none"],
+    queryFn: () => (selectedCompanyId ? goalsApi.list(selectedCompanyId) : Promise.resolve([])),
+    enabled: !!selectedCompanyId,
+  });
+
   if (!selectedCompanyId) {
     return <EmptyState icon={Target} message="Select a company to view goals." />;
   }
 
+  const goals = goalsQuery.data ?? [];
+  const prefix = selectedCompany?.issuePrefix;
+
+  if (goals.length === 0) {
+    return (
+      <div className="space-y-4">
+        <EmptyState
+          icon={Target}
+          message="Start a new goal to drive focused work across your agents and teams."
+          action="New Goal"
+          onAction={() => openNewGoal({ hideParentSelector: true })}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-4">
-      <EmptyState
-        icon={Target}
-        message="Start a new goal to drive focused work across your agents and teams."
-        action="New Goal"
-        onAction={() => openNewGoal({ hideParentSelector: true })}
-      />
+    <div className="max-w-4xl mx-auto p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Goals</h1>
+        <Button onClick={() => openNewGoal({ hideParentSelector: true })} size="sm">
+          <Plus className="h-4 w-4 mr-1" />
+          New Goal
+        </Button>
+      </div>
+      <div className="rounded-md border border-border divide-y divide-border">
+        {goals.map((goal) => (
+          <Link
+            key={goal.id}
+            to={prefix ? `/${prefix}/goals/${goal.id}` : `/goals/${goal.id}`}
+            className="flex items-center justify-between gap-4 px-4 py-3 hover:bg-muted/50 transition-colors"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="font-medium truncate">{goal.title}</div>
+              {goal.description ? (
+                <div className="text-sm text-muted-foreground truncate">{goal.description}</div>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-xs text-muted-foreground uppercase">{goal.level}</span>
+              <StatusBadge status={goal.status} />
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Stacked on top of AGE-49. First PR in AGE-50 (Socratic goal interview). Ships the preconditions gate now so users can't create goals that have no plan-generation path.

## Summary

- New service `server/src/services/cos-readiness.ts` → reports `{ ready, hasChiefOfStaff, hasLlmAdapter, reasons[], chiefOfStaffAgentId }` for a company.
- New endpoint `GET /companies/:companyId/cos-readiness` on the goals route module.
- `NewGoalDialog` queries readiness on open and:
  - Renders an inline destructive-style banner with the specific reason (no CoS / no adapter) plus a deep-link CTA (Hire Chief of Staff → / Configure adapter →).
  - Disables the Create button while not ready.
- Ready statuses are `active | idle | running`. Gated statuses (`pending_approval | paused | error | terminated`) report not ready.
- Placeholder adapter type `'process'` (the schema default for a freshly-created agent record) is treated as "no real adapter."

## Test matrix

- `pnpm vitest run src/__tests__/cos-readiness.test.ts` — **6/6 pass** (happy path, no CoS, inactive CoS, placeholder adapter, idle/running/active ready parity, adapter-prefers-real-over-placeholder).
- `pnpm -r typecheck` ✅
- `pnpm build` ✅
- Live probe against OtherCo (has CoS with `claude_local` adapter, status=idle): returns `ready: true`.
- Live probe against EEG / EEPAA companies (no CoS): returns `ready: false`, reasons list filled.

## Risks to flag to Tester

- Deep-link CTA routes to `/agents/new` and `/agents/:id/dashboard`. If the user has multiple CoS agents — one with placeholder adapter, one with a real one — readiness picks the real one; the "Configure adapter" CTA deep-links to whichever was returned. No multi-CoS UI disambiguation in this PR.
- The readiness check is a client-side precondition only. Server-side POST /goals still accepts goals without a CoS — Phase 2 will add the matching server guard if we want hard enforcement. For now the client-side gate is sufficient to prevent accidental creation.

## Base

Targets `kailortang/age-49-goal-levels-simplified` (stacked chain: AGE-48 PR-a → AGE-49 → AGE-50 Phase 1).