### PR TITLE
fix(routes): wire Assess + always-mount billing in dev

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -45,6 +45,8 @@ import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { conversationRoutes } from "./routes/conversations.js";
 import { onboardingV2Routes } from "./routes/onboarding-v2.js";
 import { billingRoutes } from "./routes/billing.js";
+import { assessRoutes } from "./routes/assess.js";
+import { HttpError } from "./errors.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
@@ -226,19 +228,24 @@ export async function createApp(
   api.use(instanceSettingsRoutes(db));
   api.use("/conversations", conversationRoutes(db));
   api.use("/onboarding", onboardingV2Routes(db));
-  // AgentDash: billing — mount only when Stripe is configured.
+  api.use(assessRoutes(db));
+  // AgentDash: billing — always mount so /api/billing/status responds with
+  // sensible defaults in dev. When Stripe is configured (STRIPE_SECRET_KEY set)
+  // checkout/portal/webhook do real work; otherwise those endpoints return 503
+  // "Billing not configured" and the requireTier middleware bypasses caps.
   const stripeKey = process.env.STRIPE_SECRET_KEY;
+  let stripeSdk: any = stripeStubForDev();
   if (stripeKey) {
     const { default: Stripe } = await import("stripe");
-    const stripe = new Stripe(stripeKey);
-    api.use("/billing", billingRoutes(db, {
-      stripe,
-      webhookSecret: process.env.STRIPE_WEBHOOK_SECRET ?? "",
-      proPriceId: process.env.STRIPE_PRO_PRICE_ID ?? "",
-      trialDays: parseInt(process.env.STRIPE_TRIAL_DAYS ?? "14", 10),
-      publicBaseUrl: process.env.BILLING_PUBLIC_BASE_URL ?? "",
-    }));
+    stripeSdk = new Stripe(stripeKey);
   }
+  api.use("/billing", billingRoutes(db, {
+    stripe: stripeSdk,
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET ?? "",
+    proPriceId: process.env.STRIPE_PRO_PRICE_ID ?? "",
+    trialDays: parseInt(process.env.STRIPE_TRIAL_DAYS ?? "14", 10),
+    publicBaseUrl: process.env.BILLING_PUBLIC_BASE_URL ?? "",
+  }));
   if (opts.databaseBackupService) {
     api.use(instanceDatabaseBackupRoutes(opts.databaseBackupService));
   }
@@ -473,4 +480,22 @@ export async function createApp(
   });
 
   return app;
+}
+
+// Dev-mode stub for the Stripe SDK so billingRoutes can mount even when
+// STRIPE_SECRET_KEY isn't set. Endpoints that exercise the real SDK
+// (checkout-session, portal-session, webhook constructEvent) throw a
+// typed "Billing not configured" error that the routes translate to 503.
+// Read-only endpoints (status) work via the DB unchanged.
+function stripeStubForDev() {
+  const notConfigured = () => {
+    throw new HttpError(503, "Billing not configured. Set STRIPE_SECRET_KEY to enable checkout/portal/webhook.");
+  };
+  return {
+    customers: { create: notConfigured, retrieve: notConfigured },
+    checkout: { sessions: { create: notConfigured } },
+    billingPortal: { sessions: { create: notConfigured } },
+    subscriptions: { update: notConfigured, retrieve: notConfigured },
+    webhooks: { constructEvent: notConfigured },
+  };
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -46,6 +46,8 @@ import { PluginPage } from "./pages/PluginPage";
 import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
 import BillingPage from "./pages/BillingPage";
+import { AssessPage } from "./pages/AssessPage";
+import { AssessHistoryPage } from "./pages/AssessHistoryPage";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
 import { CliAuthPage } from "./pages/CliAuth";
@@ -279,6 +281,9 @@ export function App() {
           <Route index element={<CompanyRootRedirect />} />
           {/* AgentDash: CoS onboarding v2 conversation */}
           <Route path="cos" element={<CoSConversation />} />
+          {/* AgentDash: Assess (port from v1) — global routes */}
+          <Route path="assess" element={<AssessPage />} />
+          <Route path="assess/history" element={<AssessHistoryPage />} />
           <Route path="onboarding" element={<OnboardingRoutePage />} />
           <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
           <Route path="instance/settings" element={<Layout />}>


### PR DESCRIPTION
## Summary
Browser-testing the v2 stack on localhost:3101 surfaced two wiring gaps unit tests missed.

- **/assess 404'd** — assessRoutes was never imported or mounted in server/src/app.ts. Now wired.
- **/billing 404'd in dev** — billingRoutes only mounted when STRIPE_SECRET_KEY was set, so the UI got 'API route not found' before requireTier could bypass via AGENTDASH_BILLING_DISABLED. Now always-mounts; when Stripe key is unset, a stripeStubForDev() makes checkout/portal/webhook return HttpError 503 'Billing not configured' while /billing/status keeps working from the DB.
- **App.tsx blank #root** — AssessPage / AssessHistoryPage were imported as default exports but both files use named exports. Module load threw a SyntaxError that wiped the entire React tree silently. Switched to named imports and added the routes inside the CloudAccessGate block.

## Verification
Verified in the browser running against pnpm dev on localhost:3101:
- /cos — conversation panel renders, prior messages persist, send + stub LLM reply round-trip works.
- /assess — marketing shell renders. (Note: visual styling regression flagged — tracked in follow-up.)
- /billing/status?companyId=... — 403 Not a member of this company (route mounted, auth check fired).
- /billing/checkout-session — same 403 (route mounted).
- /api/companies/:id/assess — 404 No assessment found (route mounted, expected empty state).

## Test plan
- [x] pnpm test:run — all suites pass (exit 0)
- [x] Manual browser verification per above
- [x] pnpm -r typecheck — pre-existing failure in plugin-host-services.ts:935,939 (Company missing pauseReason, pausedAt) reproduces on origin/main and is unrelated.
- [ ] /assess visual styling regression — to be addressed in a separate UI fix PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)