### PR TITLE
fix(autoresearch): coerce collectedAt string to Date in record-measurement (AGE-85)

### DIFF
--- a/scripts/test-cujs.sh
+++ b/scripts/test-cujs.sh
@@ -269,10 +269,15 @@ MET=$(curl -s -X POST "$BASE/companies/$CID/metric-definitions" -H "Content-Type
   -d '{"key":"signup_rate","displayName":"Daily Signup Rate","unit":"percent","dataSourceType":"manual","collectionMethod":"manual"}' | jq_ "print(d['id'])")
 [ -n "$MET" ] && pass "Create metric definition" || fail "Create metric" "no ID"
 
-# Record measurement
-MEAS=$(curl -s -X POST "$BASE/companies/$CID/experiments/$EXP/measurements" -H "Content-Type: application/json" \
-  -d "{\"metricDefinitionId\":\"$MET\",\"value\":22.5,\"collectedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"collectionMethod\":\"manual\"}" | jq_ "print(d.get('id', d.get('error','unknown')))")
-[ -n "$MEAS" ] && pass "Record measurement (22.5%) [$MEAS]" || fail "Record measurement" "no ID"
+# Record measurement — assert a real id (not an error string), to catch silent backend errors
+MEAS_RESP=$(curl -s -X POST "$BASE/companies/$CID/experiments/$EXP/measurements" -H "Content-Type: application/json" \
+  -d "{\"metricDefinitionId\":\"$MET\",\"value\":22.5,\"collectedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"collectionMethod\":\"manual\"}")
+MEAS=$(echo "$MEAS_RESP" | jq_ "print(d.get('id',''))")
+if [ -n "$MEAS" ]; then
+  pass "Record measurement (22.5%) id=$MEAS"
+else
+  fail "Record measurement" "no id in response: $MEAS_RESP"
+fi
 
 # Create evaluation
 EVAL=$(curl -s -X POST "$BASE/companies/$CID/experiments/$EXP/evaluations" -H "Content-Type: application/json" \

--- a/server/src/routes/autoresearch.ts
+++ b/server/src/routes/autoresearch.ts
@@ -243,7 +243,14 @@ export function autoresearchRoutes(db: Db) {
     try {
       const companyId = req.params.companyId as string;
       assertCompanyAccess(req, companyId);
-      const result = await svc.recordMeasurement(companyId, { ...req.body, experimentId: req.params.experimentId });
+      const body = req.body as Record<string, unknown>;
+      const collectedAt =
+        typeof body.collectedAt === "string" ? new Date(body.collectedAt) : body.collectedAt;
+      const result = await svc.recordMeasurement(companyId, {
+        ...body,
+        collectedAt,
+        experimentId: req.params.experimentId,
+      } as Parameters<typeof svc.recordMeasurement>[1]);
       res.status(201).json(result);
     } catch (err: unknown) {
       const status = (err as { statusCode?: number }).statusCode ?? 500;


### PR DESCRIPTION
Fixes [AGE-85](https://linear.app/agentdash/issue/AGE-85).

POST /companies/:cid/experiments/:eid/measurements was forwarding req.body.collectedAt straight to the service, where Drizzle's timestamp column called .toISOString() on the string and exploded. The route's try/catch caught it and returned 'value.toISOString is not a function' as the error body — but the CUJ script's loose assertion (only checked non-empty) marked it PASS.

Two fixes in one:
- Route coerces collectedAt to Date when it's a string
- CUJ script asserts d.get('id','') strictly so future regressions in this shape produce real failures

Verified: scripts/test-cujs.sh exits 0 with **60/60 PASS** and the strict assertion against a fresh dev server. Typecheck/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)