### PR TITLE
fix(ui): load brand fonts + unblock entitlement-gated CUJ tests

### DIFF
--- a/scripts/test-cujs.sh
+++ b/scripts/test-cujs.sh
@@ -29,6 +29,10 @@ CID=$(curl -s -X POST "$BASE/companies" -H "Content-Type: application/json" \
   -d '{"name":"CUJ Test Corp","description":"Testing all CUJs","issuePrefix":"CUJ"}' | jq_ "print(d['id'])")
 [ -n "$CID" ] && pass "Create company" || fail "Create company" "no ID returned"
 
+# Bump tier so entitlement-gated CUJs (AutoResearch, etc.) can run.
+curl -s -X PATCH "$BASE/companies/$CID/entitlements" -H "Content-Type: application/json" \
+  -d '{"tier":"pro"}' > /dev/null
+
 # Start onboarding session
 SESS=$(curl -s -X POST "$BASE/companies/$CID/onboarding/sessions" -H "Content-Type: application/json" \
   -d '{"createdByUserId":"test-user"}' 2>/dev/null | jq_ "print(d.get('id',''))")

--- a/ui/index.html
+++ b/ui/index.html
@@ -11,7 +11,7 @@
     <title>AgentDash</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=Mona+Sans:ital,wght@0,400..900;1,400..900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <!-- PAPERCLIP_RUNTIME_BRANDING_START -->
     <!-- PAPERCLIP_RUNTIME_BRANDING_END -->
     <!-- PAPERCLIP_FAVICON_START -->


### PR DESCRIPTION
Brand fonts (Instrument Serif / Mona Sans / JetBrains Mono) were declared in luxe.css but only Inter was loading from Google Fonts — added the three to the same preloaded URL. Also bumped tier=pro after company creation in scripts/test-cujs.sh so CUJ-7 (entitlement-gated AutoResearch) can run; CUJ suite now goes 60/60.

Verified: typecheck green, build green, CUJ script 60/60 (was aborting at CUJ-7 before this PR). Dashboard greeting now renders in Instrument Serif italic vs prior Cochin/Garamond fallback.

Out of scope and tracked separately: 7 vitest test-pollution failures (pass in isolation), 37 E2E selector-drift failures (covered by AGE-71), record-measurement toISOString backend bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)