### PR TITLE
fix(server): allow self-serve company creation without instance-admin role (AGE-104)

### DIFF
--- a/server/src/__tests__/companies-email-domain-route.test.ts
+++ b/server/src/__tests__/companies-email-domain-route.test.ts
@@ -11,11 +11,16 @@ import { companyRoutes } from "../routes/companies.js";
 import { errorHandler } from "../middleware/error-handler.js";
 import { DomainAlreadyClaimedError } from "../services/companies.js";
 
+// AGE-104: a freshly signed-up user has isInstanceAdmin=false. The route
+// must allow them to create their first company; downstream rules
+// (free-mail block, domain uniqueness, ensureMembership=owner) handle the
+// real business logic. Setting this to `true` in earlier tests masked the
+// "Instance admin required" regression.
 const ACTOR = {
   type: "board" as const,
   userId: "user-1",
   companyIds: [],
-  isInstanceAdmin: true,
+  isInstanceAdmin: false,
   source: "session" as const,
 };
 
@@ -185,6 +190,29 @@ describe("POST /api/companies — FRE Plan B email_domain (AGE-55)", () => {
     expect(res.status).toBe(201);
     expect(findByEmailDomainMock).not.toHaveBeenCalled();
     expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ emailDomain: "acme.com" }));
+  });
+
+  it("AGE-104: a non-admin signed-up user can create their first company and is promoted to owner", async () => {
+    findByEmailDomainMock.mockResolvedValue(null);
+    createMock.mockResolvedValue({
+      id: "company-fre",
+      name: "Acme",
+      budgetMonthlyCents: 0,
+      emailDomain: "acme.com",
+    });
+
+    // ACTOR has isInstanceAdmin: false (set at the top of the file).
+    const app = buildApp({ actorEmail: acmeUser.email });
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(ensureMembershipMock).toHaveBeenCalledWith(
+      "company-fre",
+      "user",
+      "user-1",
+      "owner",
+      "active",
+    );
   });
 
   it("local_implicit actors (no email) leave email_domain NULL", async () => {

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -281,9 +281,11 @@ export function companyRoutes(
 
   router.post("/", validate(createCompanySchema), async (req, res) => {
     assertBoard(req);
-    if (!(req.actor.source === "local_implicit" || req.actor.isInstanceAdmin)) {
-      throw forbidden("Instance admin required");
-    }
+    // AgentDash (AGE-104): no instance-admin gate here. The FRE Plan B
+    // contract (AGE-55) is that any authenticated board user can create
+    // their first company and is promoted to `owner` membership below.
+    // Free-mail rejection (AGE-60), domain uniqueness (AGE-55), and the
+    // free single-seat cap (AGE-100) are the real safeguards.
 
     // AgentDash (AGE-55): FRE Plan B — derive email_domain from the creator's
     // authenticated email. local_implicit actors (single-machine dev) have no


### PR DESCRIPTION
## Summary

`POST /api/companies` was gated behind `isInstanceAdmin || local_implicit`. In `authenticated` mode (Pro / WorkOS), freshly signed-up users have no `instance_user_roles` row, so the OnboardingWizard step 1 always failed with **"Instance admin required"** before they could create their first company.

The route's downstream code is already built for self-serve creation under FRE Plan B (AGE-55): it derives `email_domain` from the creator, blocks free-mail on Pro (AGE-60), enforces single-tenant-per-domain, and promotes the creator to `"owner"` via `ensureMembership`. The gate predated AGE-55 and was never relaxed; the existing route test passed only because its mock actor set `isInstanceAdmin: true`.

## Changes

- `server/src/routes/companies.ts` — remove the four-line admin gate from `POST /`. `assertBoard()` still requires an authenticated session.
- `server/src/__tests__/companies-email-domain-route.test.ts` — flip mock `isInstanceAdmin` to `false` so the existing FRE-Plan-B tests now actually exercise the non-admin path, plus a new AGE-104 regression test asserting a non-admin user creates their first company and is promoted to owner.

## Test plan

- [x] `companies-email-domain-route.test.ts` 7/7 green (was masked at 6/6 with the wrong actor)
- [x] `pnpm -r typecheck` passes
- [x] `pnpm test:run` — 1664/1668 pass; 4 pre-existing failures (`company-skills-routes`, `routines-e2e`, `skills-registry-routes`) unrelated to company-creation
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)