### PR TITLE
feat(auth): Pro free-mail block on company creation (AGE-60 — partial)

### DIFF
--- a/server/src/__tests__/signup-pro-free-mail-block.test.ts
+++ b/server/src/__tests__/signup-pro-free-mail-block.test.ts
@@ -1,0 +1,165 @@
+// AgentDash (AGE-60): on Pro deployments, the company-create route blocks
+// free-mail creator emails (gmail/yahoo/etc) with a friendly error so the
+// signup UI can prompt for a corp email instead.
+//
+// Self-hosted Free leaves the gate off (any email works, single-seat cap
+// is enforced separately).
+
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { companyRoutes } from "../routes/companies.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+const ACTOR = {
+  type: "board" as const,
+  userId: "user-1",
+  companyIds: [],
+  isInstanceAdmin: true,
+  source: "session" as const,
+};
+
+const LOCAL_ACTOR = {
+  type: "board" as const,
+  userId: "local-board",
+  companyIds: [],
+  isInstanceAdmin: true,
+  source: "local_implicit" as const,
+};
+
+const fakeDb = {
+  select: vi.fn(),
+} as any;
+
+let createMock: ReturnType<typeof vi.fn>;
+let findByEmailDomainMock: ReturnType<typeof vi.fn>;
+let ensureMembershipMock: ReturnType<typeof vi.fn>;
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    list: vi.fn().mockResolvedValue([]),
+    stats: vi.fn().mockResolvedValue({}),
+    getById: vi.fn(),
+    create: (...args: unknown[]) => createMock(...args),
+    findByEmailDomain: (...args: unknown[]) => findByEmailDomainMock(...args),
+    update: vi.fn(),
+    archive: vi.fn(),
+    remove: vi.fn(),
+  }),
+  companyPortabilityService: () => ({
+    exportBundle: vi.fn(),
+    previewExport: vi.fn(),
+    previewImport: vi.fn(),
+    importBundle: vi.fn(),
+  }),
+  accessService: () => ({
+    canUser: vi.fn(),
+    ensureMembership: (...args: unknown[]) => ensureMembershipMock(...args),
+  }),
+  budgetService: () => ({ upsertPolicy: vi.fn() }),
+  agentService: () => ({ getById: vi.fn() }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(),
+    listFeedbackTraces: vi.fn(),
+    getFeedbackTraceById: vi.fn(),
+    saveIssueVote: vi.fn(),
+  }),
+  logActivity: vi.fn(),
+}));
+
+function buildApp(opts: {
+  actorEmail?: string;
+  requireCorpEmail?: boolean;
+  actor?: typeof ACTOR | typeof LOCAL_ACTOR;
+}) {
+  fakeDb.select = vi.fn(() => ({
+    from: () => ({
+      where: () => Promise.resolve(opts.actorEmail ? [{ email: opts.actorEmail }] : []),
+    }),
+  }));
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = opts.actor ?? ACTOR;
+    next();
+  });
+  app.use(
+    "/api/companies",
+    companyRoutes(fakeDb, undefined, {
+      requireCorpEmail: opts.requireCorpEmail ?? false,
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  createMock = vi.fn();
+  findByEmailDomainMock = vi.fn().mockResolvedValue(null);
+  ensureMembershipMock = vi.fn().mockResolvedValue({});
+});
+
+describe("POST /api/companies — Pro free-mail block (AGE-60)", () => {
+  it.each(["gmail.com", "yahoo.com", "outlook.com", "hotmail.com", "icloud.com"])(
+    "rejects %s with 400 pro_requires_corp_email when requireCorpEmail is on",
+    async (domain) => {
+      const app = buildApp({ actorEmail: `alice@${domain}`, requireCorpEmail: true });
+      const res = await request(app).post("/api/companies").send({ name: "Personal" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("pro_requires_corp_email");
+      expect(res.body.error).toContain("Pro accounts require");
+      expect(createMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows corp-domain creator when requireCorpEmail is on", async () => {
+    createMock.mockResolvedValue({
+      id: "company-1",
+      name: "Acme",
+      budgetMonthlyCents: 0,
+      emailDomain: "acme.com",
+    });
+    const app = buildApp({ actorEmail: "alice@acme.com", requireCorpEmail: true });
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+  });
+
+  it("allows free-mail creator when requireCorpEmail is OFF (Free deployment)", async () => {
+    createMock.mockResolvedValue({
+      id: "company-2",
+      name: "Solo",
+      budgetMonthlyCents: 0,
+      emailDomain: "alice@gmail.com",
+    });
+    const app = buildApp({ actorEmail: "alice@gmail.com", requireCorpEmail: false });
+    const res = await request(app).post("/api/companies").send({ name: "Solo" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+  });
+
+  it("exempts local_implicit board actor even when requireCorpEmail is on", async () => {
+    createMock.mockResolvedValue({
+      id: "company-3",
+      name: "Dev Co",
+      budgetMonthlyCents: 0,
+      emailDomain: null,
+    });
+    // local_implicit actors have no userId-keyed email row; pass actorEmail
+    // undefined so the select returns []. The route's outer guard skips
+    // email lookup entirely for local_implicit anyway.
+    const app = buildApp({
+      actorEmail: undefined,
+      requireCorpEmail: true,
+      actor: LOCAL_ACTOR,
+    });
+    const res = await request(app).post("/api/companies").send({ name: "Dev Co" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -117,6 +117,9 @@ export async function createApp(
     // AgentDash (AGE-55): FRE Plan B flags
     disableSignUp?: boolean;
     allowMultiTenantPerDomain?: boolean;
+    // AgentDash (AGE-60): on Pro deployments, require a corp-email creator
+    // for new companies. Self-hosted Free leaves this off.
+    requireCorpEmail?: boolean;
     instanceId?: string;
     hostVersion?: string;
     localPluginDir?: string;
@@ -225,6 +228,8 @@ export async function createApp(
     companyRoutes(db, opts.storageService, {
       // AgentDash (AGE-55): per-domain uniqueness toggle for company creation.
       allowMultiTenantPerDomain: opts.allowMultiTenantPerDomain ?? false,
+      // AgentDash (AGE-60): block free-mail creator emails on Pro.
+      requireCorpEmail: opts.requireCorpEmail ?? false,
     }),
   );
   api.use(companySkillRoutes(db));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -542,6 +542,9 @@ export async function startServer(): Promise<StartedServer> {
     // AgentDash (AGE-55): FRE Plan B flags
     disableSignUp: config.authDisableSignUp,
     allowMultiTenantPerDomain: config.allowMultiTenantPerDomain,
+    // AgentDash (AGE-60): Pro deployments enforce corp-email signup; Free
+    // (local_trusted) does not.
+    requireCorpEmail: config.deploymentMode === "authenticated",
     betterAuthHandler,
     resolveSession,
     // AgentDash (AGE-59): wire email backend from config

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -4,6 +4,7 @@ import type { Db } from "@agentdash/db";
 import { authUsers } from "@agentdash/db";
 import {
   DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION,
+  FREE_MAIL_DOMAINS,
   companyPortabilityExportSchema,
   companyPortabilityImportSchema,
   companyPortabilityPreviewSchema,
@@ -34,6 +35,11 @@ import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 // from server/src/config.ts so test/integration harnesses can override.
 export interface CompanyRoutesOptions {
   allowMultiTenantPerDomain?: boolean;
+  // AgentDash (AGE-60): when true, reject company creation if the creator's
+  // email is a free-mail address (gmail, yahoo, etc). Pro deployments turn
+  // this on; self-hosted Free leaves it off so a single user with any
+  // email can stand up a workspace.
+  requireCorpEmail?: boolean;
 }
 
 export function companyRoutes(
@@ -42,6 +48,7 @@ export function companyRoutes(
   options: CompanyRoutesOptions = {},
 ) {
   const allowMultiTenantPerDomain = options.allowMultiTenantPerDomain ?? false;
+  const requireCorpEmail = options.requireCorpEmail ?? false;
   const router = Router();
   const svc = companyService(db);
   const agents = agentService(db);
@@ -291,6 +298,23 @@ export function companyRoutes(
         .then((rows) => rows[0] ?? null);
       creatorEmail = userRow?.email ?? null;
       if (creatorEmail) {
+        // AgentDash (AGE-60): on Pro deployments, reject free-mail addresses
+        // before we even derive the domain — they get a friendlier error
+        // code than the generic "could not derive". local_implicit is
+        // already exempt above (the outer if).
+        if (requireCorpEmail) {
+          const lower = creatorEmail.trim().toLowerCase();
+          const at = lower.lastIndexOf("@");
+          const rawDomain = at >= 0 ? lower.slice(at + 1) : "";
+          if (FREE_MAIL_DOMAINS.has(rawDomain)) {
+            res.status(400).json({
+              code: "pro_requires_corp_email",
+              error:
+                "Pro accounts require a company email. Please sign up with your work email or use the Free self-hosted plan.",
+            });
+            return;
+          }
+        }
         try {
           emailDomain = deriveCompanyEmailDomain(creatorEmail);
         } catch (err) {


### PR DESCRIPTION
Closes part 1 of [AGE-60](https://linear.app/agentdash/issue/AGE-60).

Pro deployments now reject company creation by free-mail addresses with a friendly `pro_requires_corp_email` code. local_implicit (CLI/dev) is exempt. Free deployments unaffected.

8 vitest cases covering 5 free-mail domains, corp passthrough, Free-mode passthrough, and local_implicit exemption. All green.

Out of scope (followups): Free single-seat cap, Auth.tsx inline error UI, people-page invite button hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)