### PR TITLE
test(server): remove vi.resetModules() polluter — fixes 6 of 7 named AGE-84 failures

### DIFF
--- a/server/src/__tests__/company-portability-routes.test.ts
+++ b/server/src/__tests__/company-portability-routes.test.ts
@@ -1,6 +1,8 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { companyRoutes } from "../routes/companies.js";
+import { errorHandler } from "../middleware/index.js";
 
 const mockCompanyService = vi.hoisted(() => ({
   list: vi.fn(),
@@ -49,9 +51,7 @@ vi.mock("../services/index.js", () => ({
   logActivity: mockLogActivity,
 }));
 
-async function createApp(actor: Record<string, unknown>) {
-  const { companyRoutes } = await import("../routes/companies.js");
-  const { errorHandler } = await import("../middleware/index.js");
+function createApp(actor: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -65,7 +65,11 @@ async function createApp(actor: Record<string, unknown>) {
 
 describe("company portability routes", () => {
   beforeEach(() => {
-    vi.resetModules();
+    // AGE-84: removed `vi.resetModules()` here. It was clearing the module
+    // registry mid-suite for the entire vitest worker, leaking state across
+    // unrelated test files. Mocks are reset per-test via `mockReset()` calls
+    // below; module-level imports are now static (above) so the `vi.mock`
+    // factory binds before any test consumes the routes.
     mockAgentService.getById.mockReset();
     mockCompanyPortabilityService.exportBundle.mockReset();
     mockCompanyPortabilityService.previewExport.mockReset();
@@ -80,7 +84,7 @@ describe("company portability routes", () => {
       companyId: "11111111-1111-4111-8111-111111111111",
       role: "engineer",
     });
-    const app = await createApp({
+    const app = createApp({
       type: "agent",
       agentId: "agent-1",
       companyId: "11111111-1111-4111-8111-111111111111",
@@ -112,7 +116,7 @@ describe("company portability routes", () => {
       warnings: [],
       paperclipExtensionPath: ".paperclip.yaml",
     });
-    const app = await createApp({
+    const app = createApp({
       type: "agent",
       agentId: "agent-1",
       companyId: "11111111-1111-4111-8111-111111111111",
@@ -136,7 +140,7 @@ describe("company portability routes", () => {
       companyId: "11111111-1111-4111-8111-111111111111",
       role: "chief_of_staff",
     });
-    const app = await createApp({
+    const app = createApp({
       type: "agent",
       agentId: "agent-1",
       companyId: "11111111-1111-4111-8111-111111111111",
@@ -159,7 +163,7 @@ describe("company portability routes", () => {
   });
 
   it("keeps global import preview routes board-only", async () => {
-    const app = await createApp({
+    const app = createApp({
       type: "agent",
       agentId: "agent-1",
       companyId: "11111111-1111-4111-8111-111111111111",


### PR DESCRIPTION
## Summary

Fixes the primary polluter from [AGE-84](https://linear.app/agentdash/issue/AGE-84) (Vitest test pollution — 7 server route tests fail in full suite, pass in isolation).

`server/src/__tests__/company-portability-routes.test.ts` was calling `vi.resetModules()` in its `beforeEach` and using `await import()` inside `createApp()` to dynamically reload the routes module per test. The reset busted vitest's module registry mid-suite for the entire worker, leaking state across other test files that ran in the same worker afterward — producing the cross-file pollution AGE-84 documented (entitlements, issue-closed-workspace, routines, security-routes failures with mocks returning `undefined`).

## Changes
- Hoists `companyRoutes` and `errorHandler` imports to module top so the `vi.mock("../services/index.js")` factory binds before any test consumes the routes.
- Removes `vi.resetModules()` from `beforeEach` — per-mock `mockReset()` calls already cover what the test actually needed.
- Keeps `createApp()` synchronous since dynamic imports were only required by the now-unnecessary module reset pattern.

## Impact

Server suite goes from **8 reliably failing tests** (baseline on \`agentdash-main\`) to **2 reliably failing tests** after this change.

### Originally-named AGE-84 failures (4 files, 7 tests):
- ✅ \`entitlements-routes.test.ts\` — "forwards the companyId from the URL path to the service"
- ✅ \`issue-closed-workspace-routes.test.ts\` — "rejects new issue comments when the linked isolated workspace is closed"
- ✅ \`routines-routes.test.ts\` — "requires tasks:assign permission for non-admin board routine creation"
- ⚠️ \`security-routes.test.ts\` — the named "deactivate" test passes; a different test in the same file (\`sandbox configureSandbox\`) sometimes flakes from broader pollution (see Out of Scope).

### Remaining 2 failures
Both fail in isolation as well — they are pre-existing test bugs unrelated to this polluter:
- \`feedback-service.test.ts > feedbackService.saveIssueVote\`
- \`heartbeat-comment-wake-batching.test.ts > heartbeat comment wake batching\`

### Non-deterministic flakes (run-dependent)
Two tests flake across runs from other files' shared \`vi.mock("../services/index.js")\` factories with conflicting partial shapes:
- \`instance-settings-routes.test.ts\`
- \`kpi-routes.test.ts\`

This is a broader systemic issue (~30 server route test files mock the same module path with mutually incompatible factory subsets) requiring a dedicated refactor — filed as follow-up.

## Out of scope (filed as follow-up)

The full systemic refactor of \`vi.mock("../services/index.js")\` across 30 files — and other shared mock paths like \`../services/entitlements.js\`, \`../services/policy-engine.js\` — is L/XL effort and needs:
1. An auto-vivifying mock helper at \`server/src/services/__mocks__/index.ts\` (a prototype was built during this work but reverted because the partial migration introduced subtler module-level state-sharing issues).
2. Per-file beforeEach discipline (\`vi.resetAllMocks()\` + explicit re-establish of custom impls).

A separate Linear issue tracks this work.

## Test plan
- [x] \`pnpm --filter @agentdash/server exec vitest run src/__tests__/company-portability-routes.test.ts\` — 4/4 pass in isolation
- [x] \`pnpm -r typecheck\` — passes
- [x] \`pnpm build\` — passes
- [x] \`pnpm test:run\` — 2 reliable failures (down from 8 baseline) + 2 non-deterministic flakes from out-of-scope pollution
- [ ] CI green on this PR (follow-up commits if any tests regress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)