### PR TITLE
v2 bootstrap + Stripe bypass for local dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,29 @@ MAW commands are installed under `.claude/commands/` with supporting docs in `do
 
 Staging and production steps still contain explicit `TODO_SET_*` placeholders for environment URLs and test credentials. Fill those before using the deploy/admin flows.
 
+## Local development bootstrap (first run)
+
+For your very first run as the founding user, AgentDash works in `local_trusted` deployment mode without a sign-up flow. The orchestrator detects the synthetic `local-board` actor and provisions a workspace + CoS agent for you:
+
+```sh
+# Optional: name your workspace properly (defaults to "Local Workspace")
+export AGENTDASH_BOOTSTRAP_EMAIL=you@yourdomain.com
+
+pnpm dev
+# Open http://localhost:3100/cos
+# CoS chat is ready — start the interview.
+```
+
+To test billing-gated flows (invites, agent hires) without wiring Stripe:
+
+```sh
+# Caps bypassed when STRIPE_SECRET_KEY is unset, OR explicitly:
+export AGENTDASH_BILLING_DISABLED=true
+pnpm dev
+```
+
+When `STRIPE_SECRET_KEY` is set in production, caps are enforced as designed (Free: 1 human + 1 agent; Pro: unlimited). The bypass is dev-only.
+
 ## Architecture
 
 **Monorepo** (pnpm workspaces): `server/`, `ui/`, `cli/`, `packages/*`

--- a/server/src/__tests__/require-tier.test.ts
+++ b/server/src/__tests__/require-tier.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { requireTierFor } from "../middleware/require-tier.js";
+
+// requireTierFor bypasses all checks when STRIPE_SECRET_KEY is unset (so dev/test
+// envs aren't forced into Pro-or-pay). Set it for these tests so the caps actually fire.
+const originalKey = process.env.STRIPE_SECRET_KEY;
+beforeAll(() => { process.env.STRIPE_SECRET_KEY = "sk_test_for_require_tier_tests"; });
+afterAll(() => {
+  if (originalKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+  else process.env.STRIPE_SECRET_KEY = originalKey;
+});
 
 function makeDeps(planTier: string, humanCount: number, agentCount: number) {
   return {
@@ -23,6 +32,36 @@ function makeReqRes(companyId: string) {
   const next = vi.fn();
   return { req, res, next };
 }
+
+describe("requireTierFor billing-disabled bypass", () => {
+  it("bypasses all caps when STRIPE_SECRET_KEY is unset", async () => {
+    const saved = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+    try {
+      const deps = makeDeps("free", 99, 99);
+      const { req, res, next } = makeReqRes("company-1");
+      await requireTierFor("invite", deps)(req, res, next);
+      expect(next).toHaveBeenCalledOnce();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(deps.getCompany).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_SECRET_KEY = saved;
+    }
+  });
+
+  it("bypasses all caps when AGENTDASH_BILLING_DISABLED=true (even with Stripe key set)", async () => {
+    process.env.AGENTDASH_BILLING_DISABLED = "true";
+    try {
+      const deps = makeDeps("free", 99, 99);
+      const { req, res, next } = makeReqRes("company-1");
+      await requireTierFor("hire", deps)(req, res, next);
+      expect(next).toHaveBeenCalledOnce();
+      expect(res.status).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.AGENTDASH_BILLING_DISABLED;
+    }
+  });
+});
 
 describe("requireTierFor invite", () => {
   it("allows invite when free workspace has 0 humans", async () => {

--- a/server/src/middleware/require-tier.ts
+++ b/server/src/middleware/require-tier.ts
@@ -10,8 +10,24 @@ interface Deps {
 
 const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
 
+/**
+ * Billing is "disabled" — and all caps bypass — when the operator explicitly opts out
+ * via AGENTDASH_BILLING_DISABLED=true, OR when no Stripe key is configured (the
+ * implicit signal that this is a dev/test deployment without payments wired). In
+ * both cases we treat every company as if it's on Pro.
+ *
+ * Production deployments set STRIPE_SECRET_KEY → caps are enforced as designed.
+ * Local-trusted dev never sets the key → caps never block.
+ */
+function isBillingDisabled(): boolean {
+  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
+  if (!process.env.STRIPE_SECRET_KEY) return true;
+  return false;
+}
+
 export function requireTierFor(action: "invite" | "hire", deps: Deps): RequestHandler {
   return async (req, res, next) => {
+    if (isBillingDisabled()) return next();
     const companyId = (req as any).companyId ?? req.params.companyId ?? (req.body as any)?.companyId;
     if (!companyId) return next();
     const company = await deps.getCompany(companyId);

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -15,10 +15,25 @@ interface BootstrapResult {
   conversationId: string;
 }
 
+// In `local_trusted` deployment mode, the synthetic actor has userId="local-board"
+// and there is NO auth_users row. The orchestrator must still bootstrap a working
+// workspace so the founding user can hit /cos and start chatting.
+const LOCAL_BOARD_USER_ID = "local-board";
+
+function resolveLocalUser(userId: string): { id: string; email: string | null } | null {
+  if (userId !== LOCAL_BOARD_USER_ID) return null;
+  // Optional override: AGENTDASH_BOOTSTRAP_EMAIL lets the founding user supply a
+  // real email so the company name + email_domain are set correctly. Falls back
+  // to a generic "Local Workspace" when unset.
+  const email = process.env.AGENTDASH_BOOTSTRAP_EMAIL?.trim() || null;
+  return { id: LOCAL_BOARD_USER_ID, email };
+}
+
 export function onboardingOrchestrator(deps: Deps) {
   return {
     bootstrap: async (userId: string): Promise<BootstrapResult> => {
-      const user = await deps.users.getById(userId);
+      // Try the real auth_users lookup first; fall back to local-trusted sentinel.
+      const user = (await deps.users.getById(userId)) ?? resolveLocalUser(userId);
       if (!user) throw new Error(`User ${userId} not found`);
 
       // Step 1: ensure a company. Use email-domain lookup first (idempotency).


### PR DESCRIPTION
## Why
- You said you'll set up onboarding once your own company is on it. This makes the very-first-run path work without a sign-up flow.
- You said Stripe can wait. This adds a one-flag bypass so local dev / test accounts don't hit billing caps.

## Bootstrap (`onboarding-orchestrator.ts`)
When `userId === 'local-board'` and no `auth_users` row exists (the `local_trusted` deployment mode default), fall back to a synthetic user. Optional `AGENTDASH_BOOTSTRAP_EMAIL` env so the workspace gets a real name; otherwise it's "My Workspace".

Production with real `auth_users` rows works exactly as before.

## Billing bypass (`requireTierFor`)
`requireTierFor` treats every company as Pro when:
- `AGENTDASH_BILLING_DISABLED=true`, OR
- `STRIPE_SECRET_KEY` is not set (implicit dev/test signal)

Production sets the key → caps enforced as designed.

## Tests
`require-tier.test.ts` grew from 11 → 13: added two bypass-path tests. Existing 11 still pass (the suite now sets a placeholder `STRIPE_SECRET_KEY` so the cap-enforcement assertions still fire).

## Docs
`CLAUDE.md` gets a "Local development bootstrap (first run)" section documenting both env vars and the dev workflow.