### PR TITLE
feat(ui): inline error copy for AGE-60/AGE-100 signup gate codes (AGE-101)

### DIFF
--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -24,6 +24,20 @@ function toSession(value: unknown): AuthSession | null {
   };
 }
 
+// AgentDash (AGE-101): typed auth error so the signup form can recognize
+// AGE-60 (pro_requires_corp_email) and AGE-100 (free_tier_seat_cap) codes
+// and render an inline upgrade CTA instead of a generic toast.
+export class AuthRequestError extends Error {
+  readonly code: string | null;
+  readonly status: number;
+  constructor(message: string, code: string | null, status: number) {
+    super(message);
+    this.name = "AuthRequestError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
 async function authPost(path: string, body: Record<string, unknown>) {
   const res = await fetch(`/api/auth${path}`, {
     method: "POST",
@@ -38,7 +52,11 @@ async function authPost(path: string, body: Record<string, unknown>) {
       typeof (payload as { error?: { message?: string } | string }).error === "object"
         ? ((payload as { error?: { message?: string } }).error?.message ?? `Request failed: ${res.status}`)
         : (payload as { error?: string } | null)?.error ?? `Request failed: ${res.status}`;
-    throw new Error(message);
+    const code =
+      typeof (payload as { code?: unknown } | null)?.code === "string"
+        ? ((payload as { code: string }).code)
+        : null;
+    throw new AuthRequestError(message, code, res.status);
   }
   return payload;
 }

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -88,6 +88,21 @@ export function AuthPage() {
       navigate(nextPath, { replace: true });
     },
     onError: (err) => {
+      // AgentDash (AGE-101): translate AGE-60 / AGE-100 server codes to
+      // friendlier inline copy instead of dumping the raw server message.
+      const code = (err as { code?: unknown }).code;
+      if (code === "pro_requires_corp_email") {
+        setError(
+          "Pro accounts require a company email. Please sign up with your work email or use the Free self-hosted plan.",
+        );
+        return;
+      }
+      if (code === "free_tier_seat_cap") {
+        setError(
+          "Self-hosted Free supports one human user. Upgrade to Pro to invite teammates.",
+        );
+        return;
+      }
       setError(err instanceof Error ? err.message : "Authentication failed");
     },
   });


### PR DESCRIPTION
Closes [AGE-101](https://linear.app/agentdash/issue/AGE-101).

Auth.tsx now translates the two server gate codes (`pro_requires_corp_email` from AGE-60, `free_tier_seat_cap` from AGE-100) to friendlier inline copy instead of the raw better-auth error string.

Implementation: tiny change to ui/src/api/auth.ts (new `AuthRequestError` class attaching `code`/`status`), and Auth.tsx `onError` switching on `err.code` before falling back to `err.message`.

UI typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)