### PR TITLE
doc: testing-strategy spec + goal/CoS/CAO PRD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /app
 # Copy only manifests first so this layer is invalidated only when deps change
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 COPY cli/package.json cli/
+COPY marketing/package.json marketing/
 COPY server/package.json server/
 COPY ui/package.json ui/
 COPY packages/adapter-utils/package.json packages/adapter-utils/

--- a/doc/2026-04-22-goal-cos-cao-prd.md
+++ b/doc/2026-04-22-goal-cos-cao-prd.md
@@ -1,0 +1,356 @@
+# PRD — Goal Creation, Onboarding, Chief of Staff, Chief Agent Officer
+
+**Status:** Draft, 2026-04-22
+**Owner:** Kailor Tang
+**Scope:** AgentDash — the four user-visible surfaces that make the product feel like a company-shaped agent operating system: onboarding, goal creation, the Chief of Staff assistant, and the Chief Agent Officer.
+
+---
+
+## 1. Overview
+
+AgentDash sells one promise: a single human operator (CEO / founder / department head) can set direction, and a fleet of AI agents does the work. Four surfaces carry that promise end-to-end:
+
+- **Onboarding** — first-run setup that turns "an empty dashboard" into "a company shape with goals and agents".
+- **Goal Creation** — how operators express what they want the company to achieve, and how those goals cascade into agent work.
+- **Chief of Staff (CoS)** — the operator's conversational thinking partner. Right-side chat panel. Runs Socratic `/deep-interview` for goals, proposes plans, answers workspace questions.
+- **Chief Agent Officer (CAO)** — a new dedicated role that owns the agent fleet: lifecycle, efficiency, wake cadences, priorities, budget consumption, incident response.
+
+These four are not pipelines or templates in the old Paperclip sense — they are the load-bearing concepts of AgentDash. Every product decision in this PRD defers to them.
+
+### Principles (non-negotiable)
+
+- **No "Pipelines" top-level concept.** Work rolls up to **Goals**. Impact and ROI live on the goal page.
+- **Agents are always autonomous.** No "mode toggle". They pause themselves when a human decision is required.
+- **Agents are measured on job performance** (throughput, rework, $-per-task) — not on goal KPI attribution.
+- **CoS handles humans. CAO handles agents.** Don't conflate.
+- **Minimal abstractions.** Prefer wiring real things over vendored/curated layers.
+- **Internal MAW stays internal.** The Multi-Agent Workflow is a dev tool for us, not a product surface.
+
+---
+
+## 2. Personas
+
+| Persona | Who | Primary surface | Success feels like |
+|---|---|---|---|
+| **Operator** (CEO / founder / dept head) | The human paying for AgentDash | Goal page + CoS chat | "I told it what I wanted, and work got done." |
+| **Board member** | Non-operator with read / approval rights | Dashboard + approvals | "I can see what the company is doing without asking." |
+| **Admin** | Customer's IT / ops person | Onboarding + instance settings | "I got it deployed and connected, clean handoff." |
+| **(Implicit) Chief of Staff agent** | Deployed agent, `role=chief_of_staff` | Runs under the hood | Operator rarely thinks about it as separate from AgentDash itself. |
+| **(Implicit) Chief Agent Officer agent** | Deployed agent, `role=chief_agent_officer` (new) | Runs under the hood | Operator trusts the fleet to self-manage. |
+
+Notes:
+- Operator and Board member collapse to the same account type today (`board` role).
+- Admin persona may be the same human as Operator in the small-team case.
+
+---
+
+## 3. Onboarding
+
+### 3.1 Goals
+- Take a human from "nothing" to "a company with goals and at least one CoS agent and one working agent" in **≤ 15 minutes**.
+- Never force CLI / terminal commands for the Operator persona. Admin tasks (deploy, bootstrap) can still be CLI.
+- Leave behind: company row, goals, CoS agent, ≥1 worker agent, connected adapter authentication for all of them.
+
+### 3.2 Non-goals
+- Full multi-department scaffolding. That's a later "grow your company" flow.
+- Security policy setup in the first run. Defer to "before inviting others".
+
+### 3.3 Flow
+
+```
+Admin path                       Operator path
+-----------                      --------------
+1. Install AgentDash             A. Log in, accept invite
+2. Bootstrap first board user    B. "Set up your company" wizard opens
+3. Share invite link             C. Answer 3-5 questions about the business
+                                 D. Paste / link a description (website, Notion, deck)
+                                 E. Review extracted context (industry, team, stack)
+                                 F. Name 1-3 initial goals
+                                 G. Pick CoS adapter (Claude Code / Codex / Gemini)
+                                 H. Complete → dashboard with goals + CoS ready
+```
+
+### 3.4 Requirements
+- **F-On-1.** The wizard auto-creates a `chief_of_staff` agent at completion. Default adapter is whichever one the Operator authenticated.
+- **F-On-2.** Operator authentication for adapters happens inside the wizard (AGE-54.1 style in-app OAuth for Claude Code, Codex, Gemini) — no terminal.
+- **F-On-3.** Extracted context from pasted docs is editable before commit. Nothing is auto-saved until the Operator clicks "Looks right".
+- **F-On-4.** Wizard is interruptible and resumable — close the tab and re-open without losing state.
+- **F-On-5.** Empty-state hints show up on `/goals`, `/agents`, `/inbox` for 24h post-onboarding (covers AGE-40 polish).
+- **F-On-6.** If the Admin deploys in "managed" mode, steps A–H above collapse to one URL the customer visits after we've already done 1–3.
+
+### 3.5 Open questions
+- Should the wizard create a **CAO** agent automatically, or only after the operator has ≥2 worker agents? (See §6.)
+- Pricing trial starts at wizard-complete, or at first chat send? (Pricing memo is open — do not hardcode.)
+
+---
+
+## 4. Goal Creation
+
+### 4.1 Concept
+A **Goal** is the unit of operator intent. It owns:
+- Title, description, archetype (revenue / acquisition / cost / support / content / custom)
+- Target KPIs (`goal_kpis` table — manual values per AGE-45)
+- A **proposed plan** (generated by CoS), which becomes an approved plan, which seeds issues / projects / agent assignments
+- An impact & ROI summary (computed from linked issues' activity + cost data)
+
+No "Pipelines" term, anywhere. Work linked to a goal is expressed as issues and the plan that generated them.
+
+### 4.2 Goals (meta)
+- Operator can create a goal in < 60 seconds, OR spend 10 minutes doing a deep-interview if they want help.
+- Goals are always editable; approved plans are mutable until execution is in flight.
+
+### 4.3 Flow
+
+**Fast path (<60s)** — operator already knows what they want:
+
+```
+Click "New goal" → modal with {title, archetype, target KPI?} → Save
+```
+
+**Guided path (5-10 min)** — operator wants help shaping it:
+
+```
+Click "New goal" → "Not sure yet? Run a deep-interview" →
+  Opens Chief of Staff chat with a seeded /deep-interview prompt →
+  CoS asks 3-5 Socratic questions one at a time →
+  CoS calls submit_goal_interview({goalId, payload}) →
+  A proposed plan appears on the goal page for operator approval.
+```
+
+The guided path is what the right-side chat panel was always going to power. AGE-50 Phase 4b wired the seed-message plumbing; AGE-53/54 got the SSE stream working end-to-end.
+
+### 4.4 Requirements
+- **F-Goal-1.** Both paths land the same shape: `goals` row + optional `agent_plans` row with `status=proposed`.
+- **F-Goal-2.** `submit_goal_interview` is idempotent — if a plan is already `expanded` or `approved`, the tool refuses rather than overwriting. (Already implemented AGE-50 Phase 4a.)
+- **F-Goal-3.** Operator approval on a proposed plan cascades into issue creation and agent assignment. No orphan plans.
+- **F-Goal-4.** Goal page shows: target KPI, current KPI, linked issues, linked plan, impact summary (see §7), and **which agents are working toward it**.
+- **F-Goal-5.** Goal KPI attribution is **display-only**; it does not influence agent performance scores (§7.2).
+
+### 4.5 Non-requirements
+- Templated goals ("pick from a library"). Out of scope. Bespoke is the whole point of the CoS-driven guided path.
+- Sub-goals with independent lifecycles. Keep parent/child relationships but do not model child goals as full standalone entities yet.
+
+---
+
+## 5. Chief of Staff Assistant
+
+### 5.1 Concept
+The Chief of Staff is:
+- A deployed agent with `role=chief_of_staff` (one per company).
+- The thing behind the right-side chat panel labeled "Chief of Staff".
+- The human's thinking partner — not the agent fleet's manager (that's the CAO).
+
+### 5.2 Goals
+- Operator can have a useful conversation about goals, agents, pipelines-of-work, or workspace state without leaving the current page.
+- CoS can invoke server tools (goal / agent / KPI / deep-interview) on the operator's behalf, surfaced as inline tool cards.
+
+### 5.3 Surface
+- Right-side slide-over, labeled "**Chief of Staff**" (renamed from "Assistant" in this PR).
+- Header shows the CoS agent name if configured; empty-state invites the operator to talk.
+- Conversation is **company-scoped**. Switching companies closes the panel and resets state (shipped in this PR).
+- "New chat" button starts a fresh thread without closing the panel.
+
+### 5.4 Requirements
+- **F-CoS-1.** Chat streams via SSE; chunks are `text`, `tool_use`, `tool_result`, `error`, `done`.
+- **F-CoS-2.** Tool calls render as collapsible inline cards, not as raw JSON dumps.
+- **F-CoS-3.** CoS has these tools: `create_agent`, `list_agents`, `create_issue`, `list_issues`, `set_goal`, `get_dashboard_summary`, `update_kpi`, `submit_goal_interview`. (Current set, AGE-50/53.)
+- **F-CoS-4.** CoS routes through the company's `chief_of_staff` agent's own adapter — no separate `ASSISTANT_API_KEY`. It inherits the operator's OAuth / subscription auth. (Shipped in AGE-53 PR #33.)
+- **F-CoS-5.** Adapter failures surface as **actionable** error text, never raw stderr or CLI crash dumps. (Shipped in AGE-54 follow-up.)
+- **F-CoS-6.** The panel is seeded by other UI components (e.g., `PlanApprovalCard` seeds `/deep-interview` on a goal). Seed is consumed once and cleared.
+- **F-CoS-7.** Conversation history persists per `(user, company)` and is re-fed into the adapter on each turn so the CoS has continuity.
+
+### 5.5 Non-requirements
+- Multi-CoS per company. One `chief_of_staff` agent per company; additional advisors belong under different roles.
+- Mode toggles (autonomous vs. conversational). See principles — agents are always autonomous.
+
+### 5.6 Known limits to fix
+- The CoS agent **must** have a working adapter configured. If adapter auth is missing, the Operator should see "Sign in to [adapter]" not a cryptic CLI stack trace. Partly addressed by AGE-54.1 in-app Codex login.
+- Tool-call invocation via prose markers (`TOOL_CALL: … END_TOOL_CALL`) is a workaround. Longer-term, structured tool-use via adapter-native event types.
+
+---
+
+## 6. Chief Agent Officer (CAO)
+
+### 6.1 Concept
+A **new** top-level agent role: `chief_agent_officer`. Responsible for **the agent fleet**, not for the operator's goals. Where CoS is a thinking partner, CAO is an ops manager.
+
+Why introduce it now: as soon as there are more than ~3 working agents per company, operators don't want to hand-tune heartbeat intervals, wake cadences, priorities, and budgets. The CAO owns that layer so the Operator doesn't have to.
+
+### 6.2 Scope of ownership (what the CAO decides)
+
+- **Lifecycle** — propose new hires, pause underperformers, retire idle agents, escalate terminations to Operator approval.
+- **Priority** — which agent picks up which issue when multiple are unblocked. Current code has primitive round-robin; CAO replaces it with intent-weighted ranking.
+- **Wake cadence / heartbeat** — tune `heartbeatIntervalSec` per agent based on recent activity and SLA.
+- **Budget** — watches per-agent and per-company monthly spend; throttles or pauses before hard-stop limits.
+- **Efficiency metrics** — surfaces throughput, rework rate, $/task per agent. **Not KPI attribution.** (See §7.2.)
+- **Incident response** — reacts to adapter outages, stuck runs, and stale sessions by pausing or retrying.
+- **Fleet composition reports** — weekly: who's overworked, who's idle, who's expensive, who's slow.
+
+### 6.3 What the CAO does **not** do
+
+- Decide what the company's goals are. (Operator + CoS.)
+- Take credit for or be graded against Operator KPIs (revenue, MQL, CSAT). (See §7.2.)
+- Directly execute domain work. CAO is an **orchestrator**, not a worker.
+
+### 6.4 Surface
+
+- **`/agents` page** gains a "Fleet" overview section owned by the CAO: heat map of agent status, recent throughput, cost trend, idle vs busy ratio.
+- A **CAO card** on the dashboard that summarizes one actionable decision per day ("Hire a second QA?", "Pause Research Agent 2 — idle 10 days", "Budget trending 15% over on Acquisition").
+- A **CAO tab** in the existing `ChatPanel`? — **deferred**. First release: CAO speaks via dashboard cards and approval items, not a second chat panel. Re-evaluate after usage data.
+
+### 6.5 Agent-row data model changes
+
+- Extend `AGENT_ROLES` with `chief_agent_officer`.
+- Extend `AGENT_ROLE_LABELS` with `"Chief Agent Officer"`.
+- Default instructions bundle (`SOUL.md` / `AGENTS.md` / `HEARTBEAT.md` / `TOOLS.md`) tailored to fleet-ops.
+- **Permissions scaffolding** — CAO needs: `canCreateAgents`, `canPauseAgents`, `canAdjustBudgets`, `canAdjustHeartbeats`. Today only the first exists; the rest are new permission keys.
+
+### 6.6 Requirements
+
+- **F-CAO-1.** One and only one `chief_agent_officer` per company.
+- **F-CAO-2.** Created automatically during onboarding **only if** the operator hired ≥ 2 worker agents. Otherwise offered as a first-class "Hire a CAO" prompt when the fleet reaches 3 agents.
+- **F-CAO-3.** CAO actions that change fleet state (pause / retire / re-budget) must route through the existing **approval system** — no silent changes.
+- **F-CAO-4.** CAO sees per-agent metrics via the same service layer the `/agents` page uses; no new privileged API.
+- **F-CAO-5.** CAO instructions explicitly forbid claiming goal KPI attribution. Its scorecard is fleet health, not business outcomes.
+- **F-CAO-6.** Operator can disable the CAO (revert to manual fleet ops). When disabled, the CAO card on the dashboard becomes "Enable CAO" with a one-liner value prop.
+
+### 6.7 Open questions
+
+- Does CAO have write access to agent `instructionsBundle` (prompt tuning)? Bias says **no** for v1 — that's operator territory.
+- Should CAO manage *inter-agent* delegation (when Agent A should hand off to Agent B)? Interesting but probably v2.
+- Do we name-swap: rename the existing `role=assistant` legacy slot to something else, so the terminology is fully consistent? (See §8 migration.)
+
+---
+
+## 7. Cross-cutting
+
+### 7.1 Naming and terminology (binding)
+
+| Term | Meaning | Do NOT confuse with |
+|---|---|---|
+| **Chief of Staff** | Operator's thinking partner, runs CoS chat | The right-side panel; they're the same thing |
+| **CAO / Chief Agent Officer** | Agent-fleet ops manager | CoS, Operator, admin |
+| **Assistant** | Reserved for the *identity mode* on `openclaw_gateway` agents ("agent inherits triggering user's OAuth"). **Not** a human-facing role or a chat panel. | CoS — rename has shipped; do not reintroduce "Assistant" as a CoS label. |
+| **Goal** | Unit of operator intent | Pipeline, initiative — neither exist as top-level. |
+| **Pipeline** | Internal term for orchestrator logic; **not a user-facing word**. | Goal, workflow. |
+
+### 7.2 Measurement
+
+- Agents are scored on **job performance**: throughput, rework rate, $/task, SLA adherence.
+- Agents are **not** scored on goal KPI attribution (MRR, MQL, CSAT, …). Attribution is a display-only concept shown on the goal page.
+- CAO's own scorecard is fleet health (see §6.5), not goal KPIs.
+
+### 7.3 Permissions
+
+- Operator: full write on goals, hires CoS and CAO.
+- CoS agent: read on workspace state; write via its 8 defined tools only.
+- CAO agent: read on agent metrics; write via approval-gated fleet actions.
+- Board members: read on dashboard + approval participation, no adapter authentication required.
+
+### 7.4 Observability
+
+- Every CoS and CAO tool call logs to `activity_log` with `actor_kind=agent`.
+- Every adapter failure that surfaces to the chat panel also logs to the server log with `errorMessage` and `stderrTail` (already implemented).
+
+### 7.5 Internationalization / accessibility
+
+Out of scope for this PRD. Track separately.
+
+---
+
+## 8. Migration & phasing
+
+### Phase 0 — Already shipped (this PR #33)
+- Right-side chat routes through CoS agent's adapter (AGE-53).
+- SSE disconnect bug fixed; UI hardening; "Chief of Staff" rename.
+- `submit_goal_interview` tool live.
+- Identity Mode toggle on agent config now persists.
+- In-app Codex OAuth login block (AGE-54.1).
+
+### Phase 1 — Goal & onboarding polish (2-3 weeks)
+- `F-On-5` empty-state hints on /goals, /agents, /inbox.
+- `F-On-1` onboarding auto-creates CoS agent at wizard completion.
+- `F-Goal-4` goal page shows "which agents are working on this".
+- CAO role constant added (`chief_agent_officer`) but **no** CAO agent auto-created yet.
+
+### Phase 2 — CAO v1 (4-6 weeks)
+- Fleet overview on `/agents` (read-only for Operator, CAO agent sees same data).
+- CAO dashboard card with "one actionable decision/day".
+- New permissions: `canPauseAgents`, `canAdjustBudgets`, `canAdjustHeartbeats`.
+- Approval-gated CAO actions for fleet changes.
+- `F-CAO-2` hiring prompt at 3 agents.
+
+### Phase 3 — CAO v2 (later)
+- Inter-agent delegation rules.
+- CAO-driven skill proposals.
+- Revisit: CAO conversational surface (second tab in chat panel?).
+
+### Legacy cleanup
+- `role=assistant` — deprecated slot used for pre-CoS wiring. Migrate existing rows to `role=chief_of_staff` where applicable, or archive. (Work already landed in AGE-53 conversation-repointing logic; complete the cleanup here.)
+- "Assistant" identity-mode label on `openclaw_gateway` stays — that's a real distinct concept (OAuth impersonation) that predates the chat panel.
+
+---
+
+## 9. Open questions (decisions needed before Phase 2)
+
+1. **Pricing trigger** — does CAO count as a separate "agent" for usage-based billing, or is it bundled with the company plan? (Pricing memo still open.)
+2. **Multi-operator companies** — if a company has two board-level humans, does each get their own CoS thread, or do they share one? Current: shared. Probably fine; revisit if complaints.
+3. **CoS ↔ CAO interaction** — when operator asks CoS "my fleet looks slow, what do I do?", should CoS delegate to CAO, or answer directly from read-only data? Recommendation: **delegate** via a `consult_cao` tool. Needs design.
+4. **CAO kill-switch** — should the Operator be able to revoke CAO entirely mid-session? (If yes, a pause is easier than a delete.)
+5. **Audit** — do we need a dedicated "CAO decision log" surface, separate from activity log? Probably yes for enterprise sales, probably no for early users.
+
+---
+
+## 10. Out of scope
+
+- Multi-Agent Workflow (MAW) — internal dev tool, not a customer surface.
+- Plugin marketplace — different PRD.
+- Instance-level admin (OAuth providers, SSO, audit exports) — Admin persona, different PRD.
+- Goal dependency graph visualisation — defer.
+- Real-time fleet visualization / "war room" view — defer to Phase 3.
+
+---
+
+## Appendix A — Relationship diagram
+
+```
+                        ┌────────────────────┐
+                        │     Operator       │
+                        │  (human, board)    │
+                        └─────────┬──────────┘
+              "what do I want?"   │   "is my fleet OK?"
+                                  │
+              ┌───────────────────┴───────────────────┐
+              ▼                                       ▼
+   ┌────────────────────┐                  ┌────────────────────┐
+   │  Chief of Staff    │                  │Chief Agent Officer │
+   │  (role: cos)       │  "fleet health?" │(role: cao)         │
+   │  Right-side chat   │◀────────────────▶│Dashboard cards,    │
+   │                    │  via consult_cao │approval items      │
+   └─────────┬──────────┘                  └─────────┬──────────┘
+             │ tools                                 │ approval-gated
+             │ (set_goal, submit_goal_interview,     │ (pause, budget,
+             │  update_kpi, create_agent, …)         │  heartbeat, hire)
+             ▼                                       ▼
+      ┌──────────────┐                       ┌──────────────┐
+      │   Goals      │                       │ Agent fleet  │
+      │  + proposed  │ ───── issues ────▶    │ (engineers,  │
+      │   plans      │                       │  PMs, QA, …) │
+      └──────────────┘                       └──────────────┘
+```
+
+## Appendix B — Where things live in code (today)
+
+| Concept | Code |
+|---|---|
+| Onboarding wizard | `ui/src/components/OnboardingWizard.tsx`, `server/src/services/onboarding.ts` |
+| Goal creation | `ui/src/components/NewGoalDialog.tsx`, `server/src/services/goals.ts` |
+| Proposed plans | `server/src/services/agent-plans.ts`, `ui/src/.../PlanApprovalCard.tsx` |
+| CoS chat panel | `ui/src/components/ChatPanel.tsx`, `server/src/routes/assistant.ts`, `server/src/services/assistant.ts`, `server/src/services/assistant-llm-adapter.ts` |
+| CoS tools | `server/src/services/assistant-tools.ts` |
+| Agent roles (add CAO here) | `packages/shared/src/constants.ts` (`AGENT_ROLES`, `AGENT_ROLE_LABELS`) |
+| Default instructions bundles (add CAO bundle here) | `server/src/services/default-agent-instructions.ts` |
+
+---
+
+_This PRD is intentionally trimmed — it names the load-bearing decisions and defers implementation detail. Follow-up issues per §8 phase list._

--- a/doc/2026-04-22-testing-strategy-spec.md
+++ b/doc/2026-04-22-testing-strategy-spec.md
@@ -1,0 +1,221 @@
+# Deep Interview Spec: Testing Strategy to Cut AgentDash Escape Rate
+
+## Metadata
+- Interview ID: testing-strategy-2026-04-22
+- Rounds: 3
+- Final Ambiguity Score: 19.5%
+- Type: brownfield
+- Generated: 2026-04-22
+- Threshold: 0.2 (MET)
+- Status: PASSED
+
+## Clarity Breakdown
+| Dimension | Score | Weight | Weighted |
+|---|---|---|---|
+| Goal Clarity | 0.90 | 0.35 | 0.315 |
+| Constraint Clarity | 0.75 | 0.25 | 0.188 |
+| Success Criteria | 0.70 | 0.25 | 0.175 |
+| Context Clarity | 0.85 | 0.15 | 0.128 |
+| **Total Clarity** | | | **0.805** |
+| **Ambiguity** | | | **0.195** |
+
+## Goal
+
+Cut AgentDash's **Defect Escape Rate (DER)** below 5% within 60 days by eliminating three specific classes of pre-release escape that unit tests cannot catch:
+
+1. **Contract drift** between in-monorepo layers (server SSE chunks ↔ UI parser, Zod validators ↔ DB).
+2. **Adapter subprocess failure modes** (exit-code semantics, stderr containing TUI crash markers, bootstrap stdout being mistaken for reply).
+3. **SSE / streaming lifecycle races** (request-body consumption timing vs. client disconnect, partial stream close).
+
+The strategy is "real-system simulation, not more mocks": build three AgentDash-specific test harnesses that exercise the actual failure modes, enforce them at the right trigger point, and measure DER as the headline KPI.
+
+## Constraints
+
+- PR CI time may grow to ~30 min if parallelized (operator-trust cost >> CI-time cost).
+- Add **at most one** new runtime test dependency, and only if clearly earned. Prefer Zod + existing `vitest`/`supertest`/`Playwright` stack.
+- Pre-push hook acceptable only if lightweight (changed-file scope, <60s typical).
+- Blocking merge policy applies only to listed "critical surfaces"; elsewhere advisory.
+- Real-adapter CI runs are **nightly** against a $5/day-capped account — never per-PR.
+- Must integrate with AgentDash's existing multi-agent workflow (Tester agent in `.claude/commands/tester.md`) instead of reinventing enforcement.
+- No `.husky/` exists today; whichever hook manager we pick must be lightweight.
+
+## Non-Goals
+
+- Not adopting Pact (overkill for monorepo; Zod-as-contract covers the same ground).
+- Not adopting MSW or Nock (supertest + real embedded Postgres is the existing harness; don't regress to HTTP mocks).
+- Not setting a repo-wide coverage percentage threshold (DER is the metric, not coverage).
+- Not running the full suite pre-commit or pre-push (will get disabled if slow).
+- Not rebuilding a parallel GitHub Actions enforcement layer — reuse the Tester agent as the gate.
+- Not moving away from embedded Postgres; it's the one good call inherited from paperclip.
+- Not rewriting existing 27 Playwright specs or 264+ vitest tests.
+
+## Acceptance Criteria
+
+### Infrastructure
+
+- [ ] **AC-1.** `packages/shared/src/chunks/assistant-chunks.ts` exists and exports a `z.discriminatedUnion` schema covering every chunk type the assistant SSE route emits (`text`, `tool_use`, `tool_result`, `error`, `done`). A matching `AssistantChunk` TypeScript type is exported.
+- [ ] **AC-2.** `server/src/routes/assistant.ts` types its SSE writes against the shared schema (either by direct import or by a `writeChunk(chunk: AssistantChunk)` helper). TypeScript refuses to compile if the server emits a field the schema doesn't declare.
+- [ ] **AC-3.** `ui/src/components/ChatPanel.tsx` replaces its local `chunk` literal type with `assistantChunkSchema.safeParse(json)` and switches on the parsed `chunk.type`. An invalid chunk is logged and ignored, not crashed on.
+- [ ] **AC-4.** `server/src/__tests__/helpers/sse-client.ts` exists and exposes a helper that spins up the real Express app on an ephemeral port, opens a real `fetch`-based reader (not supertest), and returns `{ readNext(), close(), events() }` for lifecycle-aware tests.
+- [ ] **AC-5.** `packages/adapters/_testing/fixture-adapter.ts` exists and exports `fixtureAdapter({ stdout, stderr, exitCode, signal, timedOut, summary, resultJson, usage })` producing an `AdapterExecuteFn`-shaped function. It can be registered via the existing adapter registry under a synthetic adapterType like `fixture`.
+
+### Tests that must exist and pass
+
+- [ ] **AC-6.** `server/src/__tests__/assistant-sse-lifecycle.test.ts` covers:
+  - Chunk stream delivers N chunks end-to-end for a successful CoS reply (via fixture adapter).
+  - Client close mid-stream causes server to stop yielding within 250ms.
+  - Server `res.close` vs `req.close` timing — explicit assertion that the response writer does NOT get aborted before any chunk yields.
+  - Graceful handling of `[DONE]` sentinel.
+- [ ] **AC-7.** `server/src/__tests__/assistant-llm-adapter-fixtures.test.ts` covers the following behaviors (fixture-adapter driven):
+  - exit=0 + `result.summary` populated → one `text` chunk, exact content match.
+  - exit=0 + summary empty + stdout with prose → stdout fallback used.
+  - exit=1 + summary empty + stdout present → stdout is NOT used; diagnostic `(No model output…)` chunk emitted.
+  - exit=1 + stderr containing `AgentLoop has been terminated` → friendly codex-Ink crash message, no raw `<n7>` leak.
+  - stdout containing `TOOL_CALL: … END_TOOL_CALL` markers → `tool_use` chunks emitted in order, de-duplicated.
+  - exit=1 + empty everything → diagnostic chunk with stderr tail appended.
+- [ ] **AC-8.** `packages/shared/src/__tests__/assistant-chunks.test.ts` covers:
+  - Every chunk shape emitted by the server in AC-7 round-trips through the schema.
+  - Unknown `type` is rejected with a parse error.
+  - Extra unknown fields are preserved or stripped consistently (spec choice: strict parse — extras cause an error, surfaced as drift).
+- [ ] **AC-9.** `server/src/__tests__/validator-parity.test.ts` — a generic test that takes every Zod `updateXxxSchema` in `packages/shared/src/validators/`, finds the matching DB schema column set, and asserts that every DB column relevant to PATCH is covered by the Zod schema (catches the `credentialMode` silent-strip class). Initially allow a declarative whitelist of exceptions.
+- [ ] **AC-10.** `tests/e2e/assistant-chat-chief-of-staff.spec.ts` — a Playwright spec that opens the chat panel, sends a message, and asserts DOM state: bubble containing user text, assistant bubble non-empty, no `<n7>` or React error-boundary text visible, no raw stdout prefix like `[paperclip]` rendered.
+
+### Enforcement
+
+- [ ] **AC-11.** `.github/workflows/pr.yml` gains a job (or existing job gains a step) that runs `pnpm test:run --related` against the PR's changed files. Existing `typecheck + test:run + build` job remains. Total PR CI time target: < 20 min p50, < 30 min p95.
+- [ ] **AC-12.** `scripts/precommit/pre-push.sh` exists. Invoked by a `package.json` `prepare` hook that installs a native `.git/hooks/pre-push`. Runs `pnpm typecheck && pnpm test:run --changed` with a soft-fail flag (developer can bypass with `SKIP_PRE_PUSH=1`). Completes in < 60s on typical changes.
+- [ ] **AC-13.** `.claude/commands/tester.md` (the Tester agent protocol) is updated to:
+  - Parse the PR diff for files matching a "critical surfaces" list.
+  - Require a matching Playwright or contract test touching the changed surface.
+  - If missing, block with verdict: `missing user-visible test for <file>`.
+  - Run the matching Playwright spec headed; attach trace on failure.
+- [ ] **AC-14.** `doc/TESTING.md` documents the critical surfaces list, the DER metric definition, and the per-PR testing expectation, replacing the current reliance on CLAUDE.md's regression block.
+- [ ] **AC-15.** `.github/workflows/nightly-real-adapter.yml` exists and runs a ~6-scenario smoke against each supported adapter (`claude_local`, `codex_local`, `gemini_local`) using real CLI binaries and a budget-capped account. Dashboard surfaces failures.
+
+### Observability
+
+- [ ] **AC-16.** Every defect logged in Linear or equivalent is tagged with `origin` (subsystem) and `discovery_phase` (one of: `pre-push` / `ci` / `review` / `staging` / `production`). Onboarding for the tag schema is in `doc/TESTING.md`.
+- [ ] **AC-17.** Weekly automation emits a DER report: `(defects discovered post-release) / (total defects) × 100`, rolling 30-day window. Target: ≤ 5%.
+- [ ] **AC-18.** DER report also segments by subsystem so we can tell whether the new harnesses are moving the assistant / adapter / validator numbers specifically.
+
+## Assumptions Exposed & Resolved
+
+| Assumption | Challenge | Resolution |
+|---|---|---|
+| "We need more tests." | Paperclip has 4 e2e specs vs our 27 and still escapes. Volume isn't the lever. | Focus on test *type* and *orchestration*, not volume. |
+| "Pact-style contract testing is the answer." | Pact is designed for cross-repo microservices. | In a monorepo, Zod discriminated unions + shared schema gives the same drift-prevention at ~zero tool cost. |
+| "Add a pre-commit hook that runs the full suite." | Slow hooks get disabled. | Lightweight pre-push only (typecheck + changed-file tests), with a skip flag. |
+| "Coverage % is the success metric." | Coverage is a lagging proxy; DER is the real outcome. | DER is the KPI. Coverage not enforced. |
+| "Run real adapters on every PR." | Flaky + expensive + slow + auth expiry. | Nightly at $5/day cap; PR CI uses the fixture adapter. |
+| "Build a new GitHub Actions enforcement framework." | Tester agent already reads PR diffs and runs tests. | Extend Tester protocol; don't build a parallel enforcement layer. |
+
+## Technical Context
+
+### Current test infrastructure (verified)
+
+- Vitest: ~264 tests across server/ui/cli/packages. Embedded Postgres via `@agentdash/db`.
+- Playwright: 27 e2e specs (`tests/e2e/`), Chromium only, 60s timeout, retries 0.
+- CUJ: `scripts/test-cujs.sh` (60 bash+curl assertions).
+- CI: `.github/workflows/pr.yml` runs `typecheck + test:run + build`; `e2e.yml` is `workflow_dispatch` only.
+- No pre-commit/pre-push hooks anywhere.
+- No coverage thresholds configured.
+- No server-chunk ↔ UI-parser contract layer.
+
+### Known escapes from this session (evidence)
+
+1. `req.on("close")` fired immediately on POST body consumption, aborting SSE before any chunk yielded. Unit test with supertest did not model the lifecycle.
+2. `ChatPanel.tsx` read `chunk.toolName / chunk.toolInput / chunk.error` while server emitted `chunk.name / chunk.input / chunk.message`. No contract test.
+3. `updateAgentSchema` lacked `credentialMode`; Zod silently stripped the field from PATCH bodies, making the AgentDetail toggle a no-op.
+4. codex-local adapter exit=1 with Ink-TUI stderr (`"The above error occurred in the <n7> component"`, `AgentLoop has been terminated`) was surfaced verbatim to the chat bubble. Adapter fallback logic used raw stdout prefix (`[paperclip] Using Paperclip-managed Codex home…`) as the "reply text".
+5. `prev[prev.length - 1]!` in ChatPanel tool_use handler could inject `undefined` into the messages array when prev was empty, crashing MessageBubble.
+
+All five have a matching harness in the Acceptance Criteria above.
+
+### Critical surfaces list (binding for AC-13, reviewable)
+
+- `server/src/routes/assistant.ts`
+- `server/src/services/assistant*.ts`
+- `server/src/services/billing*.ts`
+- `server/src/services/budget*.ts`
+- `server/src/services/approvals.ts`
+- `packages/adapters/*/src/server/**`
+- `packages/shared/src/validators/**`
+- `ui/src/components/ChatPanel.tsx`
+- `ui/src/components/OnboardingWizard.tsx`
+- `ui/src/components/NewAgentDialog.tsx`
+
+Changes to these files require a co-shipped Playwright or contract test. The list lives in `doc/TESTING.md` and is append-only; removals require a PR with justification.
+
+## Ontology (Key Entities)
+
+| Entity | Type | Fields / Responsibility |
+|---|---|---|
+| Escape | core domain | subsystem, discovery_phase, class |
+| Layer Boundary | core domain | server↔UI, validator↔DB, adapter↔consumer |
+| Real System | external system | SSE stream, subprocess, browser |
+| Test Harness | core domain | name, subsystem, scope |
+| Merge Gate | process | trigger, enforcement-mode, owner |
+| DER | metric | rolling window, formula, segmentation |
+| Contract Test | test type | schema source, drift detection |
+| Chunk Schema | artifact | discriminated union of SSE/WS event types |
+| Subprocess Fixture | artifact | stdout/stderr/exit knobs |
+| SSE Lifecycle Harness | artifact | ephemeral port, real stream, timing asserts |
+| Tester Agent | actor | reads diff, chooses tests, blocks merge |
+
+Stability at final round: 9/11 entities stable from round 2 or newly stable (2 held across rounds, 3 added and held, 0 removed or renamed).
+
+## Ontology Convergence
+
+| Round | Entity Count | New | Changed | Stable | Stability Ratio |
+|---|---|---|---|---|---|
+| 1 | 5 | 5 | - | - | N/A |
+| 2 | 7 | 2 (DER, Contract Test) | 0 | 5 | 71% |
+| 3 | 11 | 4 (Chunk Schema, Subprocess Fixture, SSE Lifecycle Harness, Tester Agent) | 0 | 7 | 64% |
+
+Note: ratio dips in round 3 because new implementation-specific entities were introduced at the solution layer. Core domain (Escape, Layer Boundary, DER, Contract Test) is stable — the growth is below the concept line, not shifting it.
+
+## Interview Transcript
+
+<details>
+<summary>Full Q&A (3 rounds)</summary>
+
+### Round 1 — Goal Clarity
+**Q:** Which of A/B/C/D/E/F best matches the pain — contract drift, real-system simulation gap, CI orchestration gap, assertion weakness, mix, or other?
+**A:** B — real-system behavior not simulated.
+**Ambiguity:** 48.5%
+
+### Round 2 — Success Criteria
+**Q:** If the testing setup is "fixed" in 60 days, what is measurable about that? A/B/C/D/E?
+**A:** (After upstream-paperclip check and industry-best-practice research) — 1: DER-as-headline, <5% over rolling window.
+**Ambiguity:** 35.7%
+
+### Round 3 — Constraints
+**Q:** 5-axis tolerance envelope for CI time, tooling, pre-push, enforcement, real-adapter cost.
+**A:** (User asked for recommendations given AgentDash's nature; I proposed 1c / 2b-with-Zod-contract-twist / 3b / 4b / 5b plus three AgentDash-specific harnesses and Tester-agent reuse.)
+**Ambiguity:** 19.5% — below threshold.
+
+</details>
+
+## Implementation sketch (phased)
+
+### Phase A — Foundations (week 1)
+- AC-1, AC-2, AC-3, AC-8: Zod chunk schema + server parity type + UI parse.
+- AC-14: `doc/TESTING.md` skeleton with critical-surfaces list.
+
+### Phase B — Harnesses (week 2)
+- AC-4: SSE lifecycle helper.
+- AC-5: Fixture adapter.
+- AC-6, AC-7: Tests written against the harnesses.
+- AC-9: Validator-parity test.
+- AC-10: First Playwright spec for the Chief-of-Staff chat path.
+
+### Phase C — Enforcement (week 3)
+- AC-11: PR CI job for related-tests.
+- AC-12: Pre-push hook with skip flag.
+- AC-13: Tester-agent protocol update (edit `.claude/commands/tester.md`).
+
+### Phase D — Observability + real adapters (week 4)
+- AC-15: Nightly real-adapter workflow.
+- AC-16, AC-17, AC-18: DER tagging + weekly report.
+
+Each phase ships as its own PR, reviewed independently. Phase A is the highest-ROI single PR and should land first — it retroactively prevents the ChatPanel drift class forever.


### PR DESCRIPTION
## Summary

Doc-only PR with two design artifacts from the 2026-04-22 session. No code changes.

### 1. `doc/2026-04-22-testing-strategy-spec.md` — Testing strategy spec

Crystallized output of a 3-round deep-interview on "why do we keep seeing escapes that tests should have caught."

**KPI:** Defect Escape Rate (DER) <5% on a rolling 30-day window, segmented by subsystem and discovery phase.

**Three AgentDash-specific harnesses** (not generic tooling):
- **Zod-as-single-contract** for SSE/WebSocket chunks — discriminated union in `packages/shared/`, server types against it, UI `safeParse`s. Makes the ChatPanel field-drift class a compile error.
- **Subprocess fixture adapter** for adapter-boundary tests (exit-code semantics, stderr patterns, bootstrap stdout vs real reply). Catches the codex Ink-crash class.
- **SSE lifecycle harness** with real Express + ephemeral port. Catches the `req.on("close")` vs `res.on("close")` class.

**Enforcement via existing Tester agent** (not a new CI framework): the agent already reads PR diffs; extend its protocol to require a co-shipped test for any file on the critical-surfaces list.

18 acceptance criteria, 4-week phased plan. Ambiguity 19.5% — ready to implement.

### 2. `doc/2026-04-22-goal-cos-cao-prd.md` — Product PRD

PRD covering the four load-bearing product surfaces:
- **Onboarding** — wizard-driven company + CoS agent creation.
- **Goal creation** — fast path (<60s) and guided path (CoS `/deep-interview`).
- **Chief of Staff chat** — right-side panel routed through company's `chief_of_staff` agent (Phase 0 shipped in PR #33).
- **Chief Agent Officer (CAO)** — new role for fleet-ops management (lifecycle, priorities, heartbeat tuning, budget, efficiency).

Includes binding naming decisions, permissions scaffolding, phased rollout (Phase 0 shipped, Phases 1-3 scoped), and open questions that need answers before Phase 2.

## Test plan

Docs only — no tests needed. Verified both files render on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)