### PR TITLE
chore(maw): pre-real-users mode + OMC integration in Builder/Tester

### DIFF
--- a/.claude/commands/builder.md
+++ b/.claude/commands/builder.md
@@ -4,7 +4,7 @@ description: 'Builder Agent: Pick up Linear issue, research requirements, implem
 
 You are the **Builder Agent** - responsible for picking up Linear issues, researching requirements, implementing features, and creating pull requests.
 
-> **OMC escalation:** if the issue spec is ambiguous or the implementation strategy isn't obvious, pause and run `/oh-my-claudecode:plan` to design before coding. For independent parallel sub-tasks (e.g. "build 4 unrelated CRM pages"), use `/oh-my-claudecode:ultrawork` to fan them out. For tricky bugs encountered mid-implementation, hand off to `/oh-my-claudecode:trace` rather than guess-and-check.
+> **OMC execution engine (default for M/L/XL):** Builder delegates the actual code-writing to OMC's parallel team runtime — see Phase 2.5 below. The Linear contract (labels, comments, PR creation, rebase-on-`agentdash-main`) stays in this file; OMC only owns "make the changes." Escalation hints: `/oh-my-claudecode:plan` for ambiguous specs, `/oh-my-claudecode:trace` for mid-implementation bugs.
 
 > ### Quick Reference: T-Shirt Sizing & Testing Requirements
 >
@@ -136,6 +136,89 @@ Use mcp__linear__save_issue with:
 4. Execute tasks
 5. Write comprehensive E2E test suite
 6. Full Tester handoff
+
+---
+
+## Phase 2.5: OMC Parallel Execution
+
+Pick the execution engine based on size. **The Linear-facing contract above does not change** — only the worker that writes the code does.
+
+| Size | Engine | Why |
+|------|--------|-----|
+| **XS** | Direct (you, Builder) | One file, not worth orchestration overhead |
+| **S** | Direct (you, Builder) | One file, fast turnaround |
+| **M** | `/oh-my-claudecode:team 2:executor` | 2 parallel workers, file-scoped subtasks |
+| **L** | `/oh-my-claudecode:team 3:executor` | 3 workers, module-scoped subtasks |
+| **XL** | `/oh-my-claudecode:team ralph` | Ralph persistence loop wraps the team pipeline (retry-on-fail, architect verification) |
+
+### 2.5.1 Pre-Conditions Before Invoking `/team`
+
+Builder retains responsibility for these before handing off to the team:
+1. Feature branch created from `agentdash-main` (`pap-<number>-<short-name>`).
+2. Acceptance criteria from the Linear issue extracted into a concrete subtask list (one per file/module).
+3. Linear issue has a size + epic label.
+
+### 2.5.2 Invoking `/team`
+
+For M/L issues, invoke from the Builder session:
+
+```
+/oh-my-claudecode:team <N>:executor "Implement AGE-<number>: <issue title>.
+
+Branch: pap-<number>-<short-name> (already created, on agentdash-main).
+Acceptance criteria:
+- <AC1>
+- <AC2>
+...
+
+Subtask hints (use these as the decomposition seed; refine in team-plan):
+- <subtask 1 — file/module scoped>
+- <subtask 2 — file/module scoped>
+
+Constraints:
+- All workers operate in the existing branch's worktree (managed by /team).
+- Follow project patterns from CLAUDE.md (service/route/schema/constants).
+- New tables MUST be exported from packages/db/src/schema/index.ts.
+- Run `pnpm -r typecheck` after every multi-file change.
+- Do NOT run pnpm build, pnpm test:run, or pnpm dev — Tester owns the test runtime.
+- Do NOT create the PR. Builder owns PR creation after the team completes.
+"
+```
+
+For XL, prefix with `ralph` so the team pipeline retries on verification failure:
+
+```
+/oh-my-claudecode:team ralph 3:executor "Implement AGE-<number>: ..."
+```
+
+### 2.5.3 Stage Routing
+
+OMC's `/team` runs `team-plan → team-prd → team-exec → team-verify → team-fix` automatically. Stage agents (selected by the team lead, not the user):
+
+- `team-plan` → `explore` + `planner` (decomposition)
+- `team-prd` → `analyst` (only if AC is ambiguous)
+- `team-exec` → N × `executor` (the workers)
+- `team-verify` → `verifier` + `code-reviewer` if the change is >20 files; `security-reviewer` for auth/billing/email touches
+- `team-fix` → `debugger` (compilation/type errors) or `executor` (logic fixes)
+
+### 2.5.4 Picking Up the Result
+
+When `/team` completes:
+
+1. Verify all team subtasks are `completed` and the team has shut down (read `~/.claude/teams/<slug>/config.json`).
+2. Read the `.omc/handoffs/team-verify.md` summary — capture decisions/risks for the PR body.
+3. Run the **mandatory regression suite from CLAUDE.md** yourself before claiming done:
+   ```bash
+   pnpm -r typecheck && pnpm test:run && pnpm build
+   ```
+   These are non-negotiable per the "Mandatory regression testing before handing off" rule. The team's `team-verify` is not a substitute.
+4. Continue to Phase 3.5 (Self-Review) → Phase 4 (PR creation) as today.
+
+### 2.5.5 When NOT to Use `/team`
+
+- Issue is XS/S — orchestration overhead is not worth it.
+- Subtasks share a single file (workers would conflict).
+- A previous `/team` run failed verification 2× in a row — escalate to human, do not loop a third time.
 
 ---
 

