### PR TITLE
chore(ci): allow pnpm-lock.yaml in PRs when package.json also changed (AGE-97)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,13 +20,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Block manual lockfile edits
+      - name: Block manual lockfile-only edits
         if: github.head_ref != 'chore/refresh-lockfile'
         run: |
           changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
           if printf '%s\n' "$changed" | grep -qx 'pnpm-lock.yaml'; then
-            echo "Do not commit pnpm-lock.yaml in pull requests. CI owns lockfile updates."
-            exit 1
+            # Lockfile is allowed when accompanied by a package.json change
+            # (legitimate dependency add/update). Lockfile-only PRs must come
+            # from the dedicated chore/refresh-lockfile branch (already exempt
+            # via the `if` above). AGE-97 follow-up.
+            if printf '%s\n' "$changed" | grep -qE '(^|/)package\.json$'; then
+              echo "pnpm-lock.yaml change accompanies a package.json change — allowed."
+            else
+              echo "Do not commit pnpm-lock.yaml in pull requests without a corresponding package.json change. CI owns lockfile-only updates."
+              exit 1
+            fi
           fi
 
       - name: Setup pnpm


### PR DESCRIPTION
## Summary

Closes the [AGE-97](https://linear.app/agentdash/issue/AGE-97) catch-22 by loosening the lockfile-policy rule in \`.github/workflows/pr.yml\`.

The PR policy check previously rejected ANY \`pnpm-lock.yaml\` diff in feature PRs, with the rationale that "CI owns lockfile updates" via the \`refresh-lockfile\` workflow. But that workflow only handles the *lockfile-only* case (e.g. weekly drift autobump). It cannot help with the legitimate case of a feature PR adding a dependency to \`package.json\` — which **requires** the lockfile to be updated in the same commit so \`pnpm install --frozen-lockfile\` succeeds in \`verify\` and \`e2e\` jobs.

The intent of the rule was to catch *manual lockfile-only edits* (drift), not block real dependency additions.

## Changes

- \`pnpm-lock.yaml\` + \`package.json\` in the diff → **allowed** (legitimate dep change)
- \`pnpm-lock.yaml\` alone in the diff → still blocked (CI handles via \`refresh-lockfile\`)
- \`chore/refresh-lockfile\` branch → still exempt (existing behavior)

## Pairing with the repo setting toggle

This pairs with the GitHub repo Settings → Actions → "Allow GitHub Actions to create and approve pull requests" toggle that was just enabled. Together they unblock PR #58 (marketing landing page) which was stuck because the work added 3 font dependencies to \`ui/package.json\`, the matching lockfile update couldn't land without violating policy, and the \`refresh-lockfile\` workflow couldn't open its own PR because of the repo setting.

After this lands:
1. The PR #58 author can re-run \`pnpm install\` locally
2. Commit the regenerated \`pnpm-lock.yaml\`
3. Force-push their branch
4. \`policy\` ✅ (lockfile + package.json both in diff)
5. \`verify\` + \`e2e\` ✅ (frozen-lockfile install succeeds)

## Test plan

- [x] Diff verified locally — `.github/workflows/pr.yml` only
- [x] Logic traced for the three cases (lockfile+package.json, lockfile-only, refresh-lockfile branch)
- [ ] CI passes on this PR (no lockfile change here, so the existing rule still applies and should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)