### PR TITLE
feat(companies): expose metadata JSONB on read + write endpoints (AGE-98)

### DIFF
--- a/cli/src/__tests__/company-delete.test.ts
+++ b/cli/src/__tests__/company-delete.test.ts
@@ -23,6 +23,7 @@ function makeCompany(overrides: Partial<Company>): Company {
     logoAssetId: null,
     logoUrl: null,
     emailDomain: null,
+    metadata: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -24,6 +24,9 @@ export interface Company {
   // `me@gmail.com`). NULL on grandfathered rows. See
   // `deriveCompanyEmailDomain` in `@agentdash/shared`.
   emailDomain: string | null;
+  // AgentDash (AGE-98): structured client metadata exposed via the read
+  // endpoints (industry, expected team size, primary CRM, pilot stage, etc).
+  metadata: Record<string, unknown> | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -10,6 +10,10 @@ export const createCompanySchema = z.object({
   description: z.string().optional().nullable(),
   budgetMonthlyCents: z.number().int().nonnegative().optional().default(0),
   brandColor: brandColorSchema,
+  // AgentDash (AGE-98): structured client metadata (industry, expected team
+  // size, primary CRM, pilot stage). Persisted in companies.metadata; read
+  // back via getCompanyQuery (server/src/services/companies.ts).
+  metadata: z.record(z.unknown()).optional().nullable(),
 });
 
 export type CreateCompany = z.infer<typeof createCompanySchema>;
@@ -26,6 +30,8 @@ export const updateCompanySchema = createCompanySchema
     feedbackDataSharingTermsVersion: feedbackDataSharingTermsVersionSchema,
     brandColor: brandColorSchema,
     logoAssetId: logoAssetIdSchema,
+    // AgentDash (AGE-98): allow PATCH /companies/:id to update metadata.
+    metadata: z.record(z.unknown()).optional().nullable(),
   });
 
 export type UpdateCompany = z.infer<typeof updateCompanySchema>;

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -64,6 +64,10 @@ export function companyService(db: Db) {
     brandColor: companies.brandColor,
     // AgentDash (AGE-55): FRE Plan B — domain claim on the company.
     emailDomain: companies.emailDomain,
+    // AgentDash (AGE-98): structured client metadata (industry, expected
+    // team size, primary CRM, pilot stage, etc.). The column existed in the
+    // schema; the read endpoints were silently dropping it.
+    metadata: companies.metadata,
     logoAssetId: companyLogos.assetId,
     createdAt: companies.createdAt,
     updatedAt: companies.updatedAt,

--- a/ui/src/pages/__tests__/WelcomePage.test.tsx
+++ b/ui/src/pages/__tests__/WelcomePage.test.tsx
@@ -43,6 +43,7 @@ function makeCompany(overrides: Partial<Company> = {}): Company {
     logoAssetId: null,
     logoUrl: null,
     emailDomain: null,
+    metadata: null,
     createdAt: new Date("2026-04-17T00:00:00.000Z"),
     updatedAt: new Date("2026-04-17T00:00:00.000Z"),
     ...overrides,


### PR DESCRIPTION
Closes [AGE-98](https://linear.app/agentdash/issue/AGE-98).

The companies.metadata column existed in the schema but was silently stripped on both ends of the API:
- getCompanyQuery didn't select it, so GET responses never carried it
- createCompanySchema / updateCompanySchema didn't list it, so POST/PATCH bodies were stripped by zod

Both fixed in this PR. Verified end-to-end against a fresh dev server: POST /companies with metadata={fooBar:[1,2,3], industry:'construction', isFirstClient:true} returns the full metadata in the response, and GET /companies/:id round-trips it identically. pnpm -r typecheck green.

Unblocks [AGE-92](https://linear.app/agentdash/issue/AGE-92) to switch its seed script from a description-string sentinel to metadata.isFirstClient for idempotence — small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)