### PR TITLE
feat(auth): Free single-seat cap on signup (AGE-100)

### DIFF
--- a/server/src/__tests__/signup-free-seat-cap.test.ts
+++ b/server/src/__tests__/signup-free-seat-cap.test.ts
@@ -1,0 +1,91 @@
+// AgentDash (AGE-100): Free single-seat cap.
+// Self-hosted Free deployments accept exactly one signup; subsequent
+// signups return HTTP 403 free_tier_seat_cap.
+
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { freeSeatCapMiddleware } from "../middleware/free-seat-cap.js";
+
+let userCount = 0;
+
+const fakeDb = {
+  select: vi.fn(() => ({
+    from: () => Promise.resolve([{ value: userCount }]),
+  })),
+} as any;
+
+function buildApp(opts: { enabled: boolean }) {
+  const app = express();
+  app.use(express.json());
+  app.use(freeSeatCapMiddleware(fakeDb, { enabled: opts.enabled }));
+  // Stand-in for better-auth handler — only reached when middleware lets us through.
+  app.all("/api/auth/*authPath", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  // Sanity: any non-auth route should be unaffected by the middleware.
+  app.get("/health", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+}
+
+beforeEach(() => {
+  userCount = 0;
+});
+
+describe("freeSeatCapMiddleware (AGE-100)", () => {
+  it("allows the 1st signup on Free (count=0)", async () => {
+    userCount = 0;
+    const app = buildApp({ enabled: true });
+    const res = await request(app).post("/api/auth/sign-up/email").send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("blocks the 2nd signup on Free with 403 free_tier_seat_cap", async () => {
+    userCount = 1;
+    const app = buildApp({ enabled: true });
+    const res = await request(app).post("/api/auth/sign-up/email").send({});
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("free_tier_seat_cap");
+    expect(res.body.error).toContain("Self-hosted Free supports one human");
+  });
+
+  it("blocks at any user count >= 1, including very many", async () => {
+    userCount = 47;
+    const app = buildApp({ enabled: true });
+    const res = await request(app).post("/api/auth/sign-up/email").send({});
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("free_tier_seat_cap");
+  });
+
+  it("does NOT gate when enabled=false (Pro deployment)", async () => {
+    userCount = 100;
+    const app = buildApp({ enabled: false });
+    const res = await request(app).post("/api/auth/sign-up/email").send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("ignores non-signup auth paths (sign-in, callback, etc)", async () => {
+    userCount = 5;
+    const app = buildApp({ enabled: true });
+    for (const p of [
+      "/api/auth/sign-in/email",
+      "/api/auth/get-session",
+      "/api/auth/callback/google",
+    ]) {
+      const res = await request(app).post(p).send({});
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("does not affect non-auth routes regardless of seat count", async () => {
+    userCount = 999;
+    const app = buildApp({ enabled: true });
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,6 +9,7 @@ import { httpLogger, errorHandler } from "./middleware/index.js";
 import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
+import { freeSeatCapMiddleware } from "./middleware/free-seat-cap.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
@@ -120,6 +121,9 @@ export async function createApp(
     // AgentDash (AGE-60): on Pro deployments, require a corp-email creator
     // for new companies. Self-hosted Free leaves this off.
     requireCorpEmail?: boolean;
+    // AgentDash (AGE-100): Free single-seat cap — block 2nd signup on
+    // self-hosted Free with HTTP 403 free_tier_seat_cap.
+    freeSeatCap?: boolean;
     instanceId?: string;
     hostVersion?: string;
     localPluginDir?: string;
@@ -183,6 +187,11 @@ export async function createApp(
     });
   });
   if (opts.betterAuthHandler) {
+    // AgentDash (AGE-100): seat-cap gate runs before the better-auth handler
+    // so we can short-circuit before better-auth's internal signup flow.
+    app.use(
+      freeSeatCapMiddleware(db, { enabled: opts.freeSeatCap ?? false }),
+    );
     app.all("/api/auth/*authPath", opts.betterAuthHandler);
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -545,6 +545,8 @@ export async function startServer(): Promise<StartedServer> {
     // AgentDash (AGE-60): Pro deployments enforce corp-email signup; Free
     // (local_trusted) does not.
     requireCorpEmail: config.deploymentMode === "authenticated",
+    // AgentDash (AGE-100): Free deployments cap to one human user.
+    freeSeatCap: config.deploymentMode === "local_trusted",
     betterAuthHandler,
     resolveSession,
     // AgentDash (AGE-59): wire email backend from config

--- a/server/src/middleware/free-seat-cap.ts
+++ b/server/src/middleware/free-seat-cap.ts
@@ -1,0 +1,49 @@
+// AgentDash (AGE-100): Free single-seat cap.
+//
+// Self-hosted Free deployments support exactly one human user. The first
+// signup succeeds; subsequent signups are blocked with HTTP 403 and a
+// friendly upgrade CTA so the UI can prompt to switch to Pro.
+//
+// Local-implicit board actor (CLI / dev) is exempt — it has no email and
+// doesn't go through the better-auth signup endpoints anyway.
+//
+// Pro deployments (deploymentMode === "authenticated") leave this gate off
+// because Pro orgs intentionally have more than one human.
+
+import type { RequestHandler } from "express";
+import { count } from "drizzle-orm";
+import type { Db } from "@agentdash/db";
+import { authUsers } from "@agentdash/db";
+
+export interface FreeSeatCapOptions {
+  enabled: boolean;
+}
+
+const SIGNUP_PATH_PREFIX = "/api/auth/sign-up";
+
+export function freeSeatCapMiddleware(db: Db, options: FreeSeatCapOptions): RequestHandler {
+  return async (req, res, next) => {
+    if (!options.enabled) return next();
+    if (!req.path.startsWith(SIGNUP_PATH_PREFIX)) return next();
+
+    try {
+      const [{ value }] = await db
+        .select({ value: count() })
+        .from(authUsers);
+      if ((value ?? 0) >= 1) {
+        res.status(403).json({
+          code: "free_tier_seat_cap",
+          error:
+            "Self-hosted Free supports one human user. Upgrade to Pro to invite teammates.",
+        });
+        return;
+      }
+    } catch (err) {
+      // If the seat-count query itself fails, surface a generic error rather
+      // than letting better-auth proceed silently. Log via next() so the
+      // upstream error handler picks it up.
+      return next(err);
+    }
+    next();
+  };
+}


### PR DESCRIPTION
Closes [AGE-100](https://linear.app/agentdash/issue/AGE-100). Followup to [AGE-60](https://linear.app/agentdash/issue/AGE-60).

Self-hosted Free deployments cap signup to 1 user. The 2nd signup attempt returns HTTP 403 `free_tier_seat_cap` with a friendly upgrade CTA. Pro deployments are unaffected (gate auto-disables when deploymentMode='authenticated'). local_implicit (CLI/dev) is exempt.

Implementation: tiny middleware in server/src/middleware/free-seat-cap.ts mounted before the better-auth handler. 6 vitest cases covering 1st-signup success, 2nd-signup block, non-signup pass-through, and Pro disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)