### PR TITLE
AGE-50 Phase 5: description-thinness ambiguity gate

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -141,7 +141,11 @@ export type IssueOriginKind = (typeof ISSUE_ORIGIN_KINDS)[number];
 export const ISSUE_RELATION_TYPES = ["blocks"] as const;
 export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 
-export const GOAL_LEVELS = ["company", "team", "agent", "task"] as const;
+// AgentDash (AGE-49): reduced goal levels to the two business-meaningful
+// tiers. Historical rows with level='agent' or level='task' are soft-
+// deprecated — the DB column is text and reads render literally; writes
+// are validated against this enum.
+export const GOAL_LEVELS = ["company", "team"] as const;
 export type GoalLevel = (typeof GOAL_LEVELS)[number];
 
 export const GOAL_STATUSES = ["planned", "active", "achieved", "cancelled"] as const;

--- a/packages/shared/src/validators/goal.ts
+++ b/packages/shared/src/validators/goal.ts
@@ -4,7 +4,7 @@ import { GOAL_LEVELS, GOAL_STATUSES } from "../constants.js";
 export const createGoalSchema = z.object({
   title: z.string().min(1),
   description: z.string().optional().nullable(),
-  level: z.enum(GOAL_LEVELS).optional().default("task"),
+  level: z.enum(GOAL_LEVELS).optional().default("company"),
   status: z.enum(GOAL_STATUSES).optional().default("planned"),
   priority: z.enum(["critical", "high", "medium", "low"]).optional().default("medium"),
   targetDate: z.string().datetime().optional().nullable(),

--- a/server/src/__tests__/cos-ambiguity-gate.test.ts
+++ b/server/src/__tests__/cos-ambiguity-gate.test.ts
@@ -1,0 +1,50 @@
+// AgentDash (AGE-50 Phase 5): unit tests for the description-thinness
+// ambiguity gate. Keeps the heuristic honest — if someone tunes the
+// thresholds these tests make the new bar visible.
+
+import { describe, it, expect } from "vitest";
+import { isDescriptionSubstantive } from "../services/cos-orchestrator.js";
+
+describe("isDescriptionSubstantive", () => {
+  it("returns false for null, undefined, or empty input", () => {
+    expect(isDescriptionSubstantive(null)).toBe(false);
+    expect(isDescriptionSubstantive(undefined)).toBe(false);
+    expect(isDescriptionSubstantive("")).toBe(false);
+    expect(isDescriptionSubstantive("   \n\t  ")).toBe(false);
+  });
+
+  it("returns false for a one-liner even if long-ish", () => {
+    // 199 chars, below the 200-char floor.
+    const short = "a".repeat(199);
+    expect(isDescriptionSubstantive(short)).toBe(false);
+  });
+
+  it("returns false for enough chars but too few words", () => {
+    // 250 chars but one giant word — no real signal.
+    const one_word = "x".repeat(250);
+    expect(isDescriptionSubstantive(one_word)).toBe(false);
+  });
+
+  it("returns true for a substantive multi-sentence description", () => {
+    const desc =
+      "Launch the premium tier end-of-quarter with three concrete bets: " +
+      "Stripe billing integration, a public pricing and packaging page, " +
+      "and targeted outreach to existing B2B customers above $10k ARR. " +
+      "Constraints: no cold outreach to net-new prospects, must preserve " +
+      "our free tier.";
+    expect(isDescriptionSubstantive(desc)).toBe(true);
+  });
+
+  it("returns false just below the word threshold even with many chars", () => {
+    // Over 200 chars but only ~20 whitespace-separated words — padding
+    // uses very long tokens so char count passes but word count fails.
+    const longTokens =
+      "supercalifragilisticexpialidocious-alpha supercalifragilisticexpialidocious-beta " +
+      "supercalifragilisticexpialidocious-gamma supercalifragilisticexpialidocious-delta " +
+      "supercalifragilisticexpialidocious-epsilon another-short-word";
+    expect(longTokens.length).toBeGreaterThanOrEqual(200);
+    const wordCount = longTokens.trim().split(/\s+/).length;
+    expect(wordCount).toBeLessThan(30);
+    expect(isDescriptionSubstantive(longTokens)).toBe(false);
+  });
+});

--- a/server/src/__tests__/cos-orchestrator.test.ts
+++ b/server/src/__tests__/cos-orchestrator.test.ts
@@ -203,11 +203,10 @@ describe("cosOrchestratorService.proposeForGoal (wired via goalService.create)",
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
-  it("skips auto-propose for company-level goals (AGE-50 Phase 4b)", async () => {
-    // Company-level goals require a Socratic deep-interview, so auto-propose
-    // is intentionally skipped — PlanApprovalCard surfaces a CTA instead of
-    // a misleading stub plan.
-    const companyGoalRow = { ...goalRow, level: "company" };
+  it("skips auto-propose for company-level goals with thin descriptions (AGE-50 Phase 4b)", async () => {
+    // Company-level goals require a Socratic deep-interview when the
+    // description lacks enough signal to generate a grounded plan.
+    const companyGoalRow = { ...goalRow, level: "company", description: "" };
     const selectImpl = vi.fn().mockReturnValueOnce(thenable([companyGoalRow]));
     const insertImpl = vi.fn().mockReturnValue(thenable([companyGoalRow]));
     const db = {
@@ -229,6 +228,64 @@ describe("cosOrchestratorService.proposeForGoal (wired via goalService.create)",
     expect(mockGeneratePlan).not.toHaveBeenCalled();
     expect(mockPlanCreate).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("auto-proposes for company-level goals with substantive descriptions (AGE-50 Phase 5)", async () => {
+    // When the operator supplies a rich, specific description the
+    // ambiguity gate treats the description itself as the interview and
+    // the generator can run directly — avoids forcing a Socratic Q&A on
+    // operators who already answered the questions in prose.
+    const richDescription =
+      "Launch the premium tier end-of-quarter with three concrete bets: " +
+      "Stripe billing integration, a public pricing and packaging page, " +
+      "and targeted outreach to existing B2B customers above $10k ARR. " +
+      "Constraints: no cold outreach to net-new prospects, must preserve " +
+      "our free tier, budget cap $2k monthly for agent runtime. Channels: " +
+      "email and in-app messaging. Success: 10 premium conversions and " +
+      "$30k new MRR in 90 days.";
+    const companyGoalRow = {
+      ...goalRow,
+      level: "company",
+      description: richDescription,
+    };
+
+    mockGeneratePlan.mockResolvedValueOnce({
+      plan: validPayload,
+      archetype: "revenue",
+      interviewHash: "h-phase5",
+      rubric: { average: 8.2, minimum: 8, passesAPlus: true, hardFailure: false, scores: {} },
+      cached: false,
+    });
+    mockPlanCreate.mockResolvedValueOnce({
+      id: "plan-phase5",
+      companyId,
+      goalId: companyGoalRow.id,
+      status: "proposed",
+      archetype: "revenue",
+      proposalPayload: validPayload,
+    });
+
+    const selectImpl = vi.fn().mockReturnValueOnce(thenable([companyGoalRow]));
+    const insertImpl = vi.fn().mockReturnValue(thenable([companyGoalRow]));
+    const db = {
+      select: selectImpl,
+      insert: insertImpl,
+      update: vi.fn().mockReturnValue(thenable([])),
+    };
+
+    const { goalService } = await import("../services/goals.js");
+    const created = await goalService(db as any).create(companyId, {
+      title: "Launch premium tier by EOQ2",
+      description: richDescription,
+      level: "company" as any,
+      status: "planned" as any,
+    });
+
+    expect(created?.id).toBe(companyGoalRow.id);
+    // Auto-propose ran — substantive description bypassed the interview gate.
+    expect(mockGeneratePlan).toHaveBeenCalledTimes(1);
+    expect(mockPlanCreate).toHaveBeenCalledTimes(1);
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
   });
 
   it("swallows thrown errors from the orchestrator and still returns the goal", async () => {

--- a/server/src/__tests__/cos-orchestrator.test.ts
+++ b/server/src/__tests__/cos-orchestrator.test.ts
@@ -70,12 +70,15 @@ const validPayload = {
 // ---- shared setup ---------------------------------------------------------
 
 const companyId = "co-1";
+// AgentDash (AGE-50 Phase 4b): team-level by default so existing tests
+// still exercise the auto-propose path. Company-level now triggers the
+// skip-for-interview branch — covered by its own test below.
 const goalRow = {
   id: "g-new",
   companyId,
-  title: "Q1 revenue lift",
+  title: "Q1 team revenue standup",
   description: "ship ICP-focused outbound",
-  level: "company",
+  level: "team",
   status: "planned",
 };
 
@@ -125,7 +128,7 @@ describe("cosOrchestratorService.proposeForGoal (wired via goalService.create)",
     const created = await goalService(db as any).create(companyId, {
       title: goalRow.title,
       description: goalRow.description,
-      level: "company" as any,
+      level: "team" as any,
       status: "planned" as any,
     });
 
@@ -166,7 +169,7 @@ describe("cosOrchestratorService.proposeForGoal (wired via goalService.create)",
       companyId,
       {
         title: "seed-only goal",
-        level: "company" as any,
+        level: "team" as any,
         status: "planned" as any,
       },
       { skipAutoPropose: true },
@@ -189,13 +192,41 @@ describe("cosOrchestratorService.proposeForGoal (wired via goalService.create)",
 
     const created = await goalService(db as any).create(companyId, {
       title: goalRow.title,
-      level: "company" as any,
+      level: "team" as any,
       status: "planned" as any,
     });
 
     // Goal creation still succeeds.
     expect(created?.id).toBe(goalRow.id);
     // No plan row was created, no activity logged.
+    expect(mockPlanCreate).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("skips auto-propose for company-level goals (AGE-50 Phase 4b)", async () => {
+    // Company-level goals require a Socratic deep-interview, so auto-propose
+    // is intentionally skipped — PlanApprovalCard surfaces a CTA instead of
+    // a misleading stub plan.
+    const companyGoalRow = { ...goalRow, level: "company" };
+    const selectImpl = vi.fn().mockReturnValueOnce(thenable([companyGoalRow]));
+    const insertImpl = vi.fn().mockReturnValue(thenable([companyGoalRow]));
+    const db = {
+      select: selectImpl,
+      insert: insertImpl,
+      update: vi.fn().mockReturnValue(thenable([])),
+    };
+
+    const { goalService } = await import("../services/goals.js");
+    const created = await goalService(db as any).create(companyId, {
+      title: "Launch premium tier by EOQ2",
+      level: "company" as any,
+      status: "planned" as any,
+    });
+
+    // Goal creation succeeds.
+    expect(created?.id).toBe(companyGoalRow.id);
+    // Auto-propose was skipped — no plan generation, no plan row, no activity.
+    expect(mockGeneratePlan).not.toHaveBeenCalled();
     expect(mockPlanCreate).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
@@ -210,7 +241,7 @@ describe("cosOrchestratorService.proposeForGoal (wired via goalService.create)",
 
     const created = await goalService(db as any).create(companyId, {
       title: goalRow.title,
-      level: "company" as any,
+      level: "team" as any,
       status: "planned" as any,
     });
 

--- a/server/src/__tests__/cos-readiness.test.ts
+++ b/server/src/__tests__/cos-readiness.test.ts
@@ -1,7 +1,25 @@
 // AgentDash (AGE-50 Phase 1): tests for the CoS readiness precondition.
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { cosReadinessService } from "../services/cos-readiness.js";
+import { __resetOmcDetectionCache } from "../services/omc-detection.js";
+
+// AgentDash (AGE-50 Phase 4a): readiness now also reports OMC state.
+// We mock `detectOmc` so these tests don't depend on the test host's
+// actual ~/.claude filesystem.
+vi.mock("../services/omc-detection.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/omc-detection.js")>(
+    "../services/omc-detection.js",
+  );
+  return {
+    ...actual,
+    detectOmc: vi.fn().mockResolvedValue({ installed: true, path: "/mock/omc", checkedPaths: ["/mock/omc"] }),
+  };
+});
+
+beforeEach(() => {
+  __resetOmcDetectionCache();
+});
 
 type Row = { id: string; adapterType: string | null; status: string };
 
@@ -14,7 +32,7 @@ function makeDb(rows: Row[]) {
 }
 
 describe("cosReadinessService.check", () => {
-  it("reports ready when a Chief of Staff with a real adapter exists", async () => {
+  it("reports ready when a Chief of Staff with a real adapter exists and OMC is installed", async () => {
     const db = makeDb([
       { id: "cos-1", adapterType: "claude_api", status: "active" },
     ]);
@@ -23,9 +41,28 @@ describe("cosReadinessService.check", () => {
       ready: true,
       hasChiefOfStaff: true,
       hasLlmAdapter: true,
+      hasOmc: true,
       reasons: [],
       chiefOfStaffAgentId: "cos-1",
     });
+  });
+
+  it("appends a soft warning reason when OMC is missing but does not gate readiness", async () => {
+    const omcModule = await import("../services/omc-detection.js");
+    vi.mocked(omcModule.detectOmc).mockResolvedValueOnce({
+      installed: false,
+      path: null,
+      checkedPaths: ["/nope"],
+    });
+    const db = makeDb([
+      { id: "cos-1", adapterType: "claude_api", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(true);
+    expect(result.hasOmc).toBe(false);
+    expect(result.reasons).toEqual([
+      expect.stringMatching(/oh-my-claudecode is not installed/),
+    ]);
   });
 
   it("reports not ready when no Chief of Staff exists at all", async () => {

--- a/server/src/__tests__/cos-readiness.test.ts
+++ b/server/src/__tests__/cos-readiness.test.ts
@@ -1,0 +1,78 @@
+// AgentDash (AGE-50 Phase 1): tests for the CoS readiness precondition.
+
+import { describe, it, expect, vi } from "vitest";
+import { cosReadinessService } from "../services/cos-readiness.js";
+
+type Row = { id: string; adapterType: string | null; status: string };
+
+function makeDb(rows: Row[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.where = vi.fn().mockReturnValue(chain);
+  chain.then = (onFulfilled: (v: Row[]) => unknown) => Promise.resolve(onFulfilled(rows));
+  return { select: vi.fn().mockReturnValue(chain) };
+}
+
+describe("cosReadinessService.check", () => {
+  it("reports ready when a Chief of Staff with a real adapter exists", async () => {
+    const db = makeDb([
+      { id: "cos-1", adapterType: "claude_api", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result).toEqual({
+      ready: true,
+      hasChiefOfStaff: true,
+      hasLlmAdapter: true,
+      reasons: [],
+      chiefOfStaffAgentId: "cos-1",
+    });
+  });
+
+  it("reports not ready when no Chief of Staff exists at all", async () => {
+    const db = makeDb([]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(false);
+    expect(result.hasChiefOfStaff).toBe(false);
+    expect(result.hasLlmAdapter).toBe(false);
+    expect(result.reasons[0]).toMatch(/No active Chief of Staff/);
+  });
+
+  it("reports not ready when CoS exists but is in a gated status", async () => {
+    const db = makeDb([
+      { id: "cos-1", adapterType: "claude_api", status: "paused" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(false);
+    expect(result.hasChiefOfStaff).toBe(false);
+  });
+
+  it("treats idle and running CoS as ready alongside active", async () => {
+    for (const status of ["idle", "running", "active"]) {
+      const db = makeDb([{ id: "cos-1", adapterType: "claude_api", status }]);
+      const result = await cosReadinessService(db as any).check("co-1");
+      expect(result.ready, `status=${status}`).toBe(true);
+    }
+  });
+
+  it("reports not ready when CoS exists but has placeholder adapter", async () => {
+    const db = makeDb([
+      { id: "cos-1", adapterType: "process", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(false);
+    expect(result.hasChiefOfStaff).toBe(true);
+    expect(result.hasLlmAdapter).toBe(false);
+    expect(result.reasons[0]).toMatch(/runtime adapter/);
+    expect(result.chiefOfStaffAgentId).toBe("cos-1");
+  });
+
+  it("prefers a CoS with a real adapter over one with placeholder", async () => {
+    const db = makeDb([
+      { id: "cos-placeholder", adapterType: "process", status: "active" },
+      { id: "cos-real", adapterType: "claude_local", status: "active" },
+    ]);
+    const result = await cosReadinessService(db as any).check("co-1");
+    expect(result.ready).toBe(true);
+    expect(result.chiefOfStaffAgentId).toBe("cos-real");
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -688,6 +688,23 @@ export async function startServer(): Promise<StartedServer> {
     server.listen(listenPort, config.host, () => {
       server.off("error", onError);
       logger.info(`Server listening on ${config.host}:${listenPort}`);
+      // AgentDash (AGE-50 Phase 4a): probe for oh-my-claudecode. Missing is
+      // non-fatal — auto-propose still works with the canned prompt path.
+      // Just surface the state so operators know deep-interview will be
+      // degraded.
+      void import("./services/omc-detection.js").then(async ({ detectOmc }) => {
+        const omc = await detectOmc();
+        if (omc.installed) {
+          logger.info({ path: omc.path }, "oh-my-claudecode detected — /deep-interview available to Chief of Staff");
+        } else {
+          logger.warn(
+            { checkedPaths: omc.checkedPaths },
+            "oh-my-claudecode not detected — /deep-interview-backed features will fall back to ad-hoc prompts. Install with `omc install`.",
+          );
+        }
+      }).catch((err) => {
+        logger.warn({ err }, "oh-my-claudecode probe failed");
+      });
       if (process.env.PAPERCLIP_OPEN_ON_LISTEN === "true") {
         const openHost = config.host === "0.0.0.0" || config.host === "::" ? "127.0.0.1" : config.host;
         const url = `http://${openHost}:${listenPort}`;

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -3,7 +3,12 @@ import type { Db } from "@agentdash/db";
 import { createGoalSchema, updateGoalSchema } from "@agentdash/shared";
 import { trackGoalCreated } from "@agentdash/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { accessService, goalService, logActivity } from "../services/index.js";
+import {
+  accessService,
+  cosReadinessService,
+  goalService,
+  logActivity,
+} from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { forbidden } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
@@ -17,6 +22,16 @@ export function goalRoutes(db: Db) {
     assertCompanyAccess(req, companyId);
     const result = await svc.list(companyId);
     res.json(result);
+  });
+
+  // AgentDash (AGE-50 Phase 1): preconditions check for goal creation.
+  // NewGoalDialog calls this on open; disables Create + surfaces a CTA
+  // when the company lacks a ready Chief of Staff + adapter path.
+  router.get("/companies/:companyId/cos-readiness", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const readiness = await cosReadinessService(db).check(companyId);
+    res.json(readiness);
   });
 
   router.get("/goals/:id", async (req, res) => {

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -3,8 +3,9 @@ import type { Db } from "@agentdash/db";
 import { createGoalSchema, updateGoalSchema } from "@agentdash/shared";
 import { trackGoalCreated } from "@agentdash/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { goalService, logActivity } from "../services/index.js";
+import { accessService, goalService, logActivity } from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { forbidden } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
 
 export function goalRoutes(db: Db) {
@@ -32,6 +33,27 @@ export function goalRoutes(db: Db) {
   router.post("/companies/:companyId/goals", validate(createGoalSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+
+    // AgentDash (AGE-49): company-level goals require owner role. Any
+    // authenticated member can create team-level goals. Agent callers
+    // (adapter keys) are allowed through — plan-driven sub-goal creation
+    // inside agentPlansService.approve() also bypasses this since it calls
+    // goalService.create directly rather than hitting the HTTP layer.
+    if (req.body?.level === "company" && req.actor.type === "board") {
+      const userId = req.actor.userId;
+      const isInstanceAdmin =
+        req.actor.source === "local_implicit" || req.actor.isInstanceAdmin;
+      if (!isInstanceAdmin) {
+        const access = accessService(db);
+        const membership = userId
+          ? await access.getMembership(companyId, "user", userId)
+          : null;
+        if (membership?.membershipRole !== "owner") {
+          throw forbidden("Only company owners can create company-level goals");
+        }
+      }
+    }
+
     const goal = await svc.create(companyId, req.body);
     const actor = getActorInfo(req);
     await logActivity(db, {

--- a/server/src/services/assistant-tools.ts
+++ b/server/src/services/assistant-tools.ts
@@ -4,12 +4,18 @@
  * AgentDash: assistant chatbot internal toolkit
  */
 import type { Db } from "@agentdash/db";
+import { and, desc, eq } from "drizzle-orm";
+import { agentPlans, goals } from "@agentdash/db";
+import { goalInterviewPayloadSchema, type GoalInterviewPayload } from "@agentdash/shared";
 import type { ToolDefinition } from "./assistant-llm.js";
 import { agentService } from "./agents.js";
 import { issueService } from "./issues.js";
 import { goalService } from "./goals.js";
 // AgentDash: Manual KPIs (AGE-45)
 import { kpisService } from "./kpis.js";
+// AgentDash (AGE-50 Phase 4a): agent-plans service for submit_goal_interview tool.
+import { agentPlansService } from "./agent-plans.js";
+import { logActivity } from "./activity-log.js";
 
 // ── Tool Context (constructed from req.actor in route handler) ─────────
 
@@ -364,6 +370,117 @@ function getDashboardSummaryTool(_db: Db): Tool {
   };
 }
 
+// ── Tool: submit_goal_interview (AgentDash: AGE-50 Phase 4a) ──────────
+
+// Lets the Chief of Staff submit the results of a Socratic /deep-interview
+// for a goal. Replaces (or creates) the `proposed` plan for that goal so
+// PlanApprovalCard picks it up on the next refetch. Idempotent: if a plan
+// is already expanded/approved, the tool rejects rather than overwriting.
+function submitGoalInterviewTool(_db: Db): Tool {
+  return {
+    definition: {
+      name: "submit_goal_interview",
+      description:
+        "Submit the results of a Socratic /deep-interview for a goal. Generates a Chief of Staff plan from the interview answers and persists it as the goal's proposed plan. Use this after running /deep-interview with the operator to capture their intent, constraints, channels, blockers, and success criteria.",
+      input_schema: {
+        type: "object",
+        properties: {
+          goalId: {
+            type: "string",
+            description: "UUID of the goal being interviewed.",
+          },
+          payload: {
+            type: "object",
+            description:
+              "GoalInterviewPayload — structured answers from the operator. Fields: archetype, goalStatement, whyNow, horizonDays, targetValue, targetUnit, baselineValue, monthlyBudgetUsd, constraints[], channels[], industry, companySize, blockers[]. All fields optional; provide as many as the interview surfaced.",
+          },
+        },
+        required: ["goalId", "payload"],
+      },
+    },
+    execute: async (input, ctx, db) => {
+      assertToolAccess(ctx, ctx.companyId);
+      const goalId = input.goalId as string;
+      const rawPayload = input.payload;
+      if (!goalId || typeof goalId !== "string") {
+        throw Object.assign(new Error("goalId is required"), { statusCode: 400 });
+      }
+      const parsed = goalInterviewPayloadSchema.safeParse(rawPayload);
+      if (!parsed.success) {
+        throw Object.assign(
+          new Error(`Invalid interview payload: ${parsed.error.message}`),
+          { statusCode: 400 },
+        );
+      }
+      const payload: GoalInterviewPayload = parsed.data;
+
+      const goal = await db
+        .select()
+        .from(goals)
+        .where(and(eq(goals.id, goalId), eq(goals.companyId, ctx.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!goal) {
+        throw Object.assign(new Error(`Goal not found: ${goalId}`), { statusCode: 404 });
+      }
+
+      const plansSvc = agentPlansService(db);
+      const generated = await plansSvc.generatePlan(ctx.companyId, goalId, payload);
+      if ("error" in generated) {
+        throw Object.assign(
+          new Error(`Plan generation failed: ${generated.error}`),
+          { statusCode: 422 },
+        );
+      }
+
+      // If an existing proposed plan exists, supersede it by rejecting the
+      // old row first — atomic overwrite would require a transaction we
+      // don't yet have. For now: leave the old plan; the new plan becomes
+      // the most-recent proposed row and PlanApprovalCard picks up by
+      // ORDER BY createdAt DESC.
+      const existing = await db
+        .select({ id: agentPlans.id, status: agentPlans.status })
+        .from(agentPlans)
+        .where(and(eq(agentPlans.goalId, goalId), eq(agentPlans.status, "proposed")))
+        .orderBy(desc(agentPlans.createdAt))
+        .then((rows) => rows[0] ?? null);
+
+      const plan = await plansSvc.create(
+        ctx.companyId,
+        {
+          goalId,
+          archetype: generated.archetype,
+          rationale: generated.plan.rationale,
+          payload: generated.plan,
+        },
+        {
+          userId: ctx.userId,
+        },
+      );
+
+      await logActivity(db, {
+        companyId: ctx.companyId,
+        actorType: "user",
+        actorId: ctx.userId,
+        agentId: null,
+        action: "plan.interview_submitted",
+        entityType: "goal",
+        entityId: goalId,
+        details: {
+          planId: plan.id,
+          archetype: plan.archetype,
+          supersededPlanId: existing?.id ?? null,
+        },
+      });
+
+      return {
+        planId: plan.id,
+        archetype: plan.archetype,
+        rubricAverage: generated.rubric.average,
+      };
+    },
+  };
+}
+
 // ── Public API ─────────────────────────────────────────────────────────
 
 export function getAssistantTools(db: Db): Tool[] {
@@ -376,6 +493,8 @@ export function getAssistantTools(db: Db): Tool[] {
     getDashboardSummaryTool(db),
     // AgentDash: Manual KPIs (AGE-45)
     updateKpiTool(db),
+    // AgentDash (AGE-50 Phase 4a): submit Socratic /deep-interview results.
+    submitGoalInterviewTool(db),
   ];
 }
 

--- a/server/src/services/assistant-tools.ts
+++ b/server/src/services/assistant-tools.ts
@@ -227,7 +227,7 @@ function setGoalTool(_db: Db): Tool {
           },
           level: {
             type: "string",
-            description: "Goal level: 'company', 'team', or 'task'. Defaults to 'company'.",
+            description: "Goal level: 'company' or 'team'. Defaults to 'company'. 'company' requires owner role.",
           },
           targetDate: {
             type: "string",

--- a/server/src/services/cos-orchestrator.ts
+++ b/server/src/services/cos-orchestrator.ts
@@ -71,6 +71,24 @@ export function defaultInterviewPayload(goal: {
   };
 }
 
+// AgentDash (AGE-50 Phase 5): ambiguity gate. A goal's description is
+// "substantive" enough to skip the Socratic deep-interview when it
+// contains both enough characters AND enough distinct words for the plan
+// generator to have real signal to work with. Thresholds are empirical —
+// if operators report canned plans despite substantive descriptions, tune
+// up. If they complain about being forced into interviews they don't need,
+// tune down.
+const SUBSTANTIVE_DESC_MIN_CHARS = 200;
+const SUBSTANTIVE_DESC_MIN_WORDS = 30;
+
+export function isDescriptionSubstantive(description: string | null | undefined): boolean {
+  if (!description) return false;
+  const trimmed = description.trim();
+  if (trimmed.length < SUBSTANTIVE_DESC_MIN_CHARS) return false;
+  const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
+  return wordCount >= SUBSTANTIVE_DESC_MIN_WORDS;
+}
+
 export function cosOrchestratorService(db: Db) {
   const plansSvc = agentPlansService(db);
   const goalsSvc = goalService(db);
@@ -93,21 +111,33 @@ export function cosOrchestratorService(db: Db) {
           return { ok: false, reason: "goal_not_found" };
         }
 
-        // AgentDash (AGE-50 Phase 4b): company-level goals require a
-        // Socratic deep-interview before a plan is written. Skip the canned
-        // auto-propose so PlanApprovalCard surfaces the "Run deep interview"
-        // CTA instead of a misleading stub plan. The submit_goal_interview
-        // tool writes the real plan after the interview completes.
+        // AgentDash (AGE-50 Phase 4b + Phase 5): company-level goals
+        // normally require a Socratic deep-interview before a plan is
+        // written — but if the operator already supplied a rich,
+        // specific description, skip the interview and auto-propose
+        // directly (AGE-50 Phase 5 ambiguity gate). The rationale: making
+        // an operator re-answer questions they already answered in the
+        // description is a conversion killer.
         //
         // Callers can still force auto-propose by passing an explicit
-        // `options.interview` (that's how submit_goal_interview would route
-        // through here if we ever wire it — today it calls plansSvc directly).
+        // `options.interview`.
         if (goal.level === "company" && !options.interview) {
+          const descSubstantive = isDescriptionSubstantive(goal.description);
+          if (!descSubstantive) {
+            logger.info(
+              { companyId, goalId },
+              "cos-orchestrator: skipping auto-propose for company-level goal (awaiting deep-interview)",
+            );
+            return {
+              ok: true,
+              skipped: true,
+              reason: "company_goal_awaiting_interview",
+            };
+          }
           logger.info(
-            { companyId, goalId },
-            "cos-orchestrator: skipping auto-propose for company-level goal (awaiting deep-interview)",
+            { companyId, goalId, descriptionChars: goal.description?.length ?? 0 },
+            "cos-orchestrator: description is substantive — auto-proposing directly (Phase 5 ambiguity gate)",
           );
-          return { ok: true, skipped: true, reason: "company_goal_awaiting_interview" };
         }
 
         const interview = options.interview ?? defaultInterviewPayload(goal);

--- a/server/src/services/cos-orchestrator.ts
+++ b/server/src/services/cos-orchestrator.ts
@@ -45,6 +45,10 @@ export interface ProposeForGoalResult {
   ok: boolean;
   planId?: string;
   reason?: string;
+  // AgentDash (AGE-50 Phase 4b): set when the orchestrator intentionally
+  // skipped auto-propose (e.g., company-level goals that require a Socratic
+  // interview instead of a canned plan).
+  skipped?: boolean;
 }
 
 // AgentDash: derive a minimal interview payload from an existing goal row.
@@ -88,6 +92,24 @@ export function cosOrchestratorService(db: Db) {
         if (!goal || goal.companyId !== companyId) {
           return { ok: false, reason: "goal_not_found" };
         }
+
+        // AgentDash (AGE-50 Phase 4b): company-level goals require a
+        // Socratic deep-interview before a plan is written. Skip the canned
+        // auto-propose so PlanApprovalCard surfaces the "Run deep interview"
+        // CTA instead of a misleading stub plan. The submit_goal_interview
+        // tool writes the real plan after the interview completes.
+        //
+        // Callers can still force auto-propose by passing an explicit
+        // `options.interview` (that's how submit_goal_interview would route
+        // through here if we ever wire it — today it calls plansSvc directly).
+        if (goal.level === "company" && !options.interview) {
+          logger.info(
+            { companyId, goalId },
+            "cos-orchestrator: skipping auto-propose for company-level goal (awaiting deep-interview)",
+          );
+          return { ok: true, skipped: true, reason: "company_goal_awaiting_interview" };
+        }
+
         const interview = options.interview ?? defaultInterviewPayload(goal);
         const generated = await plansSvc.generatePlan(companyId, goalId, interview);
         if ("error" in generated) {

--- a/server/src/services/cos-readiness.ts
+++ b/server/src/services/cos-readiness.ts
@@ -15,11 +15,16 @@
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@agentdash/db";
 import { agents } from "@agentdash/db";
+import { detectOmc } from "./omc-detection.js";
 
 export interface CosReadiness {
   ready: boolean;
   hasChiefOfStaff: boolean;
   hasLlmAdapter: boolean;
+  // AgentDash (AGE-50 Phase 4a): whether oh-my-claudecode is installed on
+  // the adapter host. When false, `/deep-interview`-backed features fall
+  // back to ad-hoc prompts. Soft signal — not gating, just informational.
+  hasOmc: boolean;
   reasons: string[];
   chiefOfStaffAgentId: string | null;
 }
@@ -48,6 +53,9 @@ export function cosReadinessService(db: Db) {
       const cos = active.find((r) => r.adapterType && r.adapterType !== PLACEHOLDER_ADAPTER) ?? null;
       const hasLlmAdapter = Boolean(cos);
 
+      const omc = await detectOmc();
+      const hasOmc = omc.installed;
+
       const reasons: string[] = [];
       if (!hasChiefOfStaff) {
         reasons.push(
@@ -58,11 +66,21 @@ export function cosReadinessService(db: Db) {
           "Chief of Staff has no runtime adapter configured. Open the agent and pick an adapter (Claude Code, Codex, Gemini, …).",
         );
       }
+      if (!hasOmc) {
+        // AgentDash (AGE-50 Phase 4a): soft warning — not a hard gate. Deep
+        // goal-interview falls back to ad-hoc prompts without OMC, but the
+        // auto-propose path still works.
+        reasons.push(
+          "oh-my-claudecode is not installed on this host — deep goal-interview will fall back to a canned prompt. Install with `omc install`.",
+        );
+      }
 
       return {
+        // Hard gates: CoS + adapter. OMC is a soft signal and does not block.
         ready: hasChiefOfStaff && hasLlmAdapter,
         hasChiefOfStaff,
         hasLlmAdapter,
+        hasOmc,
         reasons,
         chiefOfStaffAgentId: cos?.id ?? active[0]?.id ?? null,
       };

--- a/server/src/services/cos-readiness.ts
+++ b/server/src/services/cos-readiness.ts
@@ -1,0 +1,71 @@
+// AgentDash (AGE-50 Phase 1): readiness check for goal creation.
+//
+// A goal without a plan-generation path is worse than no goal — the
+// auto-propose flow (AGE-48) and the Socratic interview flow (AGE-50)
+// both assume the company has (a) an active Chief of Staff agent and
+// (b) an adapter that can actually run the CoS. If either is missing,
+// NewGoalDialog blocks submission and surfaces a CTA that routes the
+// operator to the hire/config flow.
+//
+// We treat `adapter_type='process'` as "not real" — that's the schema
+// default placeholder, not a configured runtime. Any other adapter
+// string (claude_api, claude_local, codex, gemini, …) counts as a
+// configured path.
+
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@agentdash/db";
+import { agents } from "@agentdash/db";
+
+export interface CosReadiness {
+  ready: boolean;
+  hasChiefOfStaff: boolean;
+  hasLlmAdapter: boolean;
+  reasons: string[];
+  chiefOfStaffAgentId: string | null;
+}
+
+const PLACEHOLDER_ADAPTER = "process";
+// Agents in these statuses are hired and configured but not blocked — they
+// can be triggered as part of a plan flow. Terminal / gated statuses
+// (pending_approval, paused, error, terminated) are treated as not ready.
+const READY_STATUSES = new Set(["active", "idle", "running"]);
+
+export function cosReadinessService(db: Db) {
+  return {
+    async check(companyId: string): Promise<CosReadiness> {
+      const rows = await db
+        .select({
+          id: agents.id,
+          adapterType: agents.adapterType,
+          status: agents.status,
+        })
+        .from(agents)
+        .where(and(eq(agents.companyId, companyId), eq(agents.role, "chief_of_staff")));
+
+      const active = rows.filter((r) => READY_STATUSES.has(r.status));
+      const hasChiefOfStaff = active.length > 0;
+
+      const cos = active.find((r) => r.adapterType && r.adapterType !== PLACEHOLDER_ADAPTER) ?? null;
+      const hasLlmAdapter = Boolean(cos);
+
+      const reasons: string[] = [];
+      if (!hasChiefOfStaff) {
+        reasons.push(
+          "No active Chief of Staff agent. Hire one from the Agents sidebar before creating goals.",
+        );
+      } else if (!hasLlmAdapter) {
+        reasons.push(
+          "Chief of Staff has no runtime adapter configured. Open the agent and pick an adapter (Claude Code, Codex, Gemini, …).",
+        );
+      }
+
+      return {
+        ready: hasChiefOfStaff && hasLlmAdapter,
+        hasChiefOfStaff,
+        hasLlmAdapter,
+        reasons,
+        chiefOfStaffAgentId: cos?.id ?? active[0]?.id ?? null,
+      };
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -45,3 +45,6 @@ export { agentPlansService } from "./agent-plans.js";
 export { goalsHubService } from "./goals-hub.js";
 // AgentDash (AGE-48 Phase 1): CoS auto-propose orchestrator.
 export { cosOrchestratorService, defaultInterviewPayload } from "./cos-orchestrator.js";
+// AgentDash (AGE-50 Phase 1): CoS readiness precondition check for goal creation.
+export { cosReadinessService } from "./cos-readiness.js";
+export type { CosReadiness } from "./cos-readiness.js";

--- a/server/src/services/omc-detection.ts
+++ b/server/src/services/omc-detection.ts
@@ -1,0 +1,68 @@
+// AgentDash (AGE-50 Phase 4a): detect whether oh-my-claudecode is installed
+// at the adapter host.
+//
+// OMC is the skill library that backs `/deep-interview` and other Socratic
+// behaviors the Chief of Staff relies on. If it's missing, CoS features
+// fall back to ad-hoc prompts — we warn at startup and surface the state
+// through `cosReadinessService` so the UI can show a soft warning.
+//
+// OMC installs via Claude Code's plugin marketplace. We check the known
+// install locations in order:
+//   1. `~/.claude/plugins/marketplaces/omc/` — the primary marketplace dir
+//   2. `~/.claude/plugins/cache/omc/` — the cache clone used at runtime
+//   3. `~/.claude/plugins/oh-my-claudecode/` — legacy / alternate name
+//   4. `$CLAUDE_PROJECT_DIR/.claude/plugins/marketplaces/omc/` — project-scoped
+// If any exists, we report installed=true with the matching path.
+
+import { access } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface OmcDetection {
+  installed: boolean;
+  path: string | null;
+  checkedPaths: string[];
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let cached: OmcDetection | null = null;
+
+export async function detectOmc(options: { refresh?: boolean } = {}): Promise<OmcDetection> {
+  if (cached && !options.refresh) return cached;
+
+  const home = homedir();
+  const userPaths = [
+    join(home, ".claude", "plugins", "marketplaces", "omc"),
+    join(home, ".claude", "plugins", "cache", "omc"),
+    join(home, ".claude", "plugins", "oh-my-claudecode"),
+  ];
+  const projectPath = process.env.CLAUDE_PROJECT_DIR
+    ? join(process.env.CLAUDE_PROJECT_DIR, ".claude", "plugins", "marketplaces", "omc")
+    : null;
+
+  const checkedPaths = projectPath ? [...userPaths, projectPath] : userPaths;
+
+  for (const p of checkedPaths) {
+    if (await exists(p)) {
+      cached = { installed: true, path: p, checkedPaths };
+      return cached;
+    }
+  }
+
+  cached = { installed: false, path: null, checkedPaths };
+  return cached;
+}
+
+// Test hook: clear the memoized result so tests can re-probe with a new cwd.
+export function __resetOmcDetectionCache() {
+  cached = null;
+}

--- a/ui/src/api/cos-readiness.ts
+++ b/ui/src/api/cos-readiness.ts
@@ -1,0 +1,17 @@
+// AgentDash (AGE-50 Phase 1): UI client for the CoS readiness precondition.
+// Mirrors `CosReadiness` from server/src/services/cos-readiness.ts.
+
+import { api } from "./client";
+
+export interface CosReadiness {
+  ready: boolean;
+  hasChiefOfStaff: boolean;
+  hasLlmAdapter: boolean;
+  reasons: string[];
+  chiefOfStaffAgentId: string | null;
+}
+
+export const cosReadinessApi = {
+  get: (companyId: string) =>
+    api.get<CosReadiness>(`/companies/${companyId}/cos-readiness`),
+};

--- a/ui/src/api/cos-readiness.ts
+++ b/ui/src/api/cos-readiness.ts
@@ -7,6 +7,8 @@ export interface CosReadiness {
   ready: boolean;
   hasChiefOfStaff: boolean;
   hasLlmAdapter: boolean;
+  // AgentDash (AGE-50 Phase 4a): OMC install state on the adapter host.
+  hasOmc: boolean;
   reasons: string[];
   chiefOfStaffAgentId: string | null;
 }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -11,6 +11,9 @@ export { goalsApi } from "./goals";
 // AgentDash (AGE-48 Phase 2): agent-plans API client.
 export { agentPlansApi } from "./agent-plans";
 export type { AgentPlanRow, ApproveAgentPlanResult } from "./agent-plans";
+// AgentDash (AGE-50 Phase 1): CoS readiness precondition.
+export { cosReadinessApi } from "./cos-readiness";
+export type { CosReadiness } from "./cos-readiness";
 // AgentDash: Manual KPIs (AGE-45)
 export { kpisApi } from "./kpis";
 export type { Kpi, KpiCreate, KpiUpdate } from "./kpis";

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -86,7 +86,20 @@ function MessageBubble({ message }: { message: Message }) {
   );
 }
 
-export function ChatPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function ChatPanel({
+  open,
+  onClose,
+  seedMessage,
+  onSeedConsumed,
+}: {
+  open: boolean;
+  onClose: () => void;
+  // AgentDash (AGE-50 Phase 4b): initial message auto-sent to the Chief of
+  // Staff when the panel opens with a seed. Used by PlanApprovalCard to
+  // trigger /deep-interview for company-level goals.
+  seedMessage?: string | null;
+  onSeedConsumed?: () => void;
+}) {
   const { selectedCompanyId } = useCompany();
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
@@ -120,8 +133,11 @@ export function ChatPanel({ open, onClose }: { open: boolean; onClose: () => voi
     }
   }, [open]);
 
-  const sendMessage = useCallback(async () => {
-    const text = input.trim();
+  // AgentDash (AGE-50 Phase 4b): internal helper that accepts an explicit
+  // message. Lets sendMessage use the current input state, and lets the
+  // seed-message effect bypass the input entirely.
+  const sendText = useCallback(async (rawText: string) => {
+    const text = rawText.trim();
     if (!text || isLoading || !selectedCompanyId) return;
 
     setInput("");
@@ -258,7 +274,25 @@ export function ChatPanel({ open, onClose }: { open: boolean; onClose: () => voi
       setIsLoading(false);
       abortRef.current = null;
     }
-  }, [input, isLoading, selectedCompanyId, conversationId]);
+  }, [isLoading, selectedCompanyId, conversationId]);
+
+  // AgentDash (AGE-50 Phase 4b): button/enter-key path — sends whatever is
+  // currently in the input field.
+  const sendMessage = useCallback(() => {
+    return sendText(input);
+  }, [sendText, input]);
+
+  // AgentDash (AGE-50 Phase 4b): seed-message effect. When the panel opens
+  // with a seed (e.g. PlanApprovalCard triggered a deep-interview), send
+  // it once and notify the parent to clear the seed so subsequent opens
+  // don't re-send.
+  useEffect(() => {
+    if (open && seedMessage && !isLoading && selectedCompanyId) {
+      void sendText(seedMessage);
+      onSeedConsumed?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, seedMessage, selectedCompanyId]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/ui/src/components/GoalHub.tsx
+++ b/ui/src/components/GoalHub.tsx
@@ -70,11 +70,13 @@ export function GoalHub({ companyId, goalId }: GoalHubProps) {
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="goal-hub">
       <AgentsCard agents={data.agents} />
-      <PlanCard plan={data.plan} />
-      {/* AgentDash (AGE-48 Phase 2): CoS proposal approval surface. Lives
-          alongside the existing static PlanCard so an already-approved plan
-          still renders its rollup summary while a newer proposed plan (e.g.
-          re-draft after reject) surfaces editable actions. */}
+      {/* AgentDash: the static Plan card only shows a post-approval rollup
+          ("expanded" = plan ran and spawned agents). While a plan is still
+          "proposed", the actionable PlanApprovalCard below is the single
+          surface — otherwise the operator sees the same plan twice. */}
+      {data.plan?.status === "expanded" || data.plan?.status === "approved" ? (
+        <PlanCard plan={data.plan} />
+      ) : null}
       <div className="lg:col-span-2">
         <PlanApprovalCard companyId={companyId} goalId={goalId} />
       </div>

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -53,7 +53,17 @@ function readRememberedInstanceSettingsPath(): string {
 
 export function Layout() {
   const { sidebarOpen, setSidebarOpen, toggleSidebar, isMobile } = useSidebar();
-  const { openNewIssue, openOnboarding } = useDialog();
+  const {
+    openNewIssue,
+    openOnboarding,
+    // AgentDash (AGE-50 Phase 4b): chat state lives in DialogContext so any
+    // component (e.g. PlanApprovalCard) can open it with a seed message.
+    chatOpen,
+    chatSeed,
+    openChat,
+    closeChat,
+    consumeChatSeed,
+  } = useDialog();
   const { togglePanelVisible } = usePanel();
   const {
     companies,
@@ -72,17 +82,26 @@ export function Layout() {
   const lastMainScrollTop = useRef(0);
   const [mobileNavVisible, setMobileNavVisible] = useState(true);
   const [instanceSettingsTarget, setInstanceSettingsTarget] = useState<string>(() => readRememberedInstanceSettingsPath());
-  // AgentDash: chat panel state
-  const [chatOpen, setChatOpen] = useState(() => {
-    try { return localStorage.getItem("agentdash.chatPanelOpen") === "true"; } catch { return false; }
-  });
-  const toggleChat = useCallback(() => {
-    setChatOpen((prev) => {
-      const next = !prev;
-      try { localStorage.setItem("agentdash.chatPanelOpen", String(next)); } catch { /* ignore */ }
-      return next;
-    });
+  // AgentDash: chat panel state. Source of truth is DialogContext;
+  // localStorage persists the open-state across reloads.
+  useEffect(() => {
+    try {
+      if (localStorage.getItem("agentdash.chatPanelOpen") === "true" && !chatOpen) {
+        openChat();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    } catch { /* ignore */ }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  useEffect(() => {
+    try {
+      localStorage.setItem("agentdash.chatPanelOpen", String(chatOpen));
+    } catch { /* ignore */ }
+  }, [chatOpen]);
+  const toggleChat = useCallback(() => {
+    if (chatOpen) closeChat();
+    else openChat();
+  }, [chatOpen, openChat, closeChat]);
   const nextTheme = theme === "dark" ? "light" : "dark";
   const matchedCompany = useMemo(() => {
     if (!companyPrefix) return null;
@@ -461,13 +480,14 @@ export function Layout() {
               <CompanyTheme />
             </main>
             <PropertiesPanel />
-            {/* AgentDash: assistant chat panel */}
+            {/* AgentDash: assistant chat panel. Seed message (when set by
+                DialogContext.openChat({ seedMessage })) is sent on mount
+                and then consumed so subsequent opens don't re-send. */}
             <ChatPanel
               open={chatOpen && !isMobile}
-              onClose={() => {
-                setChatOpen(false);
-                try { localStorage.setItem("agentdash.chatPanelOpen", "false"); } catch { /* ignore */ }
-              }}
+              seedMessage={chatSeed}
+              onSeedConsumed={consumeChatSeed}
+              onClose={closeChat}
             />
           </div>
         </div>

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -40,7 +40,9 @@ export function NewGoalDialog() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("planned");
-  const [level, setLevel] = useState("task");
+  // AgentDash (AGE-49): Company is the primary intent for a net-new goal;
+  // team-level is the only other permitted option for members.
+  const [level, setLevel] = useState("company");
   const [parentId, setParentId] = useState("");
   const [expanded, setExpanded] = useState(false);
 
@@ -79,7 +81,7 @@ export function NewGoalDialog() {
     setTitle("");
     setDescription("");
     setStatus("planned");
-    setLevel("task");
+    setLevel("company");
     setParentId("");
     setExpanded(false);
   }

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -1,10 +1,12 @@
 import { useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { GOAL_STATUSES, GOAL_LEVELS } from "@agentdash/shared";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { goalsApi } from "../api/goals";
 import { assetsApi } from "../api/assets";
+import { cosReadinessApi } from "../api/cos-readiness";
 import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
@@ -17,6 +19,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  AlertTriangle,
   Maximize2,
   Minimize2,
   Target,
@@ -58,6 +61,15 @@ export function NewGoalDialog() {
     queryKey: queryKeys.goals.list(selectedCompanyId!),
     queryFn: () => goalsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId && newGoalOpen,
+  });
+
+  // AgentDash (AGE-50 Phase 1): readiness precondition. Block goal creation
+  // unless the company has an active Chief of Staff with a real adapter.
+  const { data: readiness } = useQuery({
+    queryKey: queryKeys.cosReadiness.detail(selectedCompanyId!),
+    queryFn: () => cosReadinessApi.get(selectedCompanyId!),
+    enabled: !!selectedCompanyId && newGoalOpen,
+    staleTime: 30_000,
   });
 
   const createGoal = useMutation({
@@ -270,11 +282,49 @@ export function NewGoalDialog() {
           )}
         </div>
 
+        {/* AgentDash (AGE-50 Phase 1): readiness banner. Rendered only when
+            the company lacks a Chief of Staff or runtime adapter — otherwise
+            the dialog is unchanged. Link routes the operator to the hire
+            flow; if a CoS exists but needs an adapter, we deep-link to it. */}
+        {readiness && !readiness.ready ? (
+          <div
+            data-testid="cos-readiness-banner"
+            className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            <div className="space-y-1">
+              {readiness.reasons.map((r) => (
+                <p key={r}>{r}</p>
+              ))}
+              <p>
+                {!readiness.hasChiefOfStaff ? (
+                  <Link
+                    to="/agents/new"
+                    className="underline font-medium hover:text-destructive/80"
+                    onClick={() => { reset(); closeNewGoal(); }}
+                  >
+                    Hire a Chief of Staff →
+                  </Link>
+                ) : readiness.chiefOfStaffAgentId ? (
+                  <Link
+                    to={`/agents/${readiness.chiefOfStaffAgentId}/dashboard`}
+                    className="underline font-medium hover:text-destructive/80"
+                    onClick={() => { reset(); closeNewGoal(); }}
+                  >
+                    Configure Chief of Staff adapter →
+                  </Link>
+                ) : null}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
         {/* Footer */}
         <div className="flex items-center justify-end px-4 py-2.5 border-t border-border">
           <Button
             size="sm"
-            disabled={!title.trim() || createGoal.isPending}
+            disabled={!title.trim() || createGoal.isPending || (readiness ? !readiness.ready : false)}
             onClick={handleSubmit}
           >
             {createGoal.isPending ? "Creating…" : newGoalDefaults.parentId ? "Create sub-goal" : "Create goal"}

--- a/ui/src/components/PlanApprovalCard.tsx
+++ b/ui/src/components/PlanApprovalCard.tsx
@@ -23,12 +23,17 @@ import {
   AlertTriangle,
   CheckCircle2,
   ClipboardList,
+  MessageCircle,
   Pencil,
   Sparkles,
   X,
 } from "lucide-react";
 import type { AgentTeamPlanPayload } from "@agentdash/shared";
 import { agentPlansApi, type AgentPlanRow } from "@/api/agent-plans";
+import { goalsApi } from "@/api/goals";
+// AgentDash (AGE-50 Phase 4b): DialogContext exposes openChat so the
+// "Run deep interview" CTA can seed the assistant chat with a prompt.
+import { useDialog } from "../context/DialogContext";
 import { queryKeys } from "@/lib/queryKeys";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -50,9 +55,20 @@ function centsToUsd(dollars: number): string {
 
 export function PlanApprovalCard({ companyId, goalId }: PlanApprovalCardProps) {
   const queryClient = useQueryClient();
+  const { openChat } = useDialog();
   const [editorOpen, setEditorOpen] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
   const [rejectNote, setRejectNote] = useState("");
+
+  // AgentDash (AGE-50 Phase 4b): fetch the goal to know its level — company
+  // goals without a plan surface a "Run deep interview" CTA instead of the
+  // generic "drafting…" copy.
+  const goalQuery = useQuery({
+    queryKey: queryKeys.goals.detail(goalId),
+    queryFn: () => goalsApi.get(goalId),
+    enabled: !!goalId,
+    staleTime: 30_000,
+  });
 
   const plansQuery = useQuery({
     queryKey: queryKeys.agentPlans.byGoal(companyId, goalId),
@@ -110,6 +126,46 @@ export function PlanApprovalCard({ companyId, goalId }: PlanApprovalCardProps) {
   }
 
   if (!plan) {
+    // AgentDash (AGE-50 Phase 4b): company-level goals require a Socratic
+    // deep-interview before a plan is written. Show an explicit CTA — the
+    // canned "drafting…" copy would be misleading because nothing is actually
+    // queued. Clicking seeds the assistant chat.
+    const goal = goalQuery.data;
+    if (goal && goal.level === "company") {
+      const seedMessage = [
+        `Please run /deep-interview on this goal: "${goal.title}".`,
+        goal.description ? `Description: ${goal.description}` : "",
+        `Capture the operator's intent, constraints, channels, blockers, and success criteria. Ask one question at a time (3–5 total), then summarize the answers into a GoalInterviewPayload and call submit_goal_interview with goalId="${goal.id}" and the payload. Keep it friendly and brief.`,
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+
+      return (
+        <Card data-testid="plan-approval-card-company-interview">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4" />
+              Chief of Staff interview
+            </CardTitle>
+            <CardDescription>
+              Company-level goals start with a brief Q&amp;A so the Chief of
+              Staff can propose a plan grounded in your actual constraints.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              size="sm"
+              onClick={() => openChat({ seedMessage })}
+              data-testid="plan-start-interview-btn"
+            >
+              <MessageCircle className="h-3.5 w-3.5 mr-1.5" />
+              Start deep interview
+            </Button>
+          </CardContent>
+        </Card>
+      );
+    }
+
     return (
       <Card data-testid="plan-approval-card-pending">
         <CardHeader>

--- a/ui/src/context/DialogContext.tsx
+++ b/ui/src/context/DialogContext.tsx
@@ -20,6 +20,14 @@ interface OnboardingOptions {
   companyId?: string;
 }
 
+// AgentDash (AGE-50 Phase 4b): chat open state lives in DialogContext so
+// callers outside Layout (e.g. PlanApprovalCard) can open the assistant
+// chat with a seed message. Layout drives ChatPanel from this state.
+interface ChatOpenOptions {
+  // Optional initial message to auto-send to the Chief of Staff on open.
+  seedMessage?: string;
+}
+
 interface DialogContextValue {
   newIssueOpen: boolean;
   newIssueDefaults: NewIssueDefaults;
@@ -39,6 +47,14 @@ interface DialogContextValue {
   onboardingOptions: OnboardingOptions;
   openOnboarding: (options?: OnboardingOptions) => void;
   closeOnboarding: () => void;
+  // AgentDash (AGE-50 Phase 4b): assistant chat open + seed.
+  chatOpen: boolean;
+  chatSeed: string | null;
+  openChat: (options?: ChatOpenOptions) => void;
+  closeChat: () => void;
+  // Called by ChatPanel once it has consumed the seed so subsequent opens
+  // don't re-send.
+  consumeChatSeed: () => void;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
@@ -99,6 +115,26 @@ export function DialogProvider({ children }: { children: ReactNode }) {
     setOnboardingOptions({});
   }, []);
 
+  // AgentDash (AGE-50 Phase 4b): assistant chat state lives here so any
+  // component can open the chat with a seed message.
+  const [chatOpen, setChatOpen] = useState(false);
+  const [chatSeed, setChatSeed] = useState<string | null>(null);
+
+  const openChat = useCallback((options: ChatOpenOptions = {}) => {
+    if (options.seedMessage) {
+      setChatSeed(options.seedMessage);
+    }
+    setChatOpen(true);
+  }, []);
+
+  const closeChat = useCallback(() => {
+    setChatOpen(false);
+  }, []);
+
+  const consumeChatSeed = useCallback(() => {
+    setChatSeed(null);
+  }, []);
+
   return (
     <DialogContext.Provider
       value={{
@@ -120,6 +156,11 @@ export function DialogProvider({ children }: { children: ReactNode }) {
         onboardingOptions,
         openOnboarding,
         closeOnboarding,
+        chatOpen,
+        chatSeed,
+        openChat,
+        closeChat,
+        consumeChatSeed,
       }}
     >
       {children}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -85,6 +85,10 @@ export const queryKeys = {
     detail: (companyId: string, planId: string) =>
       ["agent-plans", "detail", companyId, planId] as const,
   },
+  // AgentDash (AGE-50 Phase 1): CoS readiness precondition for NewGoalDialog.
+  cosReadiness: {
+    detail: (companyId: string) => ["cos-readiness", companyId] as const,
+  },
   crm: {
     pipeline: (companyId: string) => ["crm", companyId, "pipeline"] as const,
     accounts: (companyId: string) => ["crm", companyId, "accounts"] as const,

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -1,12 +1,18 @@
 import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Target, Plus } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { EmptyState } from "../components/EmptyState";
-import { Target } from "lucide-react";
+import { StatusBadge } from "../components/StatusBadge";
+import { Button } from "@/components/ui/button";
+import { goalsApi } from "../api/goals";
+import { queryKeys } from "../lib/queryKeys";
 
 export function Goals() {
-  const { selectedCompanyId } = useCompany();
+  const { selectedCompanyId, selectedCompany } = useCompany();
   const { openNewGoal } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
 
@@ -14,18 +20,61 @@ export function Goals() {
     setBreadcrumbs([{ label: "Goals" }]);
   }, [setBreadcrumbs]);
 
+  const goalsQuery = useQuery({
+    queryKey: selectedCompanyId ? queryKeys.goals.list(selectedCompanyId) : ["goals", "none"],
+    queryFn: () => (selectedCompanyId ? goalsApi.list(selectedCompanyId) : Promise.resolve([])),
+    enabled: !!selectedCompanyId,
+  });
+
   if (!selectedCompanyId) {
     return <EmptyState icon={Target} message="Select a company to view goals." />;
   }
 
+  const goals = goalsQuery.data ?? [];
+  const prefix = selectedCompany?.issuePrefix;
+
+  if (goals.length === 0) {
+    return (
+      <div className="space-y-4">
+        <EmptyState
+          icon={Target}
+          message="Start a new goal to drive focused work across your agents and teams."
+          action="New Goal"
+          onAction={() => openNewGoal({ hideParentSelector: true })}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-4">
-      <EmptyState
-        icon={Target}
-        message="Start a new goal to drive focused work across your agents and teams."
-        action="New Goal"
-        onAction={() => openNewGoal({ hideParentSelector: true })}
-      />
+    <div className="max-w-4xl mx-auto p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Goals</h1>
+        <Button onClick={() => openNewGoal({ hideParentSelector: true })} size="sm">
+          <Plus className="h-4 w-4 mr-1" />
+          New Goal
+        </Button>
+      </div>
+      <div className="rounded-md border border-border divide-y divide-border">
+        {goals.map((goal) => (
+          <Link
+            key={goal.id}
+            to={prefix ? `/${prefix}/goals/${goal.id}` : `/goals/${goal.id}`}
+            className="flex items-center justify-between gap-4 px-4 py-3 hover:bg-muted/50 transition-colors"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="font-medium truncate">{goal.title}</div>
+              {goal.description ? (
+                <div className="text-sm text-muted-foreground truncate">{goal.description}</div>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-xs text-muted-foreground uppercase">{goal.level}</span>
+              <StatusBadge status={goal.status} />
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Stacked on #20 (AGE-50 Phase 4). Sibling to #21 (Phase 2) and #22 (Ops). Closes out the AGE-50 scope: when the operator provides a rich, specific description, skip the Socratic interview and auto-propose directly.

## Summary

Phase 4b unconditionally skipped auto-propose for company-level goals. That's right when descriptions are thin, but punitive when the operator has already answered the clarifying questions in prose. Phase 5 adds an ambiguity heuristic.

**Heuristic** (both must pass):
- `description.trim().length >= 200` chars
- word count `>= 30` whitespace-separated tokens

**Behavior matrix:**

| level | description | outcome |
|---|---|---|
| team | any | auto-propose with derived payload (unchanged) |
| company | thin/empty | skip auto-propose, surface Start deep interview CTA (unchanged) |
| company | substantive (>=200c + >=30w) | auto-propose with derived payload — new |

## Test matrix

- `pnpm -r typecheck` ✅
- `pnpm build` ✅
- `pnpm vitest run cos-orchestrator cos-ambiguity-gate` — **13/13 pass** (adds 5 heuristic tests + 1 substantive-description end-to-end test)

## Risks for Tester

- Thresholds are empirical. If operators report canned plans despite rich descriptions, tune up `SUBSTANTIVE_DESC_MIN_CHARS`/`SUBSTANTIVE_DESC_MIN_WORDS`. If they complain about being forced into interviews they don't need, tune down.
- A substantive description that happens to be gibberish (e.g. lorem ipsum) would bypass the interview and produce a canned plan. Acceptable for v1 — an LLM-backed ambiguity score can replace the dumb heuristic in v2.
- `isDescriptionSubstantive` is exported so future callers (e.g. PlanApprovalCard pre-check) can share the same definition.

## Base

Targets `kailortang/age-50-phase-4-omc-deep-interview` (#20). Sibling to #21 and #22.