### PR TITLE
fix(ci): unblock e2e — dashboard selector, comments shape, budget burn-rate 500 (AGE-70)

### DIFF
--- a/server/src/routes/budget-extended.ts
+++ b/server/src/routes/budget-extended.ts
@@ -98,6 +98,20 @@ export function budgetExtendedRoutes(db: Db) {
       assertCompanyAccess(req, companyId);
       const scopeType = req.query.scopeType as string;
       const scopeId = req.query.scopeId as string;
+
+      // AgentDash: scopeType=company returns a company-wide aggregate burn rate
+      // using the capacity service summary instead of a per-agent/project lookup.
+      if (scopeType === "company" || (!scopeType && !scopeId)) {
+        const companyBurn = await forecast.computeCompanyBurnRate(companyId);
+        res.status(200).json(companyBurn);
+        return;
+      }
+
+      if (scopeType !== "agent" && scopeType !== "project") {
+        res.status(400).json({ error: `Invalid scopeType: ${scopeType}. Must be "agent", "project", or "company".` });
+        return;
+      }
+
       const burnRate = await forecast.computeBurnRate(companyId, scopeType as "agent" | "project", scopeId);
       res.status(200).json(burnRate);
     } catch (err: unknown) {

--- a/server/src/services/budget-forecasts.ts
+++ b/server/src/services/budget-forecasts.ts
@@ -133,6 +133,64 @@ export function budgetForecastService(db: Db) {
     },
 
     /**
+     * Compute a company-wide burn rate aggregate (no scope filter).
+     * Returns the same shape as computeBurnRate so the UI can treat it uniformly.
+     * Used when the client passes scopeType=company to the burn-rate endpoint.
+     */
+    computeCompanyBurnRate: async (companyId: string) => {
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+
+      const [thirtyDayRow] = await db
+        .select({ total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int` })
+        .from(costEvents)
+        .where(and(eq(costEvents.companyId, companyId), gte(costEvents.occurredAt, thirtyDaysAgo), lte(costEvents.occurredAt, now)));
+
+      const [lastSevenRow] = await db
+        .select({ total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int` })
+        .from(costEvents)
+        .where(and(eq(costEvents.companyId, companyId), gte(costEvents.occurredAt, sevenDaysAgo), lte(costEvents.occurredAt, now)));
+
+      const [priorSevenRow] = await db
+        .select({ total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int` })
+        .from(costEvents)
+        .where(and(eq(costEvents.companyId, companyId), gte(costEvents.occurredAt, fourteenDaysAgo), lte(costEvents.occurredAt, sevenDaysAgo)));
+
+      const thirtyDayTotal = Number(thirtyDayRow?.total ?? 0);
+      const lastSevenTotal = Number(lastSevenRow?.total ?? 0);
+      const priorSevenTotal = Number(priorSevenRow?.total ?? 0);
+
+      const dailyAvgCents = Math.round(thirtyDayTotal / 30);
+      const lastSevenDailyAvg = lastSevenTotal / 7;
+      const priorSevenDailyAvg = priorSevenTotal / 7;
+      const weeklyTrendPercent =
+        priorSevenDailyAvg > 0
+          ? Math.round(((lastSevenDailyAvg - priorSevenDailyAvg) / priorSevenDailyAvg) * 100)
+          : 0;
+
+      const projectedMonthEndCents = dailyAvgCents * 30;
+
+      // UI expects these field names (BurnRateData interface in BudgetForecast.tsx)
+      return {
+        scopeType: "company",
+        scopeId: companyId,
+        dailyBurn: Math.round(dailyAvgCents / 100),
+        weeklyBurn: Math.round(lastSevenTotal / 100),
+        monthlyBurn: Math.round(thirtyDayTotal / 100),
+        projectedMonthlyTotal: Math.round(projectedMonthEndCents / 100),
+        daysUntilBudgetExhausted: null,
+        weeklyTrendPercent,
+        // legacy fields kept for backwards-compat with other callers
+        dailyAvgCents,
+        weeklyTrendPercentLegacy: weeklyTrendPercent,
+        daysUntilExhausted: null,
+        projectedMonthEndCents,
+      };
+    },
+
+    /**
      * Compute a simple ROI metric for a project: total cost vs issues completed.
      */
     computeProjectROI: async (companyId: string, projectId: string) => {

--- a/tests/e2e/comments.spec.ts
+++ b/tests/e2e/comments.spec.ts
@@ -5,9 +5,16 @@ import { test, expect, navigateAndWait, getIssues } from "./fixtures/test-helper
  * Issue detail → comment thread → chat-style rendering → waiting indicator
  */
 test.describe("CUJ-15: Agent-Human Conversation", () => {
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  test.skip("issue detail page loads with comment section", async ({ page, company, prefix }) => {
-    const issues = await getIssues(page, company.id);
+  test("issue detail page loads with comment section", async ({ page, company, prefix }) => {
+    // Ensure at least one issue exists in the fixture company before asserting
+    let issues = await getIssues(page, company.id);
+    if (issues.length === 0) {
+      const res = await page.request.post(`/api/companies/${company.id}/issues`, {
+        data: { title: "E2E comment test issue" },
+      });
+      expect(res.ok(), `create seed issue failed: ${await res.text()}`).toBe(true);
+      issues = await getIssues(page, company.id);
+    }
     expect(issues.length).toBeGreaterThan(0);
 
     await navigateAndWait(page, `/issues/${issues[0].id}`, prefix);

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -84,8 +84,11 @@ test.describe("CUJ-2: Daily Dashboard", () => {
       page.locator("h1", { hasText: /Good morning|Good afternoon|Good evening/ })
     ).toBeVisible({ timeout: 10_000 });
 
-    // Company name appears in the subtitle line
-    await expect(page.locator(`text=${company.name}`)).toBeVisible({ timeout: 5_000 });
+    // Company name appears in the subtitle line — scope to the luxe-subtitle to avoid
+    // strict-mode violation when the name also appears elsewhere on the page.
+    await expect(
+      page.locator(".luxe-subtitle", { hasText: company.name }).first()
+    ).toBeVisible({ timeout: 5_000 });
 
     // Current weekday name is present somewhere on the page
     const weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
@@ -110,54 +113,45 @@ test.describe("CUJ-2: Daily Dashboard", () => {
   // No-agents banner
   // --------------------------------------------------------------------------
 
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  test.skip("shows no-agents banner with Create one link for a company without agents", async ({ page }) => {
+  test("shows no-agents message in workforce section for a company without agents", async ({ page }) => {
     const company = await createCompany(page, "noagent");
     await navigateToDashboard(page, company.issuePrefix);
 
-    await expect(page.locator("text=No agents yet.")).toBeVisible({ timeout: 10_000 });
-    const createLink = page.locator("button", { hasText: "Create one" });
-    await expect(createLink).toBeVisible();
-    // The button must have a real onClick handler — clicking it should open a dialog
-    // (openOnboarding is called). We verify the dialog appears, not just that the
-    // button renders, so a missing handler is caught.
-    await createLink.click();
-    // The onboarding dialog or wizard heading should appear
+    // The luxe dashboard OrgChart renders this text when there are no agents
     await expect(
-      page.locator("text=/Create your first agent|Name your company|onboarding/i").first()
-    ).toBeVisible({ timeout: 5_000 });
+      page.locator("text=/No agents yet/").first()
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   // --------------------------------------------------------------------------
   // Team section
   // --------------------------------------------------------------------------
 
-  test("shows TEAM section with agent count when agents exist", async ({ page }) => {
+  test("shows workforce section with agent cards when agents exist", async ({ page }) => {
     const company = await createCompany(page, "team");
     await createAgent(page, company.id, "Alpha Agent", "engineer");
     await createAgent(page, company.id, "Beta Agent", "researcher");
     await navigateToDashboard(page, company.issuePrefix);
 
-    // Section heading
-    await expect(page.locator("text=Team").first()).toBeVisible({ timeout: 10_000 });
+    // The luxe dashboard OrgChart renders "Your workforce" as the card title
+    await expect(page.locator("text=Your workforce").first()).toBeVisible({ timeout: 10_000 });
 
-    // Count text — should say "2 agents" (or more if plan created extras)
-    await expect(page.locator("text=/\\d+ agents?/")).toBeVisible({ timeout: 10_000 });
+    // Agent names appear in the org chart
+    await expect(page.locator("text=Alpha Agent").first()).toBeVisible({ timeout: 10_000 });
   });
 
-  test("View all link in TEAM section navigates to agents list", async ({ page }) => {
+  test("View all link in workforce section navigates to agents list", async ({ page }) => {
     const company = await createCompany(page, "teamlink");
     await createAgent(page, company.id, "Gamma Agent", "engineer");
     await navigateToDashboard(page, company.issuePrefix);
 
-    // Find the "View all" link inside the Team section
-    await expect(page.locator("text=Team").first()).toBeVisible({ timeout: 10_000 });
-    const viewAllLinks = page.locator("a", { hasText: "View all" });
-    // At least one View-all link must exist (Team section)
-    await expect(viewAllLinks.first()).toBeVisible({ timeout: 5_000 });
+    // The luxe OrgChart renders a "View all →" link to /agents
+    await expect(page.locator("text=Your workforce").first()).toBeVisible({ timeout: 10_000 });
+    const viewAllLink = page.locator("a", { hasText: /View all/ }).first();
+    await expect(viewAllLink).toBeVisible({ timeout: 5_000 });
 
     // Click it and confirm navigation to agents URL
-    await viewAllLinks.first().click();
+    await viewAllLink.click();
     await expect(page).toHaveURL(/\/agents/, { timeout: 10_000 });
   });
 
@@ -165,69 +159,50 @@ test.describe("CUJ-2: Daily Dashboard", () => {
   // THIS MONTH stats
   // --------------------------------------------------------------------------
 
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  test.skip("shows This month stats cards with tasks completed and spend", async ({ page }) => {
+  test("shows stats strip with daily burn and issues in flight", async ({ page }) => {
     const company = await createCompany(page, "stats");
     await createAgent(page, company.id, "Stats Agent", "engineer");
     await navigateToDashboard(page, company.issuePrefix);
 
-    // Section heading
-    await expect(page.locator("text=This month").first()).toBeVisible({ timeout: 10_000 });
-
-    // Tasks completed card
-    await expect(page.locator("text=tasks completed")).toBeVisible({ timeout: 5_000 });
-
-    // Spend card: "spent this month"
-    await expect(page.locator("text=spent this month")).toBeVisible({ timeout: 5_000 });
-
-    // In-progress and open count line appears inside the tasks card
-    await expect(page.locator("text=/in progress.*open/")).toBeVisible({ timeout: 5_000 });
+    // The luxe dashboard renders a stats strip with these labels
+    await expect(page.locator("text=Daily burn").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("text=Issues in flight").first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("text=Approvals pending").first()).toBeVisible({ timeout: 5_000 });
   });
 
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  test.skip("spend card shows No budget set when no budget is configured", async ({ page }) => {
+  test("shows spend and budget card on the dashboard", async ({ page }) => {
     const company = await createCompany(page, "nobudget");
     await createAgent(page, company.id, "Budget Agent", "engineer");
     await navigateToDashboard(page, company.issuePrefix);
 
-    await expect(page.locator("text=spent this month")).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator("text=No budget set")).toBeVisible({ timeout: 5_000 });
+    // The luxe SpendCard renders "Spend & budget" as the card title
+    await expect(page.locator("text=Spend & budget").first()).toBeVisible({ timeout: 10_000 });
   });
 
   // --------------------------------------------------------------------------
   // Recent Activity section
   // --------------------------------------------------------------------------
 
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  test.skip("shows Recent activity section header when activity exists", async ({ page }) => {
+  test("shows heartbeat ticker section on dashboard", async ({ page }) => {
     const company = await createCompany(page, "activity");
-    const agent = await createAgent(page, company.id, "Activity Agent", "engineer");
-    // Creating and assigning an issue generates activity events
-    await createIssue(page, company.id, "Activity test task", agent.id);
+    await createAgent(page, company.id, "Activity Agent", "engineer");
     await navigateToDashboard(page, company.issuePrefix);
 
-    // Activity events may take a moment to propagate
+    // The luxe dashboard renders a "Heartbeat ticker" card (replaces "Recent activity")
     await expect(
-      page.locator("text=Recent activity")
+      page.locator("text=Heartbeat ticker").first()
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  // TODO(AGE-71): un-skip when real fix lands. Was failing on agentdash-main baseline.
-  test.skip("View all link in Recent activity section navigates to activity page", async ({ page }) => {
+  test("All activity link on dashboard navigates to activity page", async ({ page }) => {
     const company = await createCompany(page, "activitylink");
-    const agent = await createAgent(page, company.id, "Link Agent", "engineer");
-    await createIssue(page, company.id, "Link test task", agent.id);
+    await createAgent(page, company.id, "Link Agent", "engineer");
     await navigateToDashboard(page, company.issuePrefix);
 
-    await expect(page.locator("text=Recent activity")).toBeVisible({ timeout: 10_000 });
-
-    // The second "View all" link belongs to the Recent activity section
-    const viewAllLinks = page.locator("a", { hasText: "View all" });
-    const count = await viewAllLinks.count();
-    expect(count).toBeGreaterThanOrEqual(1);
-
-    // Click the last "View all" (activity section is below team section)
-    await viewAllLinks.last().click();
+    // The luxe ArtifactsCard renders "All activity →" link
+    const activityLink = page.locator("a", { hasText: /All activity/ }).first();
+    await expect(activityLink).toBeVisible({ timeout: 10_000 });
+    await activityLink.click();
     await expect(page).toHaveURL(/\/activity/, { timeout: 10_000 });
   });
 
@@ -257,9 +232,10 @@ test.describe("CUJ-2: Daily Dashboard", () => {
 
     await navigateToDashboard(page, company.issuePrefix);
 
-    await expect(page.locator("text=Needs your attention")).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator("text=/1 agent in error/")).toBeVisible({ timeout: 5_000 });
-    // All-clear panel must NOT be present
+    // The luxe AttentionList renders the eyebrow "Needs attention · N"
+    await expect(page.locator("text=/Needs attention/").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("text=/1 agent.*in error state/")).toBeVisible({ timeout: 5_000 });
+    // All-clear text must NOT be present when there are attention items
     await expect(page.locator("text=All clear")).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary

Closes AGE-70. Fixes 3 independent e2e failure clusters that were blocking CI on `agentdash-main` and preventing AGE-57 (PR #37) from merging.

## Root Causes & Fixes

### Cluster 1 — Dashboard CUJ-2 (strict-mode + stale UI assertions)

**Root cause:** The Dashboard was redesigned to a "luxe" layout (editorial cards, org chart, heartbeat ticker) after the CUJ-2 test suite was written. Tests asserted old element text ("Team", "This month", "tasks completed", "spent this month", "View all", "Recent activity") that no longer exists. Additionally, the company-name locator `text=${company.name}` matched 2 elements (subtitle + org-chart node), triggering Playwright strict-mode.

**Fix:** Rewrote 8 dashboard tests to assert actual luxe content:
- `text=Team` → `text=Your workforce`
- `text=This month` / `text=tasks completed` → `text=Daily burn` / `text=Issues in flight` / `text=Approvals pending`
- `text=No agents yet.` + `button[Create one]` → `text=/No agents yet/` (plain text in OrgChart)
- `text=Recent activity` → `text=Heartbeat ticker`
- "View all" activity link → `text=/All activity/`
- Company name selector scoped to `.luxe-subtitle` to prevent strict-mode violation

### Cluster 2 — Comments CUJ-15 (fixture company has 0 issues)

**Root cause:** The `company` fixture calls `getFirstCompany()` which picks the first company returned by `GET /api/companies`. On a fresh CI database this can be a company with zero issues. The test then asserted `issues.length > 0` and immediately accessed `issues[0].id` — crashing with `TypeError: Cannot read properties of undefined`.

**Fix:** Before asserting `issues.length > 0`, create a seed issue if the fixture company has none:
```typescript
if (issues.length === 0) {
  await page.request.post(`/api/companies/${company.id}/issues`, { data: { title: "E2E comment test issue" } });
  issues = await getIssues(page, company.id);
}
```

### Cluster 3 — Budget burn-rate 500 (`scopeType=company` unhandled)

**Root cause:** `BudgetForecast.tsx` calls `/budget-forecasts/burn-rate?scopeType=company` but `computeBurnRate()` only accepts `"agent" | "project"`. Passing `scopeType=company` left `scopeId` as `undefined`, which Drizzle passed to `eq()` conditions causing a crash → 500.

**Fix:**
- Added `computeCompanyBurnRate(companyId)` to `budget-forecasts.ts` — aggregates all `costEvents` for the company without scope filtering. Returns the same `BurnRateData` shape the UI expects (`dailyBurn`, `weeklyBurn`, `monthlyBurn`, `projectedMonthlyTotal`, `daysUntilBudgetExhausted`).
- Route now detects `scopeType=company` (or missing scopeType) and calls the new method. Returns `400` for other unknown scope types instead of crashing.

## Testing

- `pnpm -r typecheck` — passes (all packages clean)
- Affected specs: `tests/e2e/dashboard.spec.ts`, `tests/e2e/comments.spec.ts`, `tests/e2e/budget.spec.ts`
- Budget test 13 already tolerates non-ok responses; server now returns 200 with real data

## Files Changed

- `server/src/routes/budget-extended.ts` — handle `scopeType=company` in burn-rate route
- `server/src/services/budget-forecasts.ts` — add `computeCompanyBurnRate()` method
- `tests/e2e/comments.spec.ts` — seed issue when fixture company has none
- `tests/e2e/dashboard.spec.ts` — rewrite 8 tests to match luxe dashboard UI

**Size:** M

🤖 Generated with [Claude Code](https://claude.com/claude-code)