### PR TITLE
feat(onboarding): consolidate to one frictionless first-run flow (AGE-104)

### DIFF
--- a/server/src/__tests__/companies-email-domain-route.test.ts
+++ b/server/src/__tests__/companies-email-domain-route.test.ts
@@ -215,6 +215,82 @@ describe("POST /api/companies — FRE Plan B email_domain (AGE-55)", () => {
     );
   });
 
+  it("AGE-104 frictionless: a free-mail user with NO existing companies can create their first personal workspace even with requireCorpEmail=true", async () => {
+    // Legacy WorkOS-webhook-created users (or anyone who slipped past the
+    // signup-time corp-email guard) must have a forward path.
+    findByEmailDomainMock.mockResolvedValue(null);
+    createMock.mockResolvedValue({
+      id: "company-personal",
+      name: "Personal",
+      budgetMonthlyCents: 0,
+      emailDomain: "alice@gmail.com",
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "user-1",
+        companyIds: [], // <-- no existing companies
+        isInstanceAdmin: false,
+        source: "session",
+      };
+      next();
+    });
+    app.use("/api/companies", companyRoutes(fakeDb, undefined, {
+      allowMultiTenantPerDomain: false,
+      requireCorpEmail: true, // Pro deployment
+    }));
+    app.use(errorHandler);
+
+    // Stub authUsers lookup to return gmail
+    fakeDb.select = vi.fn(() => ({
+      from: () => ({
+        where: () => Promise.resolve([{ email: gmailUser.email }]),
+      }),
+    }));
+
+    const res = await request(app).post("/api/companies").send({ name: "Personal" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      emailDomain: "alice@gmail.com",
+    }));
+  });
+
+  it("AGE-104 still gates additional workspaces: a free-mail user WITH an existing company cannot create a second under requireCorpEmail", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "user-1",
+        companyIds: ["company-existing"], // <-- already has one
+        isInstanceAdmin: false,
+        source: "session",
+      };
+      next();
+    });
+    app.use("/api/companies", companyRoutes(fakeDb, undefined, {
+      allowMultiTenantPerDomain: false,
+      requireCorpEmail: true,
+    }));
+    app.use(errorHandler);
+
+    fakeDb.select = vi.fn(() => ({
+      from: () => ({
+        where: () => Promise.resolve([{ email: gmailUser.email }]),
+      }),
+    }));
+
+    const res = await request(app).post("/api/companies").send({ name: "Personal Two" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("pro_requires_corp_email");
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   it("local_implicit actors (no email) leave email_domain NULL", async () => {
     createMock.mockResolvedValue({
       id: "company-local",

--- a/server/src/__tests__/companies-email-domain-route.test.ts
+++ b/server/src/__tests__/companies-email-domain-route.test.ts
@@ -226,6 +226,15 @@ describe("POST /api/companies — FRE Plan B email_domain (AGE-55)", () => {
       emailDomain: "alice@gmail.com",
     });
 
+    // Stub authUsers lookup to return gmail BEFORE mounting routes (mirrors
+    // buildApp ordering — companyRoutes captures the db reference but the
+    // route handler reads db.select at request time).
+    fakeDb.select = vi.fn(() => ({
+      from: () => ({
+        where: () => Promise.resolve([{ email: gmailUser.email }]),
+      }),
+    }));
+
     const app = express();
     app.use(express.json());
     app.use((req, _res, next) => {
@@ -243,13 +252,6 @@ describe("POST /api/companies — FRE Plan B email_domain (AGE-55)", () => {
       requireCorpEmail: true, // Pro deployment
     }));
     app.use(errorHandler);
-
-    // Stub authUsers lookup to return gmail
-    fakeDb.select = vi.fn(() => ({
-      from: () => ({
-        where: () => Promise.resolve([{ email: gmailUser.email }]),
-      }),
-    }));
 
     const res = await request(app).post("/api/companies").send({ name: "Personal" });
 

--- a/server/src/__tests__/signup-pro-free-mail-block.test.ts
+++ b/server/src/__tests__/signup-pro-free-mail-block.test.ts
@@ -1,6 +1,9 @@
-// AgentDash (AGE-60): on Pro deployments, the company-create route blocks
-// free-mail creator emails (gmail/yahoo/etc) with a friendly error so the
-// signup UI can prompt for a corp email instead.
+// AgentDash (AGE-60 + AGE-104): on Pro deployments, the company-create
+// route blocks free-mail creator emails (gmail/yahoo/etc) ONLY when the
+// user is creating an additional workspace. A user's first workspace is
+// always allowed — the signup-time corp-email guard
+// (corp-email-signup-guard.ts) is the real safeguard for new accounts;
+// this route gate exists for legacy accounts that bypassed it.
 //
 // Self-hosted Free leaves the gate off (any email works, single-seat cap
 // is enforced separately).
@@ -12,10 +15,19 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { companyRoutes } from "../routes/companies.js";
 import { errorHandler } from "../middleware/error-handler.js";
 
-const ACTOR = {
+// AGE-104: the gate now keys on whether the user already has a workspace.
+const ACTOR_WITH_EXISTING = {
   type: "board" as const,
   userId: "user-1",
-  companyIds: [],
+  companyIds: ["existing-company"], // <-- already has a workspace
+  isInstanceAdmin: true,
+  source: "session" as const,
+};
+
+const ACTOR_NO_COMPANIES = {
+  type: "board" as const,
+  userId: "user-1",
+  companyIds: [], // <-- first workspace
   isInstanceAdmin: true,
   source: "session" as const,
 };
@@ -71,7 +83,10 @@ vi.mock("../services/index.js", () => ({
 function buildApp(opts: {
   actorEmail?: string;
   requireCorpEmail?: boolean;
-  actor?: typeof ACTOR | typeof LOCAL_ACTOR;
+  actor?:
+    | typeof ACTOR_WITH_EXISTING
+    | typeof ACTOR_NO_COMPANIES
+    | typeof LOCAL_ACTOR;
 }) {
   fakeDb.select = vi.fn(() => ({
     from: () => ({
@@ -81,7 +96,7 @@ function buildApp(opts: {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = opts.actor ?? ACTOR;
+    (req as any).actor = opts.actor ?? ACTOR_WITH_EXISTING;
     next();
   });
   app.use(
@@ -100,28 +115,59 @@ beforeEach(() => {
   ensureMembershipMock = vi.fn().mockResolvedValue({});
 });
 
-describe("POST /api/companies — Pro free-mail block (AGE-60)", () => {
+describe("POST /api/companies — Pro free-mail block (AGE-60 + AGE-104)", () => {
   it.each(["gmail.com", "yahoo.com", "outlook.com", "hotmail.com", "icloud.com"])(
-    "rejects %s with 400 pro_requires_corp_email when requireCorpEmail is on",
+    "rejects ADDITIONAL workspaces from %s with 400 pro_requires_corp_email when requireCorpEmail is on",
     async (domain) => {
-      const app = buildApp({ actorEmail: `alice@${domain}`, requireCorpEmail: true });
+      const app = buildApp({
+        actorEmail: `alice@${domain}`,
+        requireCorpEmail: true,
+        actor: ACTOR_WITH_EXISTING,
+      });
       const res = await request(app).post("/api/companies").send({ name: "Personal" });
 
       expect(res.status).toBe(400);
       expect(res.body.code).toBe("pro_requires_corp_email");
-      expect(res.body.error).toContain("Pro accounts require");
+      expect(res.body.error).toContain("company email");
       expect(createMock).not.toHaveBeenCalled();
     },
   );
 
-  it("allows corp-domain creator when requireCorpEmail is on", async () => {
+  it.each(["gmail.com", "yahoo.com", "outlook.com", "hotmail.com", "icloud.com"])(
+    "AGE-104: ALLOWS the FIRST workspace from %s (legacy account fallback) when requireCorpEmail is on",
+    async (domain) => {
+      createMock.mockResolvedValue({
+        id: "company-fre",
+        name: "Personal",
+        budgetMonthlyCents: 0,
+        emailDomain: `alice@${domain}`,
+      });
+      const app = buildApp({
+        actorEmail: `alice@${domain}`,
+        requireCorpEmail: true,
+        actor: ACTOR_NO_COMPANIES,
+      });
+      const res = await request(app).post("/api/companies").send({ name: "Personal" });
+
+      expect(res.status).toBe(201);
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+        emailDomain: `alice@${domain}`,
+      }));
+    },
+  );
+
+  it("allows corp-domain creator when requireCorpEmail is on (additional workspace)", async () => {
     createMock.mockResolvedValue({
       id: "company-1",
       name: "Acme",
       budgetMonthlyCents: 0,
       emailDomain: "acme.com",
     });
-    const app = buildApp({ actorEmail: "alice@acme.com", requireCorpEmail: true });
+    const app = buildApp({
+      actorEmail: "alice@acme.com",
+      requireCorpEmail: true,
+      actor: ACTOR_WITH_EXISTING,
+    });
     const res = await request(app).post("/api/companies").send({ name: "Acme" });
 
     expect(res.status).toBe(201);
@@ -135,7 +181,11 @@ describe("POST /api/companies — Pro free-mail block (AGE-60)", () => {
       budgetMonthlyCents: 0,
       emailDomain: "alice@gmail.com",
     });
-    const app = buildApp({ actorEmail: "alice@gmail.com", requireCorpEmail: false });
+    const app = buildApp({
+      actorEmail: "alice@gmail.com",
+      requireCorpEmail: false,
+      actor: ACTOR_WITH_EXISTING,
+    });
     const res = await request(app).post("/api/companies").send({ name: "Solo" });
 
     expect(res.status).toBe(201);

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -300,11 +300,16 @@ export function companyRoutes(
         .then((rows) => rows[0] ?? null);
       creatorEmail = userRow?.email ?? null;
       if (creatorEmail) {
-        // AgentDash (AGE-60): on Pro deployments, reject free-mail addresses
-        // before we even derive the domain — they get a friendlier error
-        // code than the generic "could not derive". local_implicit is
-        // already exempt above (the outer if).
-        if (requireCorpEmail) {
+        // AgentDash (AGE-60 + AGE-104): on Pro deployments, reject free-mail
+        // addresses ONLY when the user is creating an additional company.
+        // For a user's first company we let them through and store the full
+        // email as `email_domain` (the AGE-55 fallback) so they get a
+        // single personal workspace — this is what unblocks legacy WorkOS
+        // webhook accounts that bypassed the AGE-104 signup-time guard.
+        // The signup-time guard (corp-email-signup-guard.ts) is the real
+        // safeguard for new signups.
+        const userHasExistingCompanies = (req.actor.companyIds ?? []).length > 0;
+        if (requireCorpEmail && userHasExistingCompanies) {
           const lower = creatorEmail.trim().toLowerCase();
           const at = lower.lastIndexOf("@");
           const rawDomain = at >= 0 ? lower.slice(at + 1) : "";
@@ -312,7 +317,7 @@ export function companyRoutes(
             res.status(400).json({
               code: "pro_requires_corp_email",
               error:
-                "Pro accounts require a company email. Please sign up with your work email or use the Free self-hosted plan.",
+                "Pro accounts require a company email to create additional workspaces.",
             });
             return;
           }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,5 @@
-import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "@/lib/router";
+import { Navigate, Outlet, Route, Routes, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import { Button } from "@/components/ui/button";
 import { Layout } from "./components/Layout";
 import { OnboardingWizard } from "./components/OnboardingWizard";
 import { authApi } from "./api/auth";
@@ -86,9 +85,7 @@ import { Consulting as MarketingConsulting } from "./marketing/pages/Consulting"
 import { About as MarketingAbout } from "./marketing/pages/About";
 import { queryKeys } from "./lib/queryKeys";
 import { useCompany } from "./context/CompanyContext";
-import { useDialog } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
-import { shouldRedirectCompanylessRouteToOnboarding } from "./lib/onboarding-route";
 
 function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: boolean }) {
   return (
@@ -162,7 +159,9 @@ function boardRoutes() {
     <>
       <Route index element={<Navigate to="dashboard" replace />} />
       <Route path="dashboard" element={<Dashboard />} />
-      <Route path="onboarding" element={<OnboardingRoutePage />} />
+      {/* AgentDash (AGE-104): /{prefix}/onboarding lands on the same WelcomePage
+          as the no-companies redirect — single canonical first-run flow. */}
+      <Route path="onboarding" element={<WelcomePage />} />
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
       {/* AgentDash: Manual KPIs (AGE-45) */}
@@ -268,46 +267,10 @@ function LegacySettingsRedirect() {
   return <Navigate to={`/instance/settings/general${location.search}${location.hash}`} replace />;
 }
 
-function OnboardingRoutePage() {
-  const { companies } = useCompany();
-  const { openOnboarding } = useDialog();
-  const { companyPrefix } = useParams<{ companyPrefix?: string }>();
-  const matchedCompany = companyPrefix
-    ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase()) ?? null
-    : null;
-
-  const title = matchedCompany
-    ? `Add another agent to ${matchedCompany.name}`
-    : companies.length > 0
-      ? "Create another company"
-      : "Create your first company";
-  const description = matchedCompany
-    ? "Run onboarding again to add an agent and a starter task for this company."
-    : companies.length > 0
-      ? "Run onboarding again to create another company and seed its first agent."
-      : "Get started by creating a company and your first agent.";
-
-  return (
-    <div className="mx-auto max-w-xl py-10">
-      <div className="rounded-lg border border-border bg-card p-6">
-        <h1 className="text-xl font-semibold">{title}</h1>
-        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
-        <div className="mt-4">
-          <Button
-            onClick={() =>
-              matchedCompany
-                ? openOnboarding({ initialStep: 2, companyId: matchedCompany.id })
-                : openOnboarding()
-            }
-          >
-            {matchedCompany ? "Add Agent" : "Start Onboarding"}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
+// AgentDash (AGE-104 frictionless): WelcomePage is now the single canonical
+// first-run surface. The deprecated OnboardingRoutePage middleman + the
+// /onboarding redirect dance were removed so users land on one consistent
+// page no matter which deep link sent them there.
 function UnprefixedBoardRedirect() {
   const location = useLocation();
   const { companies, selectedCompany, loading } = useCompany();
@@ -318,15 +281,7 @@ function UnprefixedBoardRedirect() {
 
   const targetCompany = selectedCompany ?? companies[0] ?? null;
   if (!targetCompany) {
-    if (
-      shouldRedirectCompanylessRouteToOnboarding({
-        pathname: location.pathname,
-        hasCompanies: false,
-      })
-    ) {
-      return <Navigate to="/onboarding" replace />;
-    }
-    return <NoCompaniesStartPage />;
+    return <WelcomePage />;
   }
 
   return (
@@ -335,10 +290,6 @@ function UnprefixedBoardRedirect() {
       replace
     />
   );
-}
-
-function NoCompaniesStartPage() {
-  return <WelcomePage />;
 }
 
 export function App() {
@@ -354,7 +305,9 @@ export function App() {
         <Route path="about" element={<MarketingAbout />} />
 
         <Route element={<CloudAccessGate />}>
-          <Route path="onboarding" element={<OnboardingRoutePage />} />
+          {/* AgentDash (AGE-104): /onboarding lands on the same WelcomePage
+              as the no-companies redirect — single canonical first-run flow. */}
+          <Route path="onboarding" element={<WelcomePage />} />
           <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
           <Route path="instance/settings" element={<Layout />}>
             <Route index element={<Navigate to="general" replace />} />

--- a/ui/src/marketing/sections/AgentOrgChart.css
+++ b/ui/src/marketing/sections/AgentOrgChart.css
@@ -1,0 +1,176 @@
+/*
+ * AgentOrgChart — animated hero illustration for the marketing landing.
+ * Uses currentColor + var(--mkt-accent) so it inherits the editorial palette.
+ */
+
+.mkt-org {
+  width: 100%;
+  height: auto;
+  color: var(--mkt-ink);
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  display: block;
+}
+
+/* edges */
+.mkt-org__edge {
+  stroke: var(--mkt-ink);
+  stroke-width: 1;
+  opacity: 0.18;
+}
+.mkt-org__edge--dashed {
+  stroke-dasharray: 3 4;
+  opacity: 0.32;
+}
+
+/* coral work-pulse dot traveling each edge */
+.mkt-org__pulse {
+  fill: var(--mkt-accent);
+  filter: drop-shadow(0 0 4px rgba(204, 120, 92, 0.6));
+}
+
+/* central hub */
+.mkt-org__hub-ring {
+  fill: #fff;
+  stroke: var(--mkt-ink);
+  stroke-width: 1.2;
+  opacity: 0.9;
+}
+.mkt-org__hub-pulse {
+  fill: none;
+  stroke: var(--mkt-accent);
+  stroke-width: 1;
+  opacity: 0;
+  transform-origin: 210px 140px;
+  animation: mkt-org-hub-pulse 3.6s ease-out infinite;
+}
+.mkt-org__hub-label {
+  font-family: var(--mkt-font-serif, Georgia, serif);
+  font-size: 13px;
+  font-weight: 500;
+  fill: var(--mkt-ink);
+}
+.mkt-org__hub-sublabel {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  fill: var(--mkt-ink);
+  opacity: 0.55;
+  text-transform: uppercase;
+}
+@keyframes mkt-org-hub-pulse {
+  0%   { transform: scale(1);    opacity: 0.55; }
+  70%  { transform: scale(1.55); opacity: 0;    }
+  100% { transform: scale(1.55); opacity: 0;    }
+}
+
+/* established agent nodes */
+.mkt-org__node-bg {
+  fill: #fff;
+}
+.mkt-org__node-ring {
+  fill: none;
+  stroke: var(--mkt-ink);
+  stroke-width: 1.2;
+  opacity: 0.85;
+}
+.mkt-org__node-ring--new {
+  stroke: var(--mkt-accent);
+  stroke-dasharray: 3 3;
+  opacity: 1;
+}
+.mkt-org__node-name {
+  font-family: var(--mkt-font-serif, Georgia, serif);
+  font-size: 11.5px;
+  font-weight: 500;
+  fill: var(--mkt-ink);
+}
+.mkt-org__node-role {
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  fill: var(--mkt-ink);
+  opacity: 0.6;
+  text-transform: uppercase;
+}
+
+/* per-agent status indicator */
+.mkt-org__status {
+  fill: var(--mkt-ink);
+  opacity: 0.35;
+}
+.mkt-org__status--working {
+  fill: var(--mkt-accent);
+  opacity: 1;
+  animation: mkt-org-status-breathe 2.2s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes mkt-org-status-breathe {
+  0%, 100% { opacity: 0.55; transform: scale(1); }
+  50%      { opacity: 1;    transform: scale(1.35); }
+}
+
+/* new-hire slot — re-keyed per candidate so the entry animation reruns */
+.mkt-org__hire {
+  animation: mkt-org-hire-in 0.7s var(--mkt-ease, cubic-bezier(0.16, 1, 0.3, 1));
+  transform-origin: 40px 165px;
+}
+@keyframes mkt-org-hire-in {
+  0%   { opacity: 0; transform: scale(0.6); }
+  60%  { opacity: 1; transform: scale(1.04); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.mkt-org__hire-badge rect {
+  fill: var(--mkt-accent);
+  animation: mkt-org-badge-flash 6s ease-out forwards;
+}
+.mkt-org__hire-badge-label {
+  font-size: 7.5px;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  fill: #fff;
+  animation: mkt-org-badge-flash 6s ease-out forwards;
+}
+@keyframes mkt-org-badge-flash {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  60%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* footer counters — fade-in on each tick */
+.mkt-org__stats {
+  animation: mkt-org-tick 0.5s ease-out;
+  transform-origin: center;
+}
+@keyframes mkt-org-tick {
+  0%   { opacity: 0.35; transform: translateY(2px); }
+  100% { opacity: 1;    transform: translateY(0);   }
+}
+.mkt-org__stat-num {
+  font-family: var(--mkt-font-serif, Georgia, serif);
+  font-size: 18px;
+  font-weight: 500;
+  fill: var(--mkt-ink);
+}
+.mkt-org__stat-label {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  fill: var(--mkt-ink);
+  opacity: 0.55;
+  text-transform: uppercase;
+}
+
+/* honor reduced-motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .mkt-org__pulse,
+  .mkt-org__pulse animateMotion,
+  .mkt-org__hub-pulse,
+  .mkt-org__status--working,
+  .mkt-org__hire,
+  .mkt-org__hire-badge rect,
+  .mkt-org__hire-badge-label,
+  .mkt-org__stats {
+    animation: none !important;
+  }
+  .mkt-org__pulse { opacity: 0; }
+  .mkt-org__hub-pulse { opacity: 0; }
+}

--- a/ui/src/marketing/sections/AgentOrgChart.tsx
+++ b/ui/src/marketing/sections/AgentOrgChart.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from "react";
+import "./AgentOrgChart.css";
+
+type Agent = {
+  name: string;
+  role: string;
+  x: number;
+  y: number;
+  pulseDelay: number;
+  status: "working" | "idle";
+};
+
+const HUB = { x: 210, y: 140 };
+
+const AGENTS: Agent[] = [
+  { name: "Avery", role: "CEO",   x: 70,  y: 70,  pulseDelay: 0,   status: "working" },
+  { name: "Mira",  role: "CMO",   x: 350, y: 70,  pulseDelay: 0.6, status: "working" },
+  { name: "Theo",  role: "CTO",   x: 380, y: 165, pulseDelay: 1.2, status: "working" },
+  { name: "Quinn", role: "CFO",   x: 320, y: 235, pulseDelay: 1.8, status: "idle"    },
+  { name: "Sam",   role: "Sales", x: 110, y: 235, pulseDelay: 2.4, status: "working" },
+];
+
+const HIRE_SLOT = { x: 40, y: 165 };
+
+const CANDIDATES = [
+  { name: "Riley", role: "Engineer" },
+  { name: "Mae",   role: "Recruiter" },
+  { name: "Devon", role: "Researcher" },
+  { name: "Iris",  role: "Designer" },
+];
+
+export function AgentOrgChart() {
+  const [tick, setTick] = useState(0);
+  const [tasksDone, setTasksDone] = useState(17);
+  const [spend, setSpend] = useState(182);
+  const [hireIndex, setHireIndex] = useState(0);
+
+  useEffect(() => {
+    const counter = setInterval(() => {
+      setTick((t) => t + 1);
+      setTasksDone((t) => t + 1);
+      setSpend((s) => s + 4 + Math.floor(Math.random() * 7));
+    }, 3400);
+    return () => clearInterval(counter);
+  }, []);
+
+  useEffect(() => {
+    const cycle = setInterval(() => {
+      setHireIndex((i) => (i + 1) % CANDIDATES.length);
+    }, 6200);
+    return () => clearInterval(cycle);
+  }, []);
+
+  const candidate = CANDIDATES[hireIndex]!;
+  const formattedSpend = useMemo(() => `$${spend.toLocaleString()}`, [spend]);
+
+  return (
+    <svg
+      viewBox="0 0 420 320"
+      role="img"
+      aria-label="Animated AgentDash org chart with five named AI agents and a rotating new-hire slot"
+      className="mkt-org"
+      fill="none"
+    >
+      <defs>
+        <radialGradient id="mkt-org-hub-glow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="var(--mkt-accent)" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="var(--mkt-accent)" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      {/* connection edges from hub to each agent */}
+      {AGENTS.map((agent) => (
+        <line
+          key={`edge-${agent.name}`}
+          x1={HUB.x}
+          y1={HUB.y}
+          x2={agent.x}
+          y2={agent.y}
+          className="mkt-org__edge"
+        />
+      ))}
+
+      {/* dashed edge to the new-hire slot */}
+      <line
+        x1={HUB.x}
+        y1={HUB.y}
+        x2={HIRE_SLOT.x}
+        y2={HIRE_SLOT.y}
+        className="mkt-org__edge mkt-org__edge--dashed"
+      />
+
+      {/* coral work-pulses traveling each edge, staggered */}
+      {AGENTS.map((agent) => (
+        <circle
+          key={`pulse-${agent.name}`}
+          r="3"
+          className="mkt-org__pulse"
+        >
+          <animateMotion
+            dur="3.4s"
+            begin={`${agent.pulseDelay}s`}
+            repeatCount="indefinite"
+            path={`M${agent.x} ${agent.y} L${HUB.x} ${HUB.y}`}
+            keyPoints="0;1"
+            keyTimes="0;1"
+            calcMode="linear"
+          />
+        </circle>
+      ))}
+
+      {/* central hub: glow + ring + label */}
+      <circle cx={HUB.x} cy={HUB.y} r="46" fill="url(#mkt-org-hub-glow)" />
+      <circle cx={HUB.x} cy={HUB.y} r="34" className="mkt-org__hub-ring" />
+      <circle cx={HUB.x} cy={HUB.y} r="34" className="mkt-org__hub-pulse" />
+      <text x={HUB.x} y={HUB.y - 4} textAnchor="middle" className="mkt-org__hub-label">
+        AgentDash
+      </text>
+      <text x={HUB.x} y={HUB.y + 10} textAnchor="middle" className="mkt-org__hub-sublabel">
+        control plane
+      </text>
+
+      {/* five established agent nodes */}
+      {AGENTS.map((agent) => (
+        <g key={`node-${agent.name}`} className="mkt-org__node">
+          <circle cx={agent.x} cy={agent.y} r="16" className="mkt-org__node-bg" />
+          <circle cx={agent.x} cy={agent.y} r="16" className="mkt-org__node-ring" />
+          <text x={agent.x} y={agent.y - 24} textAnchor="middle" className="mkt-org__node-name">
+            {agent.name}
+          </text>
+          <text x={agent.x} y={agent.y + 32} textAnchor="middle" className="mkt-org__node-role">
+            {agent.role}
+          </text>
+          <circle
+            cx={agent.x + 14}
+            cy={agent.y - 12}
+            r="3.2"
+            className={`mkt-org__status mkt-org__status--${agent.status}`}
+          />
+        </g>
+      ))}
+
+      {/* rotating new-hire slot — re-keyed per candidate so the fade animation re-runs */}
+      <g key={`hire-${hireIndex}`} className="mkt-org__hire">
+        <circle cx={HIRE_SLOT.x} cy={HIRE_SLOT.y} r="16" className="mkt-org__node-bg" />
+        <circle cx={HIRE_SLOT.x} cy={HIRE_SLOT.y} r="16" className="mkt-org__node-ring mkt-org__node-ring--new" />
+        <text x={HIRE_SLOT.x} y={HIRE_SLOT.y - 24} textAnchor="middle" className="mkt-org__node-name">
+          {candidate.name}
+        </text>
+        <text x={HIRE_SLOT.x} y={HIRE_SLOT.y + 32} textAnchor="middle" className="mkt-org__node-role">
+          {candidate.role}
+        </text>
+        <g className="mkt-org__hire-badge">
+          <rect x={HIRE_SLOT.x - 22} y={HIRE_SLOT.y + 38} width="44" height="14" rx="7" />
+          <text x={HIRE_SLOT.x} y={HIRE_SLOT.y + 48} textAnchor="middle" className="mkt-org__hire-badge-label">
+            HIRED
+          </text>
+        </g>
+      </g>
+
+      {/* footer rule + ticking counters */}
+      <line x1="20" y1="278" x2="400" y2="278" className="mkt-org__edge" />
+      <g key={`stats-${tick}`} className="mkt-org__stats">
+        <text x="40" y="298" className="mkt-org__stat-num">{formattedSpend}</text>
+        <text x="40" y="312" className="mkt-org__stat-label">SPEND TODAY</text>
+        <text x="170" y="298" className="mkt-org__stat-num">{tasksDone}</text>
+        <text x="170" y="312" className="mkt-org__stat-label">TASKS DONE</text>
+        <text x="300" y="298" className="mkt-org__stat-num">3</text>
+        <text x="300" y="312" className="mkt-org__stat-label">FLAGGED</text>
+      </g>
+    </svg>
+  );
+}

--- a/ui/src/marketing/sections/Hero.tsx
+++ b/ui/src/marketing/sections/Hero.tsx
@@ -2,6 +2,7 @@ import "./Hero.css";
 import { Eyebrow } from "../components/Eyebrow";
 import { Button } from "../components/Button";
 import { SectionContainer } from "../components/SectionContainer";
+import { AgentOrgChart } from "./AgentOrgChart";
 
 export function Hero() {
   return (
@@ -23,62 +24,9 @@ export function Hero() {
           <p className="mkt-hero__reassure">No credit card · Free single-seat tier</p>
         </div>
         <div className="mkt-hero__art" aria-hidden>
-          <BriefingCardSvg />
+          <AgentOrgChart />
         </div>
       </div>
     </SectionContainer>
-  );
-}
-
-function BriefingCardSvg() {
-  const rows = [
-    { name: "Avery (CEO)",  status: "ok",   detail: "reviewing Q3 priorities" },
-    { name: "Mira (CMO)",   status: "ATTN", detail: "needs your input on launch" },
-    { name: "Theo (CTO)",   status: "ok",   detail: "shipping migrations" },
-    { name: "Quinn (CFO)",  status: "ok",   detail: "closing April books" },
-    { name: "Sam (Sales)",  status: "ok",   detail: "qualifying 12 leads" },
-  ];
-  return (
-    <svg viewBox="0 0 420 320" fill="none" stroke="currentColor" strokeWidth="1.2" role="img" aria-label="Sample morning briefing">
-      <text x="24" y="34" fontSize="15" fill="currentColor" fontFamily="var(--mkt-font-serif)">AgentDash · Morning briefing</text>
-      <text x="396" y="34" textAnchor="end" fontSize="11" fill="currentColor" fontFamily="var(--mkt-font-mono)" opacity="0.6">TUE · APR 29</text>
-      <line x1="24" y1="48" x2="396" y2="48" />
-      {rows.map((row, i) => {
-        const y = 78 + i * 34;
-        const isHighlighted = row.status === "ATTN";
-        return (
-          <g key={row.name}>
-            <circle cx="38" cy={y} r="9" />
-            <text x="56" y={y + 4} fontSize="11" fontWeight="500" fill="currentColor">{row.name}</text>
-            <rect
-              x="170"
-              y={y - 9}
-              width="56"
-              height="18"
-              rx="9"
-              fill={isHighlighted ? "var(--mkt-accent)" : "none"}
-              stroke={isHighlighted ? "none" : "currentColor"}
-            />
-            <text
-              x="198"
-              y={y + 4}
-              textAnchor="middle"
-              fontSize="10"
-              fontFamily="var(--mkt-font-mono)"
-              fill={isHighlighted ? "#fff" : "currentColor"}
-              stroke="none"
-            >{row.status}</text>
-            <text x="240" y={y + 4} fontSize="11" fill="currentColor" opacity="0.75">{row.detail}</text>
-          </g>
-        );
-      })}
-      <line x1="24" y1="266" x2="396" y2="266" />
-      <text x="40"  y="290" fontSize="20" fill="currentColor" fontFamily="var(--mkt-font-serif)" fontWeight="500">$182</text>
-      <text x="40"  y="306" fontSize="10" fill="currentColor" fontFamily="var(--mkt-font-mono)" opacity="0.6" letterSpacing="0.08em">SPEND TODAY</text>
-      <text x="170" y="290" fontSize="20" fill="currentColor" fontFamily="var(--mkt-font-serif)" fontWeight="500">17</text>
-      <text x="170" y="306" fontSize="10" fill="currentColor" fontFamily="var(--mkt-font-mono)" opacity="0.6" letterSpacing="0.08em">TASKS DONE</text>
-      <text x="290" y="290" fontSize="20" fill="currentColor" fontFamily="var(--mkt-font-serif)" fontWeight="500">3</text>
-      <text x="290" y="306" fontSize="10" fill="currentColor" fontFamily="var(--mkt-font-mono)" opacity="0.6" letterSpacing="0.08em">FLAGGED</text>
-    </svg>
   );
 }

--- a/ui/src/pages/SetupWizard.tsx
+++ b/ui/src/pages/SetupWizard.tsx
@@ -221,7 +221,10 @@ export function SetupWizard() {
                 </div>
               </div>
               <div className="space-y-2">
-                <label className="block text-sm font-medium">Tell us about your company</label>
+                <label className="block text-sm font-medium">
+                  Tell us about your company
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">(optional)</span>
+                </label>
                 <textarea
                   className="w-full rounded-lg border bg-background p-3 text-sm min-h-[100px] focus:outline-none focus:ring-2 focus:ring-ring"
                   placeholder="Paste a description, your website URL, or a few sentences about what you do..."
@@ -253,7 +256,10 @@ export function SetupWizard() {
                 </button>
               </div>
               <div className="space-y-2">
-                <label className="block text-sm font-medium">What's your main goal?</label>
+                <label className="block text-sm font-medium">
+                  What's your main goal?
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">(optional)</span>
+                </label>
                 <input
                   className="w-full rounded-lg border bg-background p-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                   placeholder="e.g., Close 100 deals by Q3"
@@ -314,7 +320,7 @@ export function SetupWizard() {
               <p className="text-sm text-destructive text-center">{deployError}</p>
             )}
 
-            <div className="flex justify-between">
+            <div className="flex items-center justify-between">
               <button
                 onClick={() => setStepIndex(0)}
                 disabled={deploying}
@@ -322,13 +328,25 @@ export function SetupWizard() {
               >
                 Back
               </button>
-              <button
-                onClick={handleDeploy}
-                disabled={deploying || selectedAgents.size === 0}
-                className="px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90 disabled:opacity-50"
-              >
-                {deploying ? "Deploying..." : "Deploy Team"}
-              </button>
+              {/* AgentDash (AGE-104 frictionless): users who don't want to
+                  pick a starter team yet can skip straight to the dashboard
+                  and add agents later from settings. */}
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => navigate(`/${companyPrefix}/dashboard`)}
+                  disabled={deploying}
+                  className="text-sm text-muted-foreground hover:text-foreground hover:underline disabled:opacity-30"
+                >
+                  Skip for now
+                </button>
+                <button
+                  onClick={handleDeploy}
+                  disabled={deploying || selectedAgents.size === 0}
+                  className="px-6 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90 disabled:opacity-50"
+                >
+                  {deploying ? "Deploying..." : "Deploy Team"}
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/ui/src/pages/WelcomePage.tsx
+++ b/ui/src/pages/WelcomePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import {
   ArrowRight,
@@ -20,6 +21,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useCompany } from "../context/CompanyContext";
+import { authApi } from "../api/auth";
+import { ApiError } from "../api/client";
+import { queryKeys } from "../lib/queryKeys";
 
 type FeatureCard = {
   title: string;
@@ -129,13 +133,45 @@ const setupSteps = [
   },
 ];
 
+// AgentDash (AGE-104 frictionless): derive a sensible default workspace
+// name from the signed-in user. "Kailor Tang" → "Kailor's Workspace".
+// Empty / single-word names degrade to "<name>'s Workspace". Returns null
+// when there's nothing usable so we leave the input blank.
+function suggestWorkspaceName(userName: string | null | undefined): string | null {
+  if (!userName) return null;
+  const trimmed = userName.trim();
+  if (!trimmed) return null;
+  const first = trimmed.split(/\s+/)[0];
+  if (!first) return null;
+  // Don't suggest if the value looks like an email (some auth providers
+  // store the email as the name when the user hasn't set a display name).
+  if (first.includes("@")) return null;
+  return `${first}'s Workspace`;
+}
+
 export function WelcomePage() {
   const { createCompany } = useCompany();
   const navigate = useNavigate();
   const [companyName, setCompanyName] = useState("");
+  const [hasUserEdited, setHasUserEdited] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const submittingRef = useRef(false);
+
+  // Pre-fill the workspace name from the user's profile so the field
+  // isn't blank on first paint. Only auto-fills if the user hasn't typed.
+  const sessionQuery = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    staleTime: 60_000,
+  });
+  useEffect(() => {
+    if (hasUserEdited) return;
+    const suggestion = suggestWorkspaceName(sessionQuery.data?.user?.name);
+    if (suggestion && companyName === "") {
+      setCompanyName(suggestion);
+    }
+  }, [sessionQuery.data?.user?.name, hasUserEdited, companyName]);
 
   async function handleGetStarted() {
     if (submittingRef.current) return;
@@ -148,7 +184,24 @@ export function WelcomePage() {
       const company = await createCompany({ name });
       navigate(`/${company.issuePrefix}/setup-wizard`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create company");
+      // AgentDash (AGE-104 frictionless): translate known server codes
+      // to copy that gives the user a forward path instead of a dead-end.
+      if (err instanceof ApiError) {
+        const code = (err.body as { code?: string } | null)?.code;
+        if (code === "pro_requires_corp_email") {
+          setError(
+            "This account already has a workspace and uses a personal email. To create another workspace on Pro, sign in with a work email — or stick with the existing one.",
+          );
+        } else if (code === "domain_already_claimed") {
+          setError(
+            "Someone with this email domain already created a workspace. Ask them to invite you, or use a different email to start your own.",
+          );
+        } else {
+          setError(err.message);
+        }
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to create company");
+      }
       submittingRef.current = false;
     } finally {
       setLoading(false);
@@ -242,7 +295,10 @@ export function WelcomePage() {
                         type="text"
                         placeholder="Northstar Studio"
                         value={companyName}
-                        onChange={(event) => setCompanyName(event.target.value)}
+                        onChange={(event) => {
+                          setHasUserEdited(true);
+                          setCompanyName(event.target.value);
+                        }}
                         onKeyDown={(event) => {
                           if (event.key === "Enter") handleGetStarted();
                         }}


### PR DESCRIPTION
## Summary

PM review of the onboarding pile-up uncovered **three competing first-run surfaces** (`WelcomePage`, `OnboardingRoutePage` → `OnboardingWizard` modal, `SetupWizard`) plus a corp-email gate that **dead-ends legacy free-mail accounts** at company-creation (the screenshot bug). This PR ships PR A + PR B together — collapses the surfaces and unblocks the dead end.

## Server (PR A — corp-email gate relaxation)

`companies.ts POST /`: only enforce `requireCorpEmail` when the user **already has at least one company**. A free-mail user with zero companies (legacy WorkOS-webhook accounts that bypassed the AGE-104 signup-time guard) gets one personal workspace via the existing AGE-55 fallback (`email_domain = full email`). The signup-time guard (`corp-email-signup-guard.ts`) remains the real safeguard for new accounts.

New unit tests in `companies-email-domain-route.test.ts`:
- free-mail user, no companies → **201** (first personal workspace)
- free-mail user, one existing company → **400** `pro_requires_corp_email`

## Frontend (PR B — single first-run surface)

`App.tsx`:
- Both `/onboarding` routes (root + `/{prefix}/onboarding`) now render `<WelcomePage />` directly.
- `UnprefixedBoardRedirect` no longer bounces through `/onboarding`.
- Deletes the dead-weight `OnboardingRoutePage` middleman + the `shouldRedirectCompanylessRouteToOnboarding` helper. The `OnboardingWizard` modal component is left intact for now — other surfaces may still trigger it via `openOnboarding`.

`WelcomePage`:
- Pre-fills the company name from the user's display name (`"Kailor Tang"` → `"Kailor's Workspace"`), skipping if the user has typed anything.
- Catches `ApiError` on `createCompany` and translates `pro_requires_corp_email` + `domain_already_claimed` to copy that points at a forward path instead of the raw server message.

`SetupWizard`:
- Marks "Tell us about your company" and "What's your main goal?" as **(optional)** so users don't feel stuck.
- Adds a **"Skip for now"** affordance on the Team step that navigates straight to the dashboard — agents can be added later from settings.

## Test plan

- [x] `companies-email-domain-route.test.ts` — 9/9 pass (was 7)
- [x] `corp-email-signup-guard.test.ts` — 7/7 pass
- [x] `pro-signup-flow.test.ts` (real Better Auth + DB) — 3/3 pass
- [x] `pnpm -r typecheck` — clean
- [ ] Full regression suite in CI
- [ ] Eyeball: the screenshot user (kailortang@gmail.com) can now create their first workspace and reach the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)