--- a/.claude/commands/tester.md
+++ b/.claude/commands/tester.md
@@ -4,7 +4,14 @@ description: 'Tester Agent: Run tests on PRs, code review, Chrome CUJ verificati
 
 You are the **Tester Agent** - responsible for testing pull requests, performing code review, verifying CUJs in Chrome, reporting issues, and creating human verification checklists.
 
-> **OMC escalation:** for failing or flaky tests where the cause isn't obvious from the stack, run `/oh-my-claudecode:trace` (evidence-driven causal tracing). Before declaring a feature ready, run `/oh-my-claudecode:verify` to confirm the change actually does what the issue claims. For visual QA, use `/oh-my-claudecode:visual-verdict` instead of free-form Chrome inspection.
+> **OMC execution engine:** Tester delegates the actual test running and bug fixing to OMC. Specifically:
+> - **Automated test loop** → `/oh-my-claudecode:ultraqa` (test → architect-diagnose → fix → repeat, max 5 cycles). Replaces the manual builder-respawn loop. See Phase 2.5.
+> - **Browser/CUJ flows** → `qa-tester` agent (interactive tmux-driven CLI/browser testing). See Phase 3.0.
+> - **Final pre-handoff check** → `/oh-my-claudecode:verify` to confirm the AC is actually met (not just "tests are green").
+> - **Flaky/unclear failures** → `/oh-my-claudecode:trace` for causal tracing.
+> - **Visual regressions** → `/oh-my-claudecode:visual-verdict` for structured screenshot judgment.
+>
+> The Linear-facing contract (labels, comments, sub-issues, retry counts) **stays in this file** — OMC only owns the work of running tests and fixing failures.
 
 ## Overview
 
@@ -115,7 +122,7 @@ Use mcp__conductor__DiffComment with:
 
 ---
 
-## Phase 2: Automated E2E Tests
+## Phase 2: Automated Test Suite (via UltraQA)
 
 ### 2.1 Read Test Plan from Linear Issue
 
@@ -127,29 +134,88 @@ Look for the `## Test Plan` section in the issue description. It contains:
 - **Automated Tests:** The exact command to run
 - **CUJs to Verify:** Checklist of user journeys
 
-### 2.2 Run E2E Test Suite
+### 2.2 Pre-Flight: Mandatory Regression Gates
 
-Execute the command specified in the Test Plan section.
+Per CLAUDE.md "Mandatory regression testing before handing off", run these in order. **Do not delegate to UltraQA until all three pass** — UltraQA is for the issue-specific test suite, not the project-wide gates.
 
-**Fallback (if no test plan):**
+```bash
+pnpm -r typecheck && pnpm test:run && pnpm build
+```
 
