### PR TITLE
fix(billing): customer.subscription.updated webhook re-maps tier (AGE-69)

### DIFF
--- a/server/src/__tests__/billing-routes-extended.test.ts
+++ b/server/src/__tests__/billing-routes-extended.test.ts
@@ -321,11 +321,10 @@ describe("POST /api/billing/webhook — with webhookSecret", () => {
 // ---------------------------------------------------------------------------
 
 describe("POST /api/billing/webhook — customer.subscription.updated", () => {
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  it.skip("processes subscription update, re-maps tier, and returns received=true", async () => {
-    // Webhook handler does: 1) idempotency check → [], 2) lookupCompanyByStripeCustomer → [company]
+  it("processes subscription update, re-maps tier, and returns received=true", async () => {
+    // Webhook handler idempotency uses db.insert()...returning() (not a select).
+    // The first db.select()...limit() call is lookupCompanyByStripeCustomer.
     const db = makeMultiDb([
-      [],                              // idempotency: not found
       [{ companyId: "company-test" }], // lookupCompanyByStripeCustomer
     ]);
     const entitlements = makeEntitlements();


### PR DESCRIPTION
## Summary
Closes AGE-69

Fixes a flaky CI test: `billing-routes-extended.test.ts > customer.subscription.updated > processes subscription update, re-maps tier, and returns received=true`.

## Root Cause

The test set up two rowSets in `makeMultiDb`:
```
[
  [],                              // labeled "idempotency: not found"
  [{ companyId: "company-test" }], // lookupCompanyByStripeCustomer
]
```

The comment was wrong. The idempotency gate uses `db.insert()...returning()` — not a select — so it never consumes a `rowSets` slot. The first actual `db.select()...limit()` call is `lookupCompanyByStripeCustomer`, which consumed the empty placeholder `rowSets[0] = []` and returned `null`. With `companyId = null`, the `customer.subscription.updated` handler hit `if (!companyId) break` before calling `setTier`, causing the assertion `expect(entitlements.setTier).toHaveBeenCalled()` to fail.

## Fix

Removed the spurious empty rowSet. The correct setup has exactly one rowSet for the lookup:
```
[
  [{ companyId: "company-test" }], // lookupCompanyByStripeCustomer
]
```

1 line of production code unchanged. Pure test fix.

## Test Results

- `billing-routes-extended.test.ts`: 10/10 passed (5 consecutive runs)
- Broader billing scope (34 tests across 5 files): 34/34 passed
- `pnpm -r typecheck`: all packages pass

**Size:** S — single test file, 2-line change