### PR TITLE
fix(server): block free-mail signups at signup time on Pro (AGE-104)

### DIFF
--- a/server/src/__tests__/companies-email-domain-route.test.ts
+++ b/server/src/__tests__/companies-email-domain-route.test.ts
@@ -11,11 +11,16 @@ import { companyRoutes } from "../routes/companies.js";
 import { errorHandler } from "../middleware/error-handler.js";
 import { DomainAlreadyClaimedError } from "../services/companies.js";
 
+// AGE-104: a freshly signed-up user has isInstanceAdmin=false. The route
+// must allow them to create their first company; downstream rules
+// (free-mail block, domain uniqueness, ensureMembership=owner) handle the
+// real business logic. Setting this to `true` in earlier tests masked the
+// "Instance admin required" regression.
 const ACTOR = {
   type: "board" as const,
   userId: "user-1",
   companyIds: [],
-  isInstanceAdmin: true,
+  isInstanceAdmin: false,
   source: "session" as const,
 };
 
@@ -185,6 +190,29 @@ describe("POST /api/companies — FRE Plan B email_domain (AGE-55)", () => {
     expect(res.status).toBe(201);
     expect(findByEmailDomainMock).not.toHaveBeenCalled();
     expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ emailDomain: "acme.com" }));
+  });
+
+  it("AGE-104: a non-admin signed-up user can create their first company and is promoted to owner", async () => {
+    findByEmailDomainMock.mockResolvedValue(null);
+    createMock.mockResolvedValue({
+      id: "company-fre",
+      name: "Acme",
+      budgetMonthlyCents: 0,
+      emailDomain: "acme.com",
+    });
+
+    // ACTOR has isInstanceAdmin: false (set at the top of the file).
+    const app = buildApp({ actorEmail: acmeUser.email });
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(ensureMembershipMock).toHaveBeenCalledWith(
+      "company-fre",
+      "user",
+      "user-1",
+      "owner",
+      "active",
+    );
   });
 
   it("local_implicit actors (no email) leave email_domain NULL", async () => {

--- a/server/src/__tests__/corp-email-signup-guard.test.ts
+++ b/server/src/__tests__/corp-email-signup-guard.test.ts
@@ -1,0 +1,98 @@
+// AgentDash (AGE-104 follow-up): unit tests for the corp-email signup guard.
+// The guard moves the AGE-60 rule from company-creation to the signup
+// endpoint so users see "use your work email" BEFORE they have an account
+// stuck in a dead end.
+
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { corpEmailSignupGuard } from "../middleware/corp-email-signup-guard.js";
+
+function buildApp(opts: { enabled: boolean }) {
+  const app = express();
+  app.use(express.json());
+  app.use(corpEmailSignupGuard(opts));
+  // Stand-in for the real better-auth handler — proves the guard short-circuits.
+  app.all("/api/auth/*authPath", (_req, res) => {
+    res.status(201).json({ ok: true });
+  });
+  app.use((_req, res) => {
+    res.status(404).json({ error: "not found" });
+  });
+  return app;
+}
+
+describe("corpEmailSignupGuard (AGE-104 follow-up)", () => {
+  it("blocks free-mail signup with pro_requires_corp_email when enabled", async () => {
+    const app = buildApp({ enabled: true });
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .send({ name: "Jane", email: "jane@gmail.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      code: "pro_requires_corp_email",
+      error:
+        "Pro accounts require a company email. Please sign up with your work email or use the Free self-hosted plan.",
+    });
+  });
+
+  it("treats the FREE_MAIL_DOMAINS list case-insensitively", async () => {
+    const app = buildApp({ enabled: true });
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .send({ name: "Jane", email: "Jane@YAHOO.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("pro_requires_corp_email");
+  });
+
+  it("lets corp-email signups through to better-auth", async () => {
+    const app = buildApp({ enabled: true });
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .send({ name: "Jane", email: "jane@acme.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("passes through when disabled (Free / local-trusted deployment)", async () => {
+    const app = buildApp({ enabled: false });
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .send({ name: "Jane", email: "jane@gmail.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("does not interfere with sign-in or other auth paths", async () => {
+    const app = buildApp({ enabled: true });
+    const res = await request(app)
+      .post("/api/auth/sign-in/email")
+      .send({ email: "jane@gmail.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("ignores requests with no email field (lets better-auth respond)", async () => {
+    const app = buildApp({ enabled: true });
+    const res = await request(app).post("/api/auth/sign-up/email").send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("does not block malformed emails (no @) — better-auth will reject them", async () => {
+    const app = buildApp({ enabled: true });
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .send({ name: "Jane", email: "not-an-email", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/server/src/__tests__/pro-signup-flow.test.ts
+++ b/server/src/__tests__/pro-signup-flow.test.ts
@@ -1,0 +1,213 @@
+// AgentDash (AGE-104 follow-up): real end-to-end Pro signup integration test.
+//
+// This test spins up an embedded PostgreSQL, mounts the FULL middleware
+// chain in the same order app.ts does, and uses a real Better Auth
+// instance — not a stub. It exercises the journey that user-reported
+// regressions kept slipping through:
+//
+//   1. Pro signup with a free-mail address must be blocked at the
+//      /api/auth/sign-up/email endpoint with pro_requires_corp_email,
+//      AND no row in auth_users may be created.
+//   2. Pro signup with a corp email must succeed and the user must end
+//      up able to create their first company.
+//   3. The new company creator must be promoted to "owner" (FRE Plan B).
+//
+// If any of these fails, the regression that triggered PR #65 + PR #66
+// is back. Reverting either fix turns this test red.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express, { Router, type Request as ExpressRequest } from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import {
+  authUsers,
+  companies,
+  companyMemberships,
+  createDb,
+} from "@agentdash/db";
+import {
+  createBetterAuthHandler,
+  createBetterAuthInstance,
+  resolveBetterAuthSession,
+  type BetterAuthSessionResult,
+} from "../auth/better-auth.js";
+import type { Config } from "../config.js";
+import { actorMiddleware } from "../middleware/auth.js";
+import { boardMutationGuard } from "../middleware/board-mutation-guard.js";
+import { corpEmailSignupGuard } from "../middleware/corp-email-signup-guard.js";
+import { freeSeatCapMiddleware } from "../middleware/free-seat-cap.js";
+import { errorHandler } from "../middleware/error-handler.js";
+import { companyRoutes } from "../routes/companies.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const TEST_ORIGIN = "http://127.0.0.1:3100";
+const TEST_HOST = "127.0.0.1:3100";
+
+const support = await getEmbeddedPostgresTestSupport();
+const describeIt = support.supported ? describe : describe.skip;
+
+if (!support.supported) {
+  console.warn(
+    `Skipping Pro signup flow integration test on this host: ${support.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeIt("Pro signup → first company end-to-end (AGE-104)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let app!: express.Express;
+  let originalSecret: string | undefined;
+
+  beforeAll(async () => {
+    originalSecret = process.env.BETTER_AUTH_SECRET;
+    process.env.BETTER_AUTH_SECRET = "test-better-auth-secret-32-chars-min-foobar";
+
+    tempDb = await startEmbeddedPostgresTestDatabase("agentdash-pro-signup-flow-");
+    db = createDb(tempDb.connectionString);
+
+    const config = {
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      authBaseUrlMode: "derive_from_request",
+      authPublicBaseUrl: undefined,
+      authDisableSignUp: false,
+      allowedHostnames: ["127.0.0.1", "localhost"],
+    } as unknown as Config;
+
+    const auth = createBetterAuthInstance(db as never, config, [
+      "http://127.0.0.1:3100",
+      "http://localhost:3100",
+    ]);
+    const betterAuthHandler = createBetterAuthHandler(auth);
+    const resolveSession = (req: ExpressRequest) =>
+      resolveBetterAuthSession(auth, req) as Promise<BetterAuthSessionResult | null>;
+
+    app = express();
+    app.use(express.json());
+    app.use(
+      actorMiddleware(db as never, {
+        deploymentMode: "authenticated",
+        resolveSession,
+      }),
+    );
+    // Same order as production app.ts:
+    app.use(freeSeatCapMiddleware(db as never, { enabled: false }));
+    app.use(corpEmailSignupGuard({ enabled: true }));
+    app.all("/api/auth/*authPath", betterAuthHandler);
+
+    const api = Router();
+    api.use(boardMutationGuard());
+    api.use(
+      "/companies",
+      companyRoutes(db as never, undefined, {
+        allowMultiTenantPerDomain: false,
+        requireCorpEmail: true,
+      }),
+    );
+    app.use("/api", api);
+    app.use(errorHandler);
+  }, 60_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+    if (originalSecret === undefined) {
+      delete process.env.BETTER_AUTH_SECRET;
+    } else {
+      process.env.BETTER_AUTH_SECRET = originalSecret;
+    }
+  });
+
+  it("blocks gmail signup with pro_requires_corp_email and creates no auth_users row", async () => {
+    const before = await db.select().from(authUsers);
+    const beforeCount = before.length;
+
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .set("Origin", TEST_ORIGIN)
+      .set("Host", TEST_HOST)
+      .send({ name: "Jane", email: "jane@gmail.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      code: "pro_requires_corp_email",
+      error:
+        "Pro accounts require a company email. Please sign up with your work email or use the Free self-hosted plan.",
+    });
+
+    const after = await db.select().from(authUsers);
+    expect(after.length).toBe(beforeCount);
+  });
+
+  it("blocks yahoo signup case-insensitively (defense against domain casing tricks)", async () => {
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .set("Origin", TEST_ORIGIN)
+      .set("Host", TEST_HOST)
+      .send({ name: "Jane", email: "Jane@YAHOO.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("pro_requires_corp_email");
+  });
+
+  it("corp signup creates a real auth_users row and lets the new user create their first company as owner", async () => {
+    // 1. Sign up with a corp email — must succeed end-to-end (real Better Auth).
+    const signupRes = await request(app)
+      .post("/api/auth/sign-up/email")
+      .set("Origin", TEST_ORIGIN)
+      .set("Host", TEST_HOST)
+      .send({
+        name: "Alice Acme",
+        email: "alice@acme.example",
+        password: "hunter2hunter2",
+      });
+
+    expect(signupRes.status).toBe(200);
+    const setCookieHeader = signupRes.headers["set-cookie"];
+    expect(setCookieHeader).toBeTruthy();
+    const cookieJar = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader];
+
+    const userRows = await db
+      .select()
+      .from(authUsers)
+      .where(eq(authUsers.email, "alice@acme.example"));
+    expect(userRows).toHaveLength(1);
+    const userId = userRows[0]!.id;
+
+    // 2. Create a company with the resulting session — proves PR #65 + #66 work
+    //    together: no admin gate, no late-firing free-mail block, owner promo.
+    const createRes = await request(app)
+      .post("/api/companies")
+      .set("Origin", TEST_ORIGIN)
+      .set("Host", TEST_HOST)
+      .set("Cookie", cookieJar)
+      .send({ name: "Acme Inc" });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body).toMatchObject({
+      name: "Acme Inc",
+      emailDomain: "acme.example",
+    });
+
+    // 3. The creator must be the company owner.
+    const memberships = await db
+      .select()
+      .from(companyMemberships)
+      .where(eq(companyMemberships.principalId, userId));
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0]).toMatchObject({
+      principalType: "user",
+      membershipRole: "owner",
+      status: "active",
+    });
+
+    // Sanity: the company actually exists.
+    const companyRows = await db
+      .select()
+      .from(companies)
+      .where(eq(companies.id, createRes.body.id));
+    expect(companyRows).toHaveLength(1);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { freeSeatCapMiddleware } from "./middleware/free-seat-cap.js";
+import { corpEmailSignupGuard } from "./middleware/corp-email-signup-guard.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
@@ -191,6 +192,12 @@ export async function createApp(
     // so we can short-circuit before better-auth's internal signup flow.
     app.use(
       freeSeatCapMiddleware(db, { enabled: opts.freeSeatCap ?? false }),
+    );
+    // AgentDash (AGE-104 follow-up): block free-mail signups on Pro at the
+    // signup endpoint itself, not at company-creation time. Same rule as
+    // AGE-60 but surfaced before the user has an account they can't use.
+    app.use(
+      corpEmailSignupGuard({ enabled: opts.requireCorpEmail ?? false }),
     );
     app.all("/api/auth/*authPath", opts.betterAuthHandler);
   }

--- a/server/src/middleware/corp-email-signup-guard.ts
+++ b/server/src/middleware/corp-email-signup-guard.ts
@@ -1,0 +1,50 @@
+// AgentDash (AGE-104 follow-up): corp-email signup guard.
+//
+// Pro deployments (deploymentMode === "authenticated") reject signups from
+// free-mail providers (gmail, yahoo, outlook, ...). Until now this only
+// fired at company-creation time (AGE-60), which surfaced the error AFTER
+// the user had already created an account — too late to act on the
+// "use your work email" hint. This middleware moves the same rule to the
+// signup endpoint so the friendly inline error renders BEFORE the user
+// commits to an account.
+//
+// The Auth.tsx form already maps the `pro_requires_corp_email` code to a
+// dedicated inline message (see ui/src/pages/Auth.tsx).
+
+import type { RequestHandler } from "express";
+import { FREE_MAIL_DOMAINS } from "@agentdash/shared";
+
+export interface CorpEmailSignupGuardOptions {
+  enabled: boolean;
+}
+
+const SIGNUP_PATH_PREFIX = "/api/auth/sign-up";
+
+export function corpEmailSignupGuard(options: CorpEmailSignupGuardOptions): RequestHandler {
+  return (req, res, next) => {
+    if (!options.enabled) return next();
+    if (!req.path.startsWith(SIGNUP_PATH_PREFIX)) return next();
+
+    const email = readEmailFromBody(req.body);
+    if (!email) return next();
+
+    const at = email.lastIndexOf("@");
+    if (at < 0) return next();
+    const domain = email.slice(at + 1).trim().toLowerCase();
+    if (!FREE_MAIL_DOMAINS.has(domain)) return next();
+
+    res.status(400).json({
+      code: "pro_requires_corp_email",
+      error:
+        "Pro accounts require a company email. Please sign up with your work email or use the Free self-hosted plan.",
+    });
+  };
+}
+
+function readEmailFromBody(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const candidate = (body as Record<string, unknown>).email;
+  if (typeof candidate !== "string") return null;
+  const trimmed = candidate.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -281,9 +281,11 @@ export function companyRoutes(
 
   router.post("/", validate(createCompanySchema), async (req, res) => {
     assertBoard(req);
-    if (!(req.actor.source === "local_implicit" || req.actor.isInstanceAdmin)) {
-      throw forbidden("Instance admin required");
-    }
+    // AgentDash (AGE-104): no instance-admin gate here. The FRE Plan B
+    // contract (AGE-55) is that any authenticated board user can create
+    // their first company and is promoted to `owner` membership below.
+    // Free-mail rejection (AGE-60), domain uniqueness (AGE-55), and the
+    // free single-seat cap (AGE-100) are the real safeguards.
 
     // AgentDash (AGE-55): FRE Plan B — derive email_domain from the creator's
     // authenticated email. local_implicit actors (single-machine dev) have no


### PR DESCRIPTION
## Summary

Follow-up to #65. After that PR opened up `POST /api/companies` for non-admin users, free-mail accounts (gmail, yahoo, …) on Pro deployments hit the wizard's "name your company" step and got the AGE-60 message **"Pro accounts require a company email"** — pointing at an email field that wasn't even on screen, with no recovery path because the user was already signed up.

This moves the same rule to the place users can actually act on it: the signup endpoint itself.

## Changes

- `server/src/middleware/corp-email-signup-guard.ts` — new middleware. When `requireCorpEmail` is on (Pro), intercepts `POST /api/auth/sign-up/*`, reads `email` from the body, and returns 400 with `code: pro_requires_corp_email` if the domain is in `FREE_MAIL_DOMAINS`. Otherwise passes through to better-auth.
- `server/src/app.ts` — mount it next to `freeSeatCapMiddleware`, before the better-auth handler. Reuses the existing `requireCorpEmail` flag (already wired from `index.ts`).
- `server/src/__tests__/corp-email-signup-guard.test.ts` — 7 cases: blocks gmail/yahoo, case-insensitive domain match, lets corp emails through, no-op when disabled, doesn't touch sign-in or other paths, ignores missing/malformed emails.

The downstream gate in `companies.ts` stays in place as defense-in-depth for WorkOS-webhook-created users who bypass the better-auth signup endpoint.

`Auth.tsx` already maps `pro_requires_corp_email` to friendly inline copy (AGE-101) — no UI change needed.

## Test plan

- [x] `corp-email-signup-guard.test.ts` 7/7 green
- [x] `pnpm -r typecheck` passes
- [x] `pnpm test:run` — 1670/1675 pass; 5 failures are pre-existing flakes (autoresearch, billing, budget, crm, issue-routes), none in files I touched
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)