-| Size | Tier | Default Command |
+If any of those fail, treat it like a test failure (Phase 4.3) — that's a Builder regression, not a feature bug.
+
+### 2.3 Run E2E Suite via UltraQA
+
+Delegate the issue-specific E2E run to OMC's UltraQA, which loops `test → architect-diagnose → fix → repeat` (max 5 cycles, early exit on 3× same failure).
+
+```
+/oh-my-claudecode:ultraqa --custom "pnpm exec playwright test tests/e2e/<epic>/<feature>.spec.ts"
+```
+
+Use the test command from the Linear issue's Test Plan. **Fallback by size** (only if Test Plan missing):
+
+| Size | Tier | UltraQA Command |
 |------|------|-----------------|
-| XS | Critical | `pnpm test:e2e` |
-| S | Critical | `pnpm test:e2e` |
-| M | Epic | `pnpm test:e2e` |
-| L | Epic | `pnpm test:e2e` (all affected epics) |
-| XL | Full | `pnpm test:e2e && pnpm test:release-smoke` |
+| XS | Critical | `/oh-my-claudecode:ultraqa --custom "pnpm exec playwright test --grep @<epic>"` |
+| S | Critical | `/oh-my-claudecode:ultraqa --custom "pnpm exec playwright test --grep @<epic>"` |
+| M | Epic | `/oh-my-claudecode:ultraqa --custom "pnpm exec playwright test --grep @<epic>"` |
+| L | Epic | `/oh-my-claudecode:ultraqa --custom "pnpm exec playwright test --grep @<epic>"` |
+| XL | Full | `/oh-my-claudecode:ultraqa --custom "pnpm test:e2e && pnpm test:release-smoke"` |
 
-### 2.3 Execute CUJs
+### 2.4 Interpret UltraQA Outcome
 
-For each CUJ in the test plan, verify the user journey works end-to-end.
+| UltraQA Exit | Linear Action |
+|--------------|---------------|
+| `COMPLETE: Goal met after N cycles` (cycles ≤ 1) | No fixes needed → continue to Phase 1.5 (code review) |
+| `COMPLETE: Goal met after N cycles` (cycles 2-5) | UltraQA already fixed and committed. Inspect the diff (`mcp__conductor__GetWorkspaceDiff`), confirm the fixes are reasonable, push the new commits to the PR branch. **Decrement the manual retry counter** — UltraQA cycles count as one Tester pass, not multiple Builder retries. |
+| `STOPPED: Max cycles` | Real failure, escalate per Phase 4.3 (auto-fix loop) — UltraQA already exhausted automatic recovery, so go straight to manual builder respawn or human escalation. |
+| `STOPPED: Same failure 3x` | Likely a flaky test or environment issue, not a code bug. Run `/oh-my-claudecode:trace` to investigate. |
 
 ---
 
-## Phase 3: Chrome CUJ Verification
+## Phase 3.0: Delegate Browser CUJ Sweep to qa-tester (M+ only)
 
-**After automated E2E tests pass AND code review is clean**, walk through each CUJ visually in Chrome.
+For **M, L, XL** issues: instead of walking each CUJ inline with raw `mcp__claude-in-chrome__*` calls, dispatch the OMC `qa-tester` agent. It owns a tmux session, drives the browser, captures evidence, and returns a structured report — keeping this Tester session's context clean for the Linear handoff.
+
+**Skip for XS/S** — those don't have full CUJs in scope; the inline Chrome flow in Phase 3.1-3.4 is faster.
+
+```
+Use Task tool with:
+- subagent_type: "oh-my-claudecode:qa-tester"
+- description: "Browser CUJ sweep for AGE-<number>"
+- prompt: |
+    TEST: Browser CUJ verification for AGE-<number>: <issue title>
+    Environment: http://localhost:3100 (or TODO_SET_STAGING_URL if staging-required)
+
+    CUJs to verify (from Linear issue ## Test Plan):
+    - #<cuj-1>: <expected behavior>
+    - #<cuj-2>: <expected behavior>
+    ...
+
+    For each CUJ:
+    1. Start a fresh authenticated session (use seeded test scenarios from scripts/seed-test-scenarios.sh).
+    2. Walk the journey end-to-end.
+    3. Capture screenshot or GIF of the critical step.
+    4. Check console for errors and network for non-2xx responses.
+    5. Verify responsive at 375x667 if the change touches UI.
+
+    Return a structured report:
+    - Per-CUJ: PASS/FAIL with evidence path
+    - Console errors observed
+    - Failed network requests
+    - Visual regressions
+    - Recommendation: ship / needs-fix / blocked
+```
+
+The qa-tester report becomes the body of the Phase 4.1 "Chrome CUJ Evidence" table — paste verbatim, do not re-run the flows.
+
+If qa-tester reports `needs-fix` or `blocked`, jump to Phase 4.3 (auto-fix loop). Do not silently retry.
+
+---
+
+## Phase 3: Chrome CUJ Verification (XS/S inline path)
+
+**XS/S only — for M+ use Phase 3.0 above.** Walk through each CUJ visually in Chrome.
 
 ### 3.1 Navigate to Test Environment
 
@@ -336,6 +402,8 @@ Look at issue comments for previous fix attempts. Count them.
 
 - **0-1 previous fix attempts** -> Auto-spawn Builder (proceed to Step 2)
 - **2+ previous fix attempts** -> **STOP.** Escalate to human.
+
+> **Note on UltraQA cycling:** The auto-cycles inside Phase 2.3 do NOT count toward the retry budget — those are part of a single Tester pass. This `4.3` retry counter only increments when Tester's pass returns to Builder for source-level fixes (after UltraQA has already exhausted its 5 cycles or hit a same-failure-3x signal).
 
 **Step 2: Auto-spawn Builder subagent**
 

--- a/.claude/commands/workon.md
+++ b/.claude/commands/workon.md
@@ -8,6 +8,8 @@ You are the **MAW Orchestrator** - responsible for automatically routing Linear 
 
 ## Overview
 
+> **MAW MODE: `pre-real-users` (set 2026-04-28)** — Until AgentDash has its first paying customer, **all sizes auto-add `Human-Verified`** after `Locally-Tested`. The size-conditional human gate below is preserved but disabled. Revert by deleting the auto-verify block in Phase 3.6 / Phase 4.1 and restoring the size check.
+
 `/workon AGE-XXX` is the **single entry point** for all feature and bug development. It automatically:
 1. Fetches the issue from Linear
 2. Determines size (uses estimate field or has PM set it)
@@ -15,8 +17,8 @@ You are the **MAW Orchestrator** - responsible for automatically routing Linear 
 4. Routes to the correct agent based on current state
 5. Chains agents: PM -> Builder -> Deploy + Smoke -> Tester (automated + code review + Chrome CUJ)
 6. Stops at `Locally-Tested` or `Staging-Tested`
-7. For XS/S: auto-adds `Human-Verified` (no human gate)
-8. For M+: posts human checklist, waits for human to add `Human-Verified`
+7. **`pre-real-users` mode:** auto-adds `Human-Verified` for ALL sizes; no human gate
+8. (Disabled — original behavior: XS/S auto-verified, M+ waited for human)
 
 ```
 +-------------------------------------------------------------+
@@ -222,16 +224,26 @@ Use Task tool with:
     You are the Builder Agent. Implement AGE-<number>.
 
     **PR target branch:** <agentdash-main or staging based on deployment path>
+    **Size:** <XS|S|M|L|XL>
+    **OMC execution engine (per builder.md Phase 2.5):**
+      - XS/S → write the change directly yourself.
+      - M → invoke `/oh-my-claudecode:team 2:executor` with the AC list as the task.
+      - L → invoke `/oh-my-claudecode:team 3:executor`.
+      - XL → invoke `/oh-my-claudecode:team ralph 3:executor` (Ralph persistence loop).
+      Either way, YOU still own: branch creation, rebase, PR creation, Linear labels,
+      and the mandatory regression suite (`pnpm -r typecheck && pnpm test:run && pnpm build`).
 
     Follow the full Builder workflow from .claude/commands/builder.md:
     1. Read the spec and acceptance criteria
     2. Create feature branch
-    3. Implement the feature
-    4. Write unit tests + E2E tests (S+)
-    5. **REBASE on `agentdash-main`**: `git fetch origin agentdash-main && git rebase origin/agentdash-main`
-    6. Create PR targeting appropriate branch
-    7. Add `PR-Ready` label to Linear
-    8. Add comment: "@tester Ready for E2E testing"
+    3. Pick the execution engine per the size above (Phase 2.5)
+    4. Implement the feature (directly or via /team)
+    5. Write unit tests + E2E tests (S+)
+    6. Run the mandatory regression suite — non-negotiable
+    7. **REBASE on `agentdash-main`**: `git fetch origin agentdash-main && git rebase origin/agentdash-main`
+    8. Create PR targeting appropriate branch
+    9. Add `PR-Ready` label to Linear
+    10. Add comment: "@tester Ready for E2E testing"
 
     When complete, return "BUILDER_COMPLETE" so orchestrator can continue.
 ```
@@ -263,13 +275,28 @@ Use Task tool with:
 - prompt: |
     You are the Tester Agent. Test AGE-<number>.
 
+    **Size:** <XS|S|M|L|XL>
+    **OMC execution engine (per tester.md):**
+      - Phase 2.2 — run the mandatory project-wide gates yourself FIRST:
+        `pnpm -r typecheck && pnpm test:run && pnpm build`. Do not skip.
+      - Phase 2.3 — wrap the issue-specific E2E run in
+        `/oh-my-claudecode:ultraqa --custom "<test command from Linear test plan>"`.
+        UltraQA's internal cycles do NOT count against the manual retry budget (Phase 4.3).
+      - Phase 3.0 (M+) — delegate browser CUJ sweep to `qa-tester` agent
+        (Task subagent_type "oh-my-claudecode:qa-tester"). Paste its report verbatim
+        into the Linear handoff. XS/S use the inline Chrome flow (Phase 3.1-3.4).
+      - Final check — run `/oh-my-claudecode:verify` to confirm AC is actually met
+        before posting Locally-Tested.
+
     Follow the full Tester workflow from .claude/commands/tester.md:
     1. Read test plan from Linear issue description
-    2. Execute E2E tests based on epic/CUJ scope
-    3. Code review: GetWorkspaceDiff + DiffComment
-    4. Chrome CUJ verification: walk each CUJ, record GIFs
-    5. If pass: Add `Locally-Tested` (or `Staging-Tested`) label
-    6. If fail: Add `Tests-Failed` label, create sub-issues
+    2. Run mandatory regression gates (Phase 2.2)
+    3. Run E2E suite via UltraQA (Phase 2.3) and interpret outcome (Phase 2.4)
+    4. Code review: GetWorkspaceDiff + DiffComment
+    5. Chrome CUJ verification: qa-tester for M+, inline for XS/S
+    6. /oh-my-claudecode:verify to confirm the change meets AC
+    7. If pass: Add `Locally-Tested` (or `Staging-Tested`) label
+    8. If fail: Add `Tests-Failed` label, create sub-issues, follow Phase 4.3 retry rules
 
     **CRITICAL - Human Verification Checklist:**
     When all tests pass, post a checklist containing ONLY
@@ -282,9 +309,11 @@ Use Task tool with:
 
 **If `Locally-Tested` or `Staging-Tested` is set:**
 
-Check issue size:
-- **XS/S (1-2 pts):** Auto-add `Human-Verified` label. No human gate needed.
-- **M+ (3+ pts):** Post human verification checklist. Stop and wait for human.
+**`pre-real-users` mode (current):** Auto-add `Human-Verified` label regardless of size. Post the human checklist as an informational comment but do NOT block on it. Hand off to TPM.
+
+Original size-gated logic (disabled — preserved for revert):
+- ~~**XS/S (1-2 pts):** Auto-add `Human-Verified` label. No human gate needed.~~
+- ~~**M+ (3+ pts):** Post human verification checklist. Stop and wait for human.~~
 
 ```
 ## Awaiting Human Validation (M+ only)


### PR DESCRIPTION
Pre-real-users mode toggle in workon.md + OMC ultraqa/team integration in tester.md/builder.md. No code paths changed; MAW SOP docs only.

Tester sweep evidence (AGE-44 sibling): typecheck ✅, build ✅, 1487/1538 tests pass; 4 fails = pre-existing flakes already covered by AGE-69 fix + AGE-71.

Revert: delete the pre-real-users blocks; size-conditional logic preserved in adjacent strikethrough comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)