### PR TITLE
docs: Board Operator playbook + MKthink Day-1 checklist (AGE-94)

### DIFF
--- a/doc/clients/mkthink/day-1-checklist.md
+++ b/doc/clients/mkthink/day-1-checklist.md
@@ -1,0 +1,107 @@
+# MKthink — Day-1 Live Walkthrough Checklist
+
+**Use during:** the live Day-1 session with MKthink's CEO/COO.
+**Time:** ~90 minutes (60 min walkthrough + 30 min Q&A).
+**Pair this with:** [`doc/operator-playbook.md`](../../operator-playbook.md) — leave a copy with the operator after the session.
+
+---
+
+## Pre-flight (do these BEFORE the meeting)
+
+| ✅ | Item | Owner |
+|---|---|---|
+| ☐ | AgentDash deployed on `TODO_SET_MKTHINK_URL` (cloud VM or self-hosted) | AgentDash team |
+| ☐ | Health check passes — `curl -sf $URL/api/health` returns 200 | AgentDash team |
+| ☐ | MKthink company seeded via `bash scripts/seed-mkthink.sh` (industry=construction, suggested templates pre-ranked) | AgentDash team |
+| ☐ | HubSpot sandbox credentials acquired from MKthink's IT contact | AgentDash team |
+| ☐ | HubSpot OAuth flow tested end-to-end with sandbox creds | AgentDash team |
+| ☐ | At least 2 starter agents heartbeating (visible on `/agents`) | AgentDash team |
+| ☐ | Kill switch tested in staging (halt → resume cycle works) | AgentDash team |
+| ☐ | Operator playbook printed/shared with attendees | AgentDash team |
+| ☐ | Anthropic API key configured (BYOT — confirm with MKthink which key) | MKthink + AgentDash |
+| ☐ | AgentDash support Slack channel exists and the operator is invited | AgentDash team |
+
+---
+
+## Live walkthrough (60 min, with COO present)
+
+### Block 1 — Dashboard tour (15 min)
+
+| ✅ | Step | Talking points |
+|---|---|---|
+| ☐ | Open `/` and let them read the headline | "On-track" should be green; explain the daily routine is reading this line |
+| ☐ | Click each top-level tile (MRR, daily burn, issues in flight, approvals) | Show what each metric means; show how to drill in |
+| ☐ | Click an agent on the workforce strip | Show role, adapter, recent runs, current task |
+| ☐ | Open `/issues` | Explain status pills; show how blocked/attention items surface |
+| ☐ | Open `/approvals` | Show a real approval (or seed one); demonstrate one-click approve |
+
+### Block 2 — Goal-setting & first agent (15 min)
+
+| ✅ | Step | Talking points |
+|---|---|---|
+| ☐ | Open `/goals` → New Goal | Have COO type a real business goal in their words ("close 5 new construction contracts this quarter") |
+| ☐ | Show how the Chief of Staff agent proposes a plan | Explain: agents don't just execute — they propose work for human approval |
+| ☐ | Approve the proposed plan (or edit + approve) | Show that approval is the only "agent does something irreversible" gate |
+| ☐ | Show the spawned issues for the first agent to pick up | Watch one agent grab the first issue from the queue |
+
+### Block 3 — Kill switch + safety (10 min)
+
+| ✅ | Step | Talking points |
+|---|---|---|
+| ☐ | Walk to Security page | This is the "stop everything" button — explain when to use it |
+| ☐ | Click HALT ALL AGENTS → confirm | Watch the status flip; show audit trail |
+| ☐ | Wait 30 seconds | Let the silence sink in — system is fully halted |
+| ☐ | Click Resume All Agents | Status flips back to running; agents resume from their last checkpoint |
+| ☐ | Show per-agent halt | Sometimes you only need to stop one agent, not all |
+
+### Block 4 — HubSpot integration (10 min)
+
+| ✅ | Step | Talking points |
+|---|---|---|
+| ☐ | Open `/connectors` and confirm HubSpot is connected | Sandbox first, then production after pilot week 1 |
+| ☐ | Show a synced account in `/crm/accounts` | Same data, both directions; HubSpot remains source of truth |
+| ☐ | Show a deal that has agent activity | Agent action timeline lives alongside HubSpot timeline |
+| ☐ | Show webhook receiver is healthy | Real-time updates from HubSpot land in AgentDash within seconds |
+
+### Block 5 — Daily routine handoff (10 min)
+
+| ✅ | Step | Talking points |
+|---|---|---|
+| ☐ | Walk through the daily 60-sec routine | (per [`doc/operator-playbook.md`](../../operator-playbook.md) §Daily routine) |
+| ☐ | Walk through the weekly ~30-min routine | (per playbook §Weekly routine) |
+| ☐ | Show the escalation table | (per playbook §When something is wrong) |
+| ☐ | Confirm Slack support channel is in their workspace | They should never feel stuck |
+
+---
+
+## Q&A (30 min)
+
+Common questions to be ready for:
+
+- **"What if an agent does something wrong?"** → kill switch, audit trail, every action is reversible at the data layer
+- **"What does this cost us in LLM tokens?"** → BYOT model; daily burn card shows real-time spend; tier caps prevent runaway
+- **"Can we add or remove agents anytime?"** → yes, spawn from templates in 2 clicks; retire from agent detail
+- **"What about data security?"** → company-scoped data, no agent can see another company's data; policy engine blocks egress
+- **"What if HubSpot goes down?"** → AgentDash queues changes; syncs when HubSpot returns
+
+---
+
+## Post-walkthrough — same day
+
+| ✅ | Item | Owner |
+|---|---|---|
+| ☐ | Send the operator playbook + this checklist as PDFs | AgentDash team |
+| ☐ | Confirm Day-1 kill switch test was logged in audit trail (proof it works) | AgentDash team |
+| ☐ | Schedule daily Slack check-in for week 1 (5 min/day, async) | AgentDash team |
+| ☐ | Schedule Day-7 review meeting | AgentDash team + COO |
+| ☐ | Capture Day-1 baseline metrics (per [AGE-95](https://linear.app/agentdash/issue/AGE-95)) | AgentDash team |
+
+---
+
+## If something goes wrong during the walkthrough
+
+- **Demo agent crashes mid-tour** → halt that agent only; show how the system isolates failure
+- **HubSpot sync fails** → show retry logic + manual re-sync; reassure that data isn't lost
+- **Kill switch doesn't reactivate** → known recovery path: `pnpm agentdash heartbeat-run` from CLI; if needed, escalate
+
+The walkthrough succeeding is more important than the walkthrough being perfect. If you hit an issue, narrate it: "this is exactly why we test in pilot — let me show you the recovery." That builds trust faster than a perfect demo.

--- a/doc/operator-playbook.md
+++ b/doc/operator-playbook.md
@@ -1,0 +1,107 @@
+# Board Operator Playbook
+
+**Audience:** the human in your company who oversees the AI workforce — usually CEO, COO, or VP of Ops.
+**Time investment:** 30 min onboarding · 60 sec/day · ~30 min/week.
+**Outcome:** by end of week 1, you trust the system enough to step away from it for a day.
+
+---
+
+## What "Board Operator" means
+
+You don't manage agents the way you manage humans — you set goals, approve scaling decisions, watch for trouble, and step in when something needs a human. The agents do the work. AgentDash is the interface that makes oversight cheap.
+
+---
+
+## 30-minute onboarding agenda
+
+| Min | Step | What you do |
+|---:|---|---|
+| 0–5 | **Tour the dashboard** | Open `/`. Read the top line ("Good morning. Your workforce is on-track."). Look at MRR, daily burn, issues in flight, approvals pending. |
+| 5–10 | **Open the Agents page** | `/agents`. Each card is one agent. Status dot = green/amber/red. Click one to see what it's doing right now. |
+| 10–15 | **Open Issues** | `/issues`. This is the work queue. Anything blocked or needing attention is highlighted. |
+| 15–20 | **Walk through Approvals** | `/approvals`. Anything an agent wants you to OK lives here — spawn requests, scope expansions, content the agent isn't sure about. |
+| 20–25 | **Test the kill switch** | Security page → HALT ALL AGENTS → confirm. Watch the status flip. Resume. *Do this once now so it's not scary later.* |
+| 25–30 | **Set your first goal** | `/goals` → New Goal. Describe a business outcome ("hit $20K MRR by July"). The Chief of Staff agent will propose tasks to get there. |
+
+That's it. You're trained.
+
+---
+
+## Daily routine — 60 seconds
+
+Open `/` once a day. Scan in this order:
+
+1. **The headline:** "on-track" or "X items need your attention." If on-track, you can close the tab.
+2. **Approvals pending:** if non-zero, click. Approve or reject each one (1-click).
+3. **Daily burn vs. budget:** if the trend is red, spot-check before the day starts.
+
+If the headline is green and approvals are 0, you're done. Close the tab. Get coffee.
+
+---
+
+## Weekly routine — ~30 minutes
+
+Once a week (suggest: Monday morning before standup):
+
+1. **Read the weekly auto-report** (sent Monday 8am): pipeline numbers, top wins, top blockers.
+2. **Review escalations:** any issue an agent flagged for human input. Decide → respond in the issue thread.
+3. **Tune budgets:** anything over forecast, anything underused. Adjust on the agent detail page.
+4. **One spawn or retire:** based on the week's data, do one of: spawn a new agent for a gap, retire an agent that's not earning its budget, or do nothing (most weeks).
+
+---
+
+## When something is wrong — escalation paths
+
+| Signal | What it means | What you do |
+|---|---|---|
+| **Status dot is red** on an agent | Last heartbeat failed | Click → read the error → if you can't tell, escalate to AgentDash support |
+| **Burn rate spikes** | Agent looped or did expensive work | Agent detail → recent runs → look for the spike → consider tightening the agent's budget cap |
+| **Approval queue grows** | Agents are uncertain more than usual | Read 3 of them — pattern? If yes, the agent's instructions probably need updating |
+| **Issues stuck in "blocked"** | Dependency unresolved | Issue detail → see what's blocking → unblock manually or escalate |
+| **Customer complaint** about agent output | Agent did something wrong | **Halt the offending agent** (per-agent kill, not company-wide), then triage |
+| **You're not sure** | Anything weird | **HALT ALL AGENTS** is always safe. They resume on your one-click. Better halt and ask than let it run. |
+
+---
+
+## Glossary (because the words matter)
+
+| Term | What it means |
+|---|---|
+| **Agent** | One AI worker. Has a role, an adapter (e.g. Claude, Codex), a budget, and an OKR. Operates inside policies you set. |
+| **Adapter** | The LLM provider this agent talks to (Claude local, Claude API, Codex, Gemini, etc.). Mostly invisible day-to-day. |
+| **Run** | One unit of work an agent executes — pick up a task, do it, report back. |
+| **Heartbeat** | The signal an agent is alive. If heartbeats stop, the agent is shown as red. |
+| **OKR** | The agent's objective + measurable key results. Set on the agent detail page. |
+| **Spawn request** | An agent asking permission to scale (create more like itself). Lands in your Approvals queue. |
+| **Pipeline** | A multi-stage workflow with hand-offs and HITL gates. Agents execute the stages. |
+| **Approval** | Anything an agent wants your sign-off on before doing. Always a 1-click decision. |
+| **Kill switch** | The HALT ALL AGENTS button. Stops everything in seconds. Always reversible. |
+| **Tier** | Your AgentDash plan (Free / Pro / Enterprise). Caps agents, monthly actions, and feature access. |
+| **Track A** | The AI agent workforce (what you operate). |
+| **Track B** | Sanctioned employee-built apps (the IT-controlled alternative to your team pasting data into ChatGPT). |
+
+---
+
+## Things you should *never* have to do
+
+- Edit code
+- Read logs by hand
+- SSH into a server
+- Manage agent prompts directly (use the Agent Instructions UI)
+- Recover from a failed run (the system retries)
+
+If you find yourself doing any of these, escalate to AgentDash support — the system is supposed to make these invisible to you.
+
+---
+
+## The one principle
+
+**Trust the dashboard, halt anything weird, ship one improvement a week.** That's the job.
+
+---
+
+## Related docs
+
+- [`doc/clients/mkthink/day-1-checklist.md`](clients/mkthink/day-1-checklist.md) — first-day live walkthrough for the MKthink pilot
+- [`doc/PRD.md`](PRD.md) — full product overview with all 19 CUJs
+- [`doc/BUSINESS-PLAN.md`](BUSINESS-PLAN.md) — pricing and pilot structure if you're sizing a contract


### PR DESCRIPTION
Fixes [AGE-94](https://linear.app/agentdash/issue/AGE-94) — partial.

Two deliverables of three from AGE-94 ship in this PR:

- **doc/operator-playbook.md** — the generic Board Operator playbook (30-min onboarding, daily/weekly routine, escalation table, glossary). Ships with every pilot, not MKthink-specific.
- **doc/clients/mkthink/day-1-checklist.md** — pilot-specific live walkthrough script for MKthink Day-1: pre-flight, 5 timed blocks, Q&A prep, post-walkthrough handoff. Uses TODO_SET_* placeholders for the real deploy URL and creds.

Out of scope: the 12-15 slide PDF training deck. Recording a Loom or building a deck is human work, not agent work — flagged in the commit message and a follow-up Linear issue should track it. AGE-94 is otherwise complete after this PR + that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)