### PR TITLE
feat(ui): restore v1 marketing landing + brand + theme isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,6 @@ tests/release-smoke/playwright-report/
 .omc/
 **/.omc/
 
-# Stale marketing tree from v1 (no Next.js app on v2 trunk)
-marketing/
+# Stale Next.js marketing tree from v1 — only the repo-root /marketing dir is dead.
+# (ui/src/marketing/ IS our active React marketing surface; keep tracking it.)
+/marketing/

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,8 +7,8 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Paperclip" />
-    <title>Paperclip</title>
+    <meta name="apple-mobile-web-app-title" content="AgentDash" />
+    <title>AgentDash</title>
     <!-- PAPERCLIP_RUNTIME_BRANDING_START -->
     <!-- PAPERCLIP_RUNTIME_BRANDING_END -->
     <!-- AgentDash: Claude design typography -->
@@ -25,11 +25,20 @@
     <link rel="manifest" href="/site.webmanifest" />
     <script>
       (() => {
-        const key = "paperclip.theme";
+        const key = "agentdash.theme";
+        const legacyKey = "paperclip.theme";
         const darkThemeColor = "#18181b";
         const lightThemeColor = "#ffffff";
         try {
-          const stored = window.localStorage.getItem(key);
+          let stored = window.localStorage.getItem(key);
+          if (!stored) {
+            const legacy = window.localStorage.getItem(legacyKey);
+            if (legacy === "light" || legacy === "dark") {
+              stored = legacy;
+              window.localStorage.setItem(key, legacy);
+              window.localStorage.removeItem(legacyKey);
+            }
+          }
           const theme = stored === "light" || stored === "dark" ? stored : "dark";
           const isDark = theme === "dark";
           document.documentElement.classList.toggle("dark", isDark);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -55,6 +55,10 @@ import { InviteLandingPage } from "./pages/InviteLanding";
 import { JoinRequestQueue } from "./pages/JoinRequestQueue";
 import { NotFoundPage } from "./pages/NotFound";
 import { CoSConversation } from "./pages/CoSConversation";
+// AgentDash: marketing pages — render on cream/light surface, no CloudAccessGate.
+import { Landing as MarketingLanding } from "./marketing/pages/Landing";
+import { Consulting as MarketingConsulting } from "./marketing/pages/Consulting";
+import { About as MarketingAbout } from "./marketing/pages/About";
 import { useCompany } from "./context/CompanyContext";
 import { useDialogActions } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
@@ -276,14 +280,18 @@ export function App() {
         <Route path="cli-auth/:id" element={<CliAuthPage />} />
         <Route path="invite/:token" element={<InviteLandingPage />} />
         <Route path="tests/perf/long-thread" element={<IssueChatLongThreadPerf />} />
+        {/* AgentDash: marketing routes — render outside CloudAccessGate so the
+            cream/light surface isn't fighting the dashboard's html.dark theme.
+            Landing redirects logged-in users to /companies on its own. */}
+        <Route path="/" element={<MarketingLanding />} />
+        <Route path="consulting" element={<MarketingConsulting />} />
+        <Route path="about" element={<MarketingAbout />} />
+        <Route path="assess" element={<AssessPage />} />
+        <Route path="assess/history" element={<AssessHistoryPage />} />
 
         <Route element={<CloudAccessGate />}>
-          <Route index element={<CompanyRootRedirect />} />
           {/* AgentDash: CoS onboarding v2 conversation */}
           <Route path="cos" element={<CoSConversation />} />
-          {/* AgentDash: Assess (port from v1) — global routes */}
-          <Route path="assess" element={<AssessPage />} />
-          <Route path="assess/history" element={<AssessHistoryPage />} />
           <Route path="onboarding" element={<OnboardingRoutePage />} />
           <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
           <Route path="instance/settings" element={<Layout />}>

--- a/ui/src/context/BreadcrumbContext.tsx
+++ b/ui/src/context/BreadcrumbContext.tsx
@@ -39,10 +39,10 @@ export function BreadcrumbProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (breadcrumbs.length === 0) {
-      document.title = "Paperclip";
+      document.title = "AgentDash";
     } else {
       const parts = [...breadcrumbs].reverse().map((b) => b.label);
-      document.title = `${parts.join(" · ")} · Paperclip`;
+      document.title = `${parts.join(" · ")} · AgentDash`;
     }
   }, [breadcrumbs]);
 

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -16,7 +16,7 @@ interface ThemeContextValue {
   toggleTheme: () => void;
 }
 
-const THEME_STORAGE_KEY = "paperclip.theme";
+const THEME_STORAGE_KEY = "agentdash.theme";
 const DARK_THEME_COLOR = "#18181b";
 const LIGHT_THEME_COLOR = "#ffffff";
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -19,6 +19,10 @@ import { initPluginBridge } from "./plugins/bridge-init";
 import { PluginLauncherProvider } from "./plugins/launchers";
 import "@mdxeditor/editor/style.css";
 import "./index.css";
+// AgentDash: marketing surface tokens — required for `var(--mkt-*)` to resolve.
+import "./marketing/tokens.css";
+import "./marketing/fonts.css";
+import "./marketing/typography.css";
 
 initPluginBridge(React, ReactDOM);
 

--- a/ui/src/marketing/MarketingFooter.css
+++ b/ui/src/marketing/MarketingFooter.css
@@ -1,0 +1,47 @@
+.mkt-footer {
+  background: var(--mkt-surface-cream-2);
+  border-top: 1px solid var(--mkt-rule);
+  padding: 80px var(--mkt-container-gutter) 40px;
+}
+.mkt-footer__inner {
+  max-width: var(--mkt-container-max);
+  margin-inline: auto;
+}
+.mkt-footer__cols {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 48px;
+}
+.mkt-footer__brand {
+  font-family: var(--mkt-font-serif);
+  font-size: 22px;
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+.mkt-footer__tagline { color: var(--mkt-ink-soft); max-width: 36ch; }
+.mkt-footer__col h4 {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--mkt-ink-soft);
+  margin: 0 0 16px;
+  font-family: var(--mkt-font-mono);
+  font-weight: 500;
+}
+.mkt-footer__col ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 10px; }
+.mkt-footer__col a { text-decoration: none; color: var(--mkt-ink); }
+.mkt-footer__col a:hover { color: var(--mkt-accent-ink); }
+.mkt-footer__legal {
+  margin-top: 64px;
+  padding-top: 24px;
+  border-top: 1px solid var(--mkt-rule);
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--mkt-ink-soft);
+  flex-wrap: wrap;
+  gap: 16px;
+}
+@media (max-width: 800px) {
+  .mkt-footer__cols { grid-template-columns: 1fr 1fr; }
+}

--- a/ui/src/marketing/MarketingFooter.tsx
+++ b/ui/src/marketing/MarketingFooter.tsx
@@ -1,0 +1,46 @@
+import "./MarketingFooter.css";
+
+export function MarketingFooter() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="mkt-footer">
+      <div className="mkt-footer__inner">
+        <div className="mkt-footer__cols">
+          <div>
+            <div className="mkt-footer__brand">AgentDash</div>
+            <p className="mkt-footer__tagline">
+              The control plane for your AI company.
+            </p>
+          </div>
+          <div className="mkt-footer__col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="/">Features</a></li>
+              <li><a href="/assess">Assessment</a></li>
+              <li><a href="/auth">Sign in</a></li>
+            </ul>
+          </div>
+          <div className="mkt-footer__col">
+            <h4>Consulting</h4>
+            <ul>
+              <li><a href="/consulting">Approach</a></li>
+              <li><a href="/consulting#research">Research</a></li>
+              <li><a href="mailto:consulting@agentdash.com">Talk to us</a></li>
+            </ul>
+          </div>
+          <div className="mkt-footer__col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="/about">About</a></li>
+              <li><a href="mailto:hello@agentdash.com">Contact</a></li>
+            </ul>
+          </div>
+        </div>
+        <div className="mkt-footer__legal">
+          <span>© {year} AgentDash. All rights reserved.</span>
+          <span>consulting@agentdash.com</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/ui/src/marketing/MarketingHeader.css
+++ b/ui/src/marketing/MarketingHeader.css
@@ -1,0 +1,42 @@
+.mkt-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(250, 249, 245, 0.85);
+  backdrop-filter: saturate(180%) blur(8px);
+  border-bottom: 1px solid var(--mkt-rule);
+}
+.mkt-header__inner {
+  max-width: var(--mkt-container-max);
+  margin-inline: auto;
+  padding: 16px var(--mkt-container-gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.mkt-header__brand {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  color: var(--mkt-ink);
+  /* Wordmark size + tracking come from AgentDashLogo's size prop. */
+}
+.mkt-header__nav {
+  display: flex;
+  gap: 32px;
+}
+.mkt-header__nav a {
+  text-decoration: none;
+  font-size: 15px;
+  color: var(--mkt-ink-soft);
+}
+.mkt-header__nav a:hover { color: var(--mkt-ink); }
+.mkt-header__cta {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+@media (max-width: 800px) {
+  .mkt-header__nav { display: none; }
+}

--- a/ui/src/marketing/MarketingHeader.tsx
+++ b/ui/src/marketing/MarketingHeader.tsx
@@ -1,0 +1,25 @@
+import "./MarketingHeader.css";
+import { Button } from "./components/Button";
+import { AgentDashLogo } from "./components/AgentDashLogo";
+
+export function MarketingHeader() {
+  return (
+    <header className="mkt-header">
+      <div className="mkt-header__inner">
+        <a href="/" className="mkt-header__brand" aria-label="AgentDash home">
+          <AgentDashLogo size="md" />
+        </a>
+        <nav className="mkt-header__nav" aria-label="Primary">
+          <a href="/">Product</a>
+          <a href="/consulting">Consulting</a>
+          <a href="/assess">Assessment</a>
+          <a href="/about">About</a>
+        </nav>
+        <div className="mkt-header__cta">
+          <Button href="/auth" variant="link">Sign in</Button>
+          <Button href="/auth?mode=sign_up">Start free</Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/ui/src/marketing/MarketingShell.css
+++ b/ui/src/marketing/MarketingShell.css
@@ -1,0 +1,22 @@
+/* AgentDash: marketing surface always renders in cream/light theme,
+   regardless of the dashboard's global html.dark class. Without this,
+   marketing pages painted cream cards on a dark body and looked broken. */
+.mkt-root {
+  color-scheme: light;
+  background: var(--mkt-surface-cream);
+  color: var(--mkt-ink);
+  min-height: 100vh;
+}
+
+.mkt-skip-link {
+  position: absolute;
+  top: -100px;
+  left: 16px;
+  background: var(--mkt-ink);
+  color: var(--mkt-surface-cream);
+  padding: 12px 16px;
+  border-radius: 6px;
+  text-decoration: none;
+  z-index: 100;
+}
+.mkt-skip-link:focus { top: 12px; }

--- a/ui/src/marketing/MarketingShell.tsx
+++ b/ui/src/marketing/MarketingShell.tsx
@@ -1,0 +1,15 @@
+import "./MarketingShell.css";
+import type { ReactNode } from "react";
+import { MarketingHeader } from "./MarketingHeader";
+import { MarketingFooter } from "./MarketingFooter";
+
+export function MarketingShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="mkt-root">
+      <a href="#mkt-main" className="mkt-skip-link">Skip to content</a>
+      <MarketingHeader />
+      <main id="mkt-main">{children}</main>
+      <MarketingFooter />
+    </div>
+  );
+}

--- a/ui/src/marketing/components/AgentDashLogo.css
+++ b/ui/src/marketing/components/AgentDashLogo.css
@@ -1,0 +1,36 @@
+/*
+ * AgentDash brand lockup. Mark + wordmark, vertically centered, with
+ * size-specific tracking. The mark itself is in AgentDashLogo.tsx as
+ * inline SVG so it inherits currentColor when desired.
+ */
+
+.mkt-logo {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+  text-decoration: none;
+  color: inherit;
+}
+
+.mkt-logo__mark {
+  display: block;
+  flex-shrink: 0;
+}
+
+.mkt-logo__wordmark {
+  font-family: var(--mkt-font-serif, "Iowan Old Style", "Palatino Linotype", Georgia, serif);
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1;
+  color: var(--mkt-ink, #1f1e1d);
+  white-space: nowrap;
+}
+
+/* Size-specific micro-adjustments — small sizes need tighter tracking. */
+.mkt-logo--sm .mkt-logo__wordmark {
+  letter-spacing: -0.01em;
+}
+
+.mkt-logo--lg .mkt-logo__wordmark {
+  letter-spacing: -0.02em;
+}

--- a/ui/src/marketing/components/AgentDashLogo.tsx
+++ b/ui/src/marketing/components/AgentDashLogo.tsx
@@ -1,0 +1,103 @@
+import "./AgentDashLogo.css";
+
+// AgentDash brand mark: monogram 'a' (hexagonal silhouette with chamfered
+// top-right corner) wrapping a counter-space NE arrow. The hexagon
+// references a dashboard tile; the arrow communicates forward motion +
+// the lowercase 'a' counter. Teal primary per CLAUDE.md.
+//
+// Variants:
+//   • <AgentDashLogo />                 → full lockup (mark + wordmark)
+//   • <AgentDashLogo variant="mark" />  → mark only (favicon, app chrome)
+//   • <AgentDashLogo size="sm|md|lg" /> → coordinated sizing
+//
+// The mark itself is colour-agnostic: pass `tone="dark"` when rendering on
+// a dark surface (e.g. dashboard chrome) — the arrow's knockout flips to
+// stay readable. Default tone is "light" (cream-knockout arrow on teal).
+
+type Tone = "light" | "dark";
+type Variant = "lockup" | "mark";
+type Size = "sm" | "md" | "lg";
+
+export interface AgentDashLogoProps {
+  variant?: Variant;
+  size?: Size;
+  tone?: Tone;
+  className?: string;
+  /** Override the wordmark text colour (defaults to ink). */
+  wordmarkColor?: string;
+}
+
+const SIZE_PX: Record<Size, { mark: number; gap: number; word: number }> = {
+  sm: { mark: 22, gap: 8,  word: 16 },
+  md: { mark: 32, gap: 10, word: 22 },
+  lg: { mark: 44, gap: 14, word: 30 },
+};
+
+export function AgentDashLogo({
+  variant = "lockup",
+  size = "md",
+  tone = "light",
+  className,
+  wordmarkColor,
+}: AgentDashLogoProps) {
+  const sizing = SIZE_PX[size];
+  const cls = ["mkt-logo", `mkt-logo--${size}`, className].filter(Boolean).join(" ");
+
+  return (
+    <span className={cls} aria-label="AgentDash">
+      <AgentDashMark size={sizing.mark} tone={tone} />
+      {variant === "lockup" ? (
+        <span
+          className="mkt-logo__wordmark"
+          style={{
+            fontSize: sizing.word,
+            marginLeft: sizing.gap,
+            color: wordmarkColor,
+          }}
+        >
+          AgentDash
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function AgentDashMark({ size, tone }: { size: number; tone: Tone }) {
+  // The mark sits in a 64x64 viewBox. The outer path is the chamfered
+  // hexagonal 'a' silhouette. The inner two strokes draw a NE arrow as
+  // counter-space (cream on teal) — same geometry as Lucide ArrowUpRight,
+  // scaled and recentred so the visual weight balances inside the hex.
+  const fill = tone === "dark" ? "var(--mkt-surface-cream, #faf9f5)" : "#0d9488";
+  const arrow = tone === "dark" ? "#0d9488" : "var(--mkt-surface-cream, #faf9f5)";
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      role="img"
+      aria-hidden="true"
+      className="mkt-logo__mark"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Outer 'a' hexagon — rounded rect with a chamfered top-right corner */}
+      <path
+        d="M14 4 H42 L60 22 V50 A10 10 0 0 1 50 60 H14 A10 10 0 0 1 4 50 V14 A10 10 0 0 1 14 4 Z"
+        fill={fill}
+      />
+      {/* NE arrow counter — drawn with rounded strokes for crispness at small sizes */}
+      <g
+        stroke={arrow}
+        strokeWidth={6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      >
+        {/* Diagonal shaft, SW → NE */}
+        <line x1="22" y1="42" x2="42" y2="22" />
+        {/* Arrowhead corner: top edge, then right edge */}
+        <polyline points="26,22 42,22 42,38" />
+      </g>
+    </svg>
+  );
+}

--- a/ui/src/marketing/components/Button.css
+++ b/ui/src/marketing/components/Button.css
@@ -1,0 +1,45 @@
+.mkt-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 22px;
+  border-radius: 8px;
+  font-family: var(--mkt-font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background-color 160ms var(--mkt-ease), color 160ms var(--mkt-ease), border-color 160ms var(--mkt-ease);
+  white-space: nowrap;
+}
+.mkt-btn--primary {
+  background: var(--mkt-accent);
+  color: #fff;
+}
+.mkt-btn--primary:hover { background: var(--mkt-accent-ink); }
+.mkt-btn--ghost {
+  background: transparent;
+  color: var(--mkt-ink);
+  border-color: var(--mkt-ink);
+}
+.mkt-btn--ghost:hover { background: var(--mkt-ink); color: var(--mkt-surface-cream); }
+.mkt-btn--link {
+  background: transparent;
+  color: var(--mkt-ink);
+  padding: 0;
+  border: none;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.mkt-btn--link:hover { color: var(--mkt-accent-ink); }
+.mkt-btn--disabled,
+.mkt-btn--disabled:hover {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: var(--mkt-rule);
+  color: var(--mkt-ink-soft);
+  border-color: transparent;
+}

--- a/ui/src/marketing/components/Button.tsx
+++ b/ui/src/marketing/components/Button.tsx
@@ -1,0 +1,56 @@
+import "./Button.css";
+import type { ReactNode, MouseEvent } from "react";
+
+type Variant = "primary" | "ghost" | "link";
+
+interface BaseProps {
+  children: ReactNode;
+  variant?: Variant;
+  className?: string;
+  disabled?: boolean;
+}
+
+interface AnchorProps extends BaseProps {
+  href: string;
+  onClick?: (e: MouseEvent<HTMLAnchorElement>) => void;
+}
+
+interface ButtonProps extends BaseProps {
+  href?: undefined;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  type?: "button" | "submit";
+}
+
+export function Button(props: AnchorProps | ButtonProps) {
+  const variant: Variant = props.variant ?? "primary";
+  const disabled = props.disabled ?? false;
+  const cls = [
+    "mkt-btn",
+    `mkt-btn--${variant}`,
+    disabled ? "mkt-btn--disabled" : null,
+    props.className,
+  ].filter(Boolean).join(" ");
+
+  if ("href" in props && props.href !== undefined) {
+    return (
+      <a
+        href={disabled ? undefined : props.href}
+        onClick={disabled ? (e) => e.preventDefault() : props.onClick}
+        className={cls}
+        aria-disabled={disabled || undefined}
+      >
+        {props.children}
+      </a>
+    );
+  }
+  return (
+    <button
+      type={props.type ?? "button"}
+      onClick={props.onClick}
+      className={cls}
+      disabled={disabled}
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/ui/src/marketing/components/Eyebrow.tsx
+++ b/ui/src/marketing/components/Eyebrow.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function Eyebrow({ children }: { children: ReactNode }) {
+  return <div className="mkt-eyebrow">{children}</div>;
+}

--- a/ui/src/marketing/components/LogoStrip.css
+++ b/ui/src/marketing/components/LogoStrip.css
@@ -1,0 +1,18 @@
+.mkt-logo-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+.mkt-logo-strip__item {
+  height: 28px;
+  opacity: 0.7;
+  filter: grayscale(1);
+}
+.mkt-logo-strip__placeholder {
+  height: 28px;
+  width: 120px;
+  background: var(--mkt-rule);
+  border-radius: 4px;
+}

--- a/ui/src/marketing/components/LogoStrip.tsx
+++ b/ui/src/marketing/components/LogoStrip.tsx
@@ -1,0 +1,22 @@
+import "./LogoStrip.css";
+
+export interface LogoItem {
+  name: string;
+  src?: string; // when undefined, renders a placeholder rectangle
+}
+
+export function LogoStrip({ items }: { items: LogoItem[] }) {
+  return (
+    <div className="mkt-logo-strip" role="list" aria-label="Customers and partners">
+      {items.map((item) => (
+        <div key={item.name} role="listitem" aria-label={item.name}>
+          {item.src ? (
+            <img src={item.src} alt={item.name} className="mkt-logo-strip__item" />
+          ) : (
+            <div className="mkt-logo-strip__placeholder" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/marketing/components/QuoteBlock.css
+++ b/ui/src/marketing/components/QuoteBlock.css
@@ -1,0 +1,13 @@
+.mkt-quote {
+  font-family: var(--mkt-font-serif);
+  font-weight: 400;
+  font-size: clamp(24px, 3vw, 32px);
+  line-height: 1.3;
+  text-align: center;
+  max-width: 28ch;
+  margin-inline: auto;
+}
+.mkt-quote__attr {
+  margin-top: 24px;
+  text-align: center;
+}

--- a/ui/src/marketing/components/QuoteBlock.tsx
+++ b/ui/src/marketing/components/QuoteBlock.tsx
@@ -1,0 +1,10 @@
+import "./QuoteBlock.css";
+
+export function QuoteBlock({ quote, attribution }: { quote: string; attribution: string }) {
+  return (
+    <figure>
+      <blockquote className="mkt-quote">"{quote}"</blockquote>
+      <figcaption className="mkt-quote__attr mkt-caption">{attribution}</figcaption>
+    </figure>
+  );
+}

--- a/ui/src/marketing/components/SectionContainer.css
+++ b/ui/src/marketing/components/SectionContainer.css
@@ -1,0 +1,9 @@
+.mkt-section {
+  padding-block: clamp(96px, 12vh, 160px);
+}
+.mkt-section--cream-2 { background: var(--mkt-surface-cream-2); }
+.mkt-section__inner {
+  max-width: var(--mkt-container-max);
+  margin-inline: auto;
+  padding-inline: var(--mkt-container-gutter);
+}

--- a/ui/src/marketing/components/SectionContainer.tsx
+++ b/ui/src/marketing/components/SectionContainer.tsx
@@ -1,0 +1,23 @@
+import "./SectionContainer.css";
+import type { ReactNode } from "react";
+
+export function SectionContainer({
+  children,
+  background = "cream",
+  id,
+  as: Tag = "section",
+}: {
+  children: ReactNode;
+  background?: "cream" | "cream-2";
+  id?: string;
+  as?: "section" | "div";
+}) {
+  const cls = ["mkt-section", background === "cream-2" ? "mkt-section--cream-2" : null]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <Tag id={id} className={cls}>
+      <div className="mkt-section__inner">{children}</div>
+    </Tag>
+  );
+}

--- a/ui/src/marketing/diagrams/AgentPrimitivesDiagram.tsx
+++ b/ui/src/marketing/diagrams/AgentPrimitivesDiagram.tsx
@@ -1,0 +1,21 @@
+export function AgentPrimitivesDiagram() {
+  const subs = ["IDENTITY", "MEMORY", "HEARTBEAT", "TOOLS"];
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {/* main agent block */}
+      <rect x="20" y="80" width="80" height="40" rx="6" fill="var(--mkt-accent)" stroke="none" />
+      <text x="60" y="104" textAnchor="middle" fontSize="11" fill="#fff" fontFamily="var(--mkt-font-mono)">AGENT</text>
+      {/* connecting lines */}
+      {subs.map((_, i) => (
+        <line key={i} x1="100" y1={100} x2="180" y2={30 + i * 47} />
+      ))}
+      {/* sub-blocks */}
+      {subs.map((label, i) => (
+        <g key={label}>
+          <rect x="180" y={20 + i * 47} width="100" height="30" rx="5" />
+          <text x="230" y={39 + i * 47} textAnchor="middle" fontSize="10" fill="currentColor" fontFamily="var(--mkt-font-mono)">{label}</text>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/ui/src/marketing/diagrams/ControlPlaneDiagram.tsx
+++ b/ui/src/marketing/diagrams/ControlPlaneDiagram.tsx
@@ -1,0 +1,22 @@
+export function ControlPlaneDiagram() {
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {/* board node */}
+      <rect x="120" y="20" width="80" height="32" rx="4" fill="var(--mkt-accent)" stroke="none" />
+      <text x="160" y="40" textAnchor="middle" fontSize="12" fill="#fff" fontFamily="var(--mkt-font-mono)">BOARD</text>
+      {/* CEO */}
+      <line x1="160" y1="52" x2="160" y2="80" />
+      <rect x="130" y="80" width="60" height="28" rx="4" />
+      <text x="160" y="98" textAnchor="middle" fontSize="11" fill="currentColor">CEO</text>
+      {/* execs */}
+      <line x1="160" y1="108" x2="160" y2="130" />
+      <line x1="80" y1="130" x2="240" y2="130" />
+      <line x1="80" y1="130" x2="80" y2="148" />
+      <line x1="160" y1="130" x2="160" y2="148" />
+      <line x1="240" y1="130" x2="240" y2="148" />
+      <rect x="55" y="148" width="50" height="24" rx="4" />
+      <rect x="135" y="148" width="50" height="24" rx="4" />
+      <rect x="215" y="148" width="50" height="24" rx="4" />
+    </svg>
+  );
+}

--- a/ui/src/marketing/diagrams/InteropDiagram.tsx
+++ b/ui/src/marketing/diagrams/InteropDiagram.tsx
@@ -1,0 +1,27 @@
+export function InteropDiagram() {
+  const chips = [
+    { label: "HubSpot", angle: 0 },
+    { label: "Slack", angle: 90 },
+    { label: "Email", angle: 180 },
+    { label: "Webhook", angle: 270 },
+  ];
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      <circle cx="160" cy="100" r="30" fill="var(--mkt-accent)" stroke="none" />
+      <text x="160" y="104" textAnchor="middle" fontSize="11" fill="#fff" fontFamily="var(--mkt-font-mono)">CORE</text>
+      <circle cx="160" cy="100" r="60" />
+      <circle cx="160" cy="100" r="80" strokeDasharray="2 4" />
+      {chips.map((chip) => {
+        const rad = (chip.angle * Math.PI) / 180;
+        const x = 160 + Math.cos(rad) * 80;
+        const y = 100 + Math.sin(rad) * 80;
+        return (
+          <g key={chip.label}>
+            <rect x={x - 30} y={y - 12} width="60" height="24" rx="4" fill="var(--mkt-surface-cream)" />
+            <text x={x} y={y + 4} textAnchor="middle" fontSize="10" fill="currentColor">{chip.label}</text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/ui/src/marketing/diagrams/ModelServingDiagram.tsx
+++ b/ui/src/marketing/diagrams/ModelServingDiagram.tsx
@@ -1,0 +1,21 @@
+export function ModelServingDiagram() {
+  const models = ["Anthropic", "OpenAI", "Your own"];
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {/* boundary line — what's above is AgentDash, below is the model layer */}
+      <line x1="20" y1="60" x2="300" y2="60" strokeDasharray="4 4" />
+      <text x="20" y="50" fontSize="10" fill="currentColor" fontFamily="var(--mkt-font-mono)">— AGENTDASH —</text>
+      <text x="20" y="80" fontSize="10" fill="currentColor" fontFamily="var(--mkt-font-mono)">YOUR INFERENCE LAYER</text>
+      {models.map((label, i) => {
+        const x = 30 + i * 95;
+        const isHighlighted = i === 2;
+        return (
+          <g key={label}>
+            <rect x={x} y={110} width="80" height="50" rx="6" fill={isHighlighted ? "var(--mkt-accent)" : "none"} stroke={isHighlighted ? "none" : "currentColor"} />
+            <text x={x + 40} y={140} textAnchor="middle" fontSize="11" fill={isHighlighted ? "#fff" : "currentColor"}>{label}</text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/ui/src/marketing/diagrams/OrchestrationDiagram.tsx
+++ b/ui/src/marketing/diagrams/OrchestrationDiagram.tsx
@@ -1,0 +1,26 @@
+export function OrchestrationDiagram() {
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {/* nodes */}
+      {[
+        { x: 40, y: 40 },
+        { x: 160, y: 30 },
+        { x: 280, y: 50 },
+        { x: 100, y: 110 },
+        { x: 220, y: 120 },
+        { x: 160, y: 170 },
+      ].map((n, i) => (
+        <circle key={i} cx={n.x} cy={n.y} r="10" fill="var(--mkt-surface-cream)" />
+      ))}
+      {/* normal edges */}
+      <line x1="40" y1="40" x2="100" y2="110" />
+      <line x1="280" y1="50" x2="220" y2="120" />
+      <line x1="160" y1="30" x2="220" y2="120" />
+      <line x1="100" y1="110" x2="160" y2="170" />
+      {/* highlighted edges (coral) */}
+      <line x1="160" y1="30" x2="100" y2="110" stroke="var(--mkt-accent)" strokeWidth="2" />
+      <line x1="100" y1="110" x2="220" y2="120" stroke="var(--mkt-accent)" strokeWidth="2" />
+      <line x1="220" y1="120" x2="160" y2="170" stroke="var(--mkt-accent)" strokeWidth="2" />
+    </svg>
+  );
+}

--- a/ui/src/marketing/diagrams/TrustSafetyDiagram.tsx
+++ b/ui/src/marketing/diagrams/TrustSafetyDiagram.tsx
@@ -1,0 +1,18 @@
+export function TrustSafetyDiagram() {
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {/* ledger */}
+      <rect x="80" y="100" width="160" height="80" rx="4" />
+      {[120, 140, 160].map((y) => (
+        <line key={y} x1="92" y1={y} x2="228" y2={y} />
+      ))}
+      {/* shield */}
+      <path
+        d="M160 20 L200 35 L200 70 Q200 95 160 110 Q120 95 120 70 L120 35 Z"
+        fill="var(--mkt-accent)"
+        stroke="none"
+      />
+      <path d="M148 65 L158 75 L175 55" stroke="#fff" strokeWidth="2.5" fill="none" />
+    </svg>
+  );
+}

--- a/ui/src/marketing/diagrams/WorkspacesDiagram.tsx
+++ b/ui/src/marketing/diagrams/WorkspacesDiagram.tsx
@@ -1,0 +1,37 @@
+export function WorkspacesDiagram() {
+  const labels = ["Claude", "Codex", "Cursor", "Gemini", "Pi", "OpenCode", "OpenClaw"];
+  const cols = 4;
+  return (
+    <svg viewBox="0 0 320 200" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {labels.map((label, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        const x = 20 + col * 75;
+        const y = 40 + row * 60;
+        const isHighlighted = i === 0;
+        return (
+          <g key={label}>
+            <rect
+              x={x}
+              y={y}
+              width="64"
+              height="40"
+              rx="6"
+              fill={isHighlighted ? "var(--mkt-accent)" : "none"}
+              stroke={isHighlighted ? "none" : "currentColor"}
+            />
+            <text
+              x={x + 32}
+              y={y + 24}
+              textAnchor="middle"
+              fontSize="11"
+              fill={isHighlighted ? "#fff" : "currentColor"}
+              stroke="none"
+              fontFamily="var(--mkt-font-sans)"
+            >{label}</text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/ui/src/marketing/fonts.css
+++ b/ui/src/marketing/fonts.css
@@ -1,0 +1,10 @@
+/*
+ * Marketing fonts. Loaded via the Google Fonts <link> in ui/index.html so we
+ * stay in sync with the rest of the app and avoid lockfile churn from
+ * Fontsource npm packages.
+ */
+:root {
+  --mkt-font-serif: "Newsreader", "Times New Roman", serif;
+  --mkt-font-sans: "Inter Tight", "Inter", system-ui, sans-serif;
+  --mkt-font-mono: "JetBrains Mono", ui-monospace, monospace;
+}

--- a/ui/src/marketing/hooks/useDescentProgress.ts
+++ b/ui/src/marketing/hooks/useDescentProgress.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+
+export function computeProgress(
+  rect: { top: number; height: number },
+  viewportHeight: number,
+): number {
+  const travel = rect.height - viewportHeight;
+  if (travel <= 0) return 0;
+  // top is 0 when section enters viewport from above; goes negative as we scroll past.
+  // Progress = how far through `travel` we've scrolled, clamped 0..1.
+  const scrolled = -rect.top;
+  if (scrolled <= 0) return 0;
+  if (scrolled >= travel) return 1;
+  return scrolled / travel;
+}
+
+export function useDescentProgress(ref: React.RefObject<HTMLElement | null>): number {
+  const [progress, setProgress] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const tick = () => {
+      if (!mounted) return;
+      const el = ref.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        const next = computeProgress(
+          { top: rect.top, height: rect.height },
+          window.innerHeight,
+        );
+        setProgress((prev) => (Math.abs(prev - next) < 0.001 ? prev : next));
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      mounted = false;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [ref]);
+
+  return progress;
+}

--- a/ui/src/marketing/hooks/usePrefersReducedMotion.ts
+++ b/ui/src/marketing/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefers, setPrefers] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = (e: MediaQueryListEvent) => setPrefers(e.matches);
+    mq.addEventListener("change", listener);
+    return () => mq.removeEventListener("change", listener);
+  }, []);
+
+  return prefers;
+}

--- a/ui/src/marketing/pages/About.tsx
+++ b/ui/src/marketing/pages/About.tsx
@@ -1,0 +1,23 @@
+import { MarketingShell } from "../MarketingShell";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+import { AboutMission } from "../sections/AboutMission";
+import { AboutFounder } from "../sections/AboutFounder";
+
+export function About() {
+  return (
+    <MarketingShell>
+      <SectionContainer>
+        <Eyebrow>About</Eyebrow>
+        <h1 className="mkt-display-page" style={{ marginTop: 16 }}>Why AgentDash exists.</h1>
+      </SectionContainer>
+      <AboutMission />
+      <AboutFounder />
+      <SectionContainer>
+        <p style={{ textAlign: "center", color: "var(--mkt-ink-soft)" }}>
+          Press, partnerships, careers — <a href="mailto:hello@agentdash.com">hello@agentdash.com</a>
+        </p>
+      </SectionContainer>
+    </MarketingShell>
+  );
+}

--- a/ui/src/marketing/pages/Consulting.tsx
+++ b/ui/src/marketing/pages/Consulting.tsx
@@ -1,0 +1,42 @@
+import { MarketingShell } from "../MarketingShell";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+import { ConsultingPhases } from "../sections/ConsultingPhases";
+import { ResearchBriefs } from "../sections/ResearchBriefs";
+import { ReadinessBand } from "../sections/ReadinessBand";
+import { EngagementCards } from "../sections/EngagementCards";
+
+export function Consulting() {
+  return (
+    <MarketingShell>
+      <SectionContainer>
+        <Eyebrow>Consulting practice</Eyebrow>
+        <h1 className="mkt-display-page" style={{ marginTop: 16, marginBottom: 32, maxWidth: "18ch" }}>
+          We install AI workforces inside enterprises.
+        </h1>
+        <div style={{ display: "grid", gap: 24, maxWidth: "60ch", color: "var(--mkt-ink-soft)" }}>
+          <p className="mkt-body-lg">
+            Most enterprise AI pilots stall after the demo. The slideware is excellent.
+            The integration is a slog. The first six months disappear.
+          </p>
+          <p className="mkt-body-lg">
+            We run a structured deployment, not a slideware engagement. We sit with
+            your team, ship agents into production within the first quarter, and stay
+            through the first quarter of operation so the workforce becomes
+            something the team owns — not a project we have to babysit.
+          </p>
+        </div>
+      </SectionContainer>
+      <ConsultingPhases />
+      <ResearchBriefs />
+      <ReadinessBand />
+      <EngagementCards />
+      <SectionContainer>
+        <h2 className="mkt-display-section" style={{ textAlign: "center" }}>Tell us what you're trying to build.</h2>
+        <p style={{ textAlign: "center", marginTop: 24 }}>
+          <a href="mailto:consulting@agentdash.com">consulting@agentdash.com</a>
+        </p>
+      </SectionContainer>
+    </MarketingShell>
+  );
+}

--- a/ui/src/marketing/pages/Landing.tsx
+++ b/ui/src/marketing/pages/Landing.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from "@tanstack/react-query";
+import { Navigate, useSearchParams } from "@/lib/router";
+import { authApi } from "../../api/auth";
+import { queryKeys } from "../../lib/queryKeys";
+import { healthApi } from "../../api/health";
+import { MarketingShell } from "../MarketingShell";
+import { Hero } from "../sections/Hero";
+import { LayeredDescent } from "../sections/LayeredDescent";
+import { CapabilitiesGrid } from "../sections/CapabilitiesGrid";
+import { HowItWorks } from "../sections/HowItWorks";
+import { ConsultingBand } from "../sections/ConsultingBand";
+import { FinalCTA } from "../sections/FinalCTA";
+import { SectionContainer } from "../components/SectionContainer";
+import { LogoStrip } from "../components/LogoStrip";
+import { QuoteBlock } from "../components/QuoteBlock";
+
+const PLACEHOLDER_LOGOS = [
+  { name: "Logo 1" },
+  { name: "Logo 2" },
+  { name: "Logo 3" },
+  { name: "Logo 4" },
+  { name: "Logo 5" },
+];
+
+export function Landing() {
+  const [searchParams] = useSearchParams();
+  // ?preview=1 skips the logged-in redirect so the marketing landing is
+  // viewable locally even in local_trusted mode (where the user is implicitly
+  // logged in and would otherwise be sent straight to /companies).
+  const previewMode = searchParams.get("preview") === "1";
+  const healthQuery = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+    retry: false,
+  });
+  const isAuthenticatedMode = healthQuery.data?.deploymentMode === "authenticated";
+  const sessionQuery = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    enabled: isAuthenticatedMode,
+    retry: false,
+  });
+
+  if (!previewMode && (healthQuery.isLoading || (isAuthenticatedMode && sessionQuery.isLoading))) return null;
+  const loggedIn = !isAuthenticatedMode || Boolean(sessionQuery.data);
+  if (!previewMode && loggedIn) return <Navigate to="/companies" replace />;
+
+  return (
+    <MarketingShell>
+      <Hero />
+      <SectionContainer>
+        <LogoStrip items={PLACEHOLDER_LOGOS} />
+      </SectionContainer>
+      <SectionContainer background="cream-2">
+        <QuoteBlock
+          quote="The first week our agents shipped, we caught up on six months of backlog. By month two, the board stopped asking how we'd staff the new initiative."
+          attribution="— Placeholder: replace with a real operator quote"
+        />
+      </SectionContainer>
+      <LayeredDescent />
+      <CapabilitiesGrid />
+      <HowItWorks />
+      <ConsultingBand />
+      <FinalCTA />
+    </MarketingShell>
+  );
+}

--- a/ui/src/marketing/sections/AboutFounder.css
+++ b/ui/src/marketing/sections/AboutFounder.css
@@ -1,0 +1,34 @@
+.mkt-founder-card {
+  background: var(--mkt-surface-cream-2);
+  border: 1px solid var(--mkt-rule);
+  border-radius: 16px;
+  padding: 80px 64px;
+  max-width: 960px;
+  margin-inline: auto;
+}
+.mkt-founder-card__title {
+  text-align: center;
+  font-family: var(--mkt-font-serif);
+  font-weight: 600;
+  font-size: 56px;
+  margin-bottom: 56px;
+}
+.mkt-founder { display: grid; grid-template-columns: auto 1fr; gap: 48px; align-items: center; }
+.mkt-founder__portrait {
+  width: 160px;
+  height: 160px;
+  border-radius: 999px;
+  border: 4px solid var(--mkt-accent);
+  background: var(--mkt-rule);
+  object-fit: cover;
+  display: block;
+}
+.mkt-founder__name { font-family: var(--mkt-font-sans); font-weight: 600; font-size: 28px; margin-bottom: 16px; }
+.mkt-founder__bio { color: var(--mkt-ink-soft); font-size: 17px; line-height: 1.55; margin-bottom: 16px; }
+.mkt-founder__linkedin { display: inline-flex; align-items: center; gap: 8px; color: var(--mkt-accent-ink); text-decoration: none; }
+.mkt-founder__linkedin:hover { text-decoration: underline; }
+@media (max-width: 700px) {
+  .mkt-founder-card { padding: 48px 24px; }
+  .mkt-founder { grid-template-columns: 1fr; text-align: center; }
+  .mkt-founder__portrait { margin-inline: auto; }
+}

--- a/ui/src/marketing/sections/AboutFounder.tsx
+++ b/ui/src/marketing/sections/AboutFounder.tsx
@@ -1,0 +1,35 @@
+import "./AboutFounder.css";
+import { Linkedin } from "lucide-react";
+import { SectionContainer } from "../components/SectionContainer";
+
+// FILL IN: founder.{name|portrait|bio|linkedin} — supplied by the user.
+const FOUNDER = {
+  name: "[Founder Name]",
+  portrait: "", // empty string renders the placeholder ring
+  bio: "[Title] of AgentDash | [Background line, modeled on yarda's: e.g., 'Former Google & Consulting professional focused on giving every company the operating clarity to run AI agents safely.']",
+  linkedin: "https://www.linkedin.com/in/",
+};
+
+export function AboutFounder() {
+  return (
+    <SectionContainer>
+      <div className="mkt-founder-card">
+        <div className="mkt-founder-card__title">Who We Are</div>
+        <div className="mkt-founder">
+          {FOUNDER.portrait ? (
+            <img src={FOUNDER.portrait} alt={FOUNDER.name} className="mkt-founder__portrait" />
+          ) : (
+            <div className="mkt-founder__portrait" aria-label="Portrait placeholder" />
+          )}
+          <div>
+            <div className="mkt-founder__name">{FOUNDER.name}</div>
+            <p className="mkt-founder__bio">{FOUNDER.bio}</p>
+            <a href={FOUNDER.linkedin} className="mkt-founder__linkedin" target="_blank" rel="noreferrer">
+              <Linkedin size={18} strokeWidth={1.5} aria-hidden /> Follow on LinkedIn
+            </a>
+          </div>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/AboutMission.tsx
+++ b/ui/src/marketing/sections/AboutMission.tsx
@@ -1,0 +1,16 @@
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+
+// FILL IN: mission — paragraph supplied by the user. Placeholder copy below.
+const MISSION = "AgentDash exists so that any company can run an AI workforce with the same clarity, accountability, and safety it expects from its human teams.";
+
+export function AboutMission() {
+  return (
+    <SectionContainer>
+      <div style={{ textAlign: "center", marginBottom: 48 }}>
+        <Eyebrow>Our mission</Eyebrow>
+      </div>
+      <p className="mkt-mission">{MISSION}</p>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/CapabilitiesGrid.css
+++ b/ui/src/marketing/sections/CapabilitiesGrid.css
@@ -1,0 +1,10 @@
+.mkt-cap-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 48px;
+}
+.mkt-cap-tile { display: grid; gap: 12px; }
+.mkt-cap-tile__icon { color: var(--mkt-ink); }
+.mkt-cap-tile__title { font-weight: 600; font-size: 20px; }
+.mkt-cap-tile__body { color: var(--mkt-ink-soft); }
+@media (max-width: 800px) { .mkt-cap-grid { grid-template-columns: 1fr; } }

--- a/ui/src/marketing/sections/CapabilitiesGrid.tsx
+++ b/ui/src/marketing/sections/CapabilitiesGrid.tsx
@@ -1,0 +1,33 @@
+import "./CapabilitiesGrid.css";
+import { Factory, GitBranch, ShieldAlert, BookOpen, ScrollText, Boxes } from "lucide-react";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+
+const TILES = [
+  { Icon: Factory,     title: "Agent Factory",      body: "Spawn from templates, scale up or down." },
+  { Icon: GitBranch,   title: "Task Dependencies",  body: "Hierarchical work that traces to the goal." },
+  { Icon: ShieldAlert, title: "Budget Hard-Stops",  body: "Spend caps you can defend in a board meeting." },
+  { Icon: BookOpen,    title: "Skills Registry",    body: "Teach an agent once, reuse everywhere." },
+  { Icon: ScrollText,  title: "Activity Audit",     body: "Every action, every decision, fully logged." },
+  { Icon: Boxes,       title: "Multi-Adapter",      body: "Claude, Codex, Cursor, Gemini, Pi, OpenCode, OpenClaw." },
+];
+
+export function CapabilitiesGrid() {
+  return (
+    <SectionContainer>
+      <Eyebrow>What's in the box</Eyebrow>
+      <h2 className="mkt-display-section" style={{ marginTop: 16, marginBottom: 64 }}>
+        Built for the work agents actually do.
+      </h2>
+      <div className="mkt-cap-grid">
+        {TILES.map(({ Icon, title, body }) => (
+          <div className="mkt-cap-tile" key={title}>
+            <Icon className="mkt-cap-tile__icon" size={24} strokeWidth={1.5} />
+            <div className="mkt-cap-tile__title">{title}</div>
+            <div className="mkt-cap-tile__body">{body}</div>
+          </div>
+        ))}
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/ConsultingBand.css
+++ b/ui/src/marketing/sections/ConsultingBand.css
@@ -1,0 +1,4 @@
+.mkt-cb { display: grid; grid-template-columns: 1.2fr 1fr; gap: 64px; align-items: center; }
+.mkt-cb__copy { display: grid; gap: 24px; }
+.mkt-cb__art { color: var(--mkt-ink); }
+@media (max-width: 800px) { .mkt-cb { grid-template-columns: 1fr; } }

--- a/ui/src/marketing/sections/ConsultingBand.tsx
+++ b/ui/src/marketing/sections/ConsultingBand.tsx
@@ -1,0 +1,64 @@
+import "./ConsultingBand.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Button } from "../components/Button";
+
+export function ConsultingBand() {
+  return (
+    <SectionContainer background="cream-2">
+      <div className="mkt-cb">
+        <div className="mkt-cb__copy">
+          <h2 className="mkt-display-section">Want this installed for you?</h2>
+          <p className="mkt-body-lg" style={{ color: "var(--mkt-ink-soft)" }}>
+            Our consulting practice deploys AgentDash inside enterprises — diagnose
+            the highest-impact pain points, design the agent org, ship the first
+            workforce in production, and stay through the first quarter of
+            operation.
+          </p>
+          <div>
+            <Button href="/consulting" variant="ghost">Talk to our consulting team</Button>
+          </div>
+        </div>
+        <div className="mkt-cb__art" aria-hidden>
+          <OrgChartSvg />
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}
+
+function OrgChartSvg() {
+  return (
+    <svg viewBox="0 0 360 280" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      {/* CEO node, coral */}
+      <rect x="150" y="20" width="60" height="36" rx="6" fill="var(--mkt-accent)" stroke="none" />
+      <text x="180" y="42" textAnchor="middle" fontSize="12" fill="#fff">CEO</text>
+      {/* execs */}
+      <line x1="180" y1="56" x2="180" y2="80" />
+      <line x1="80" y1="80" x2="280" y2="80" />
+      <line x1="80" y1="80" x2="80" y2="100" />
+      <line x1="180" y1="80" x2="180" y2="100" />
+      <line x1="280" y1="80" x2="280" y2="100" />
+      {[
+        { x: 60, label: "CTO" },
+        { x: 160, label: "CMO" },
+        { x: 260, label: "CFO" },
+      ].map((n) => (
+        <g key={n.label}>
+          <rect x={n.x} y="100" width="40" height="28" rx="4" />
+          <text x={n.x + 20} y="118" textAnchor="middle" fontSize="11" fill="currentColor">{n.label}</text>
+        </g>
+      ))}
+      {/* reports */}
+      {[60, 160, 260].map((x) => (
+        <g key={x}>
+          <line x1={x + 20} y1="128" x2={x + 20} y2="160" />
+          <line x1={x - 8} y1="160" x2={x + 48} y2="160" />
+          <line x1={x - 8} y1="160" x2={x - 8} y2="180" />
+          <line x1={x + 48} y1="160" x2={x + 48} y2="180" />
+          <rect x={x - 24} y="180" width="32" height="22" rx="3" />
+          <rect x={x + 32} y="180" width="32" height="22" rx="3" />
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/ui/src/marketing/sections/ConsultingPhases.css
+++ b/ui/src/marketing/sections/ConsultingPhases.css
@@ -1,0 +1,7 @@
+.mkt-phases { display: grid; gap: 64px; max-width: 760px; }
+.mkt-phase { display: grid; grid-template-columns: 80px 1fr; gap: 32px; padding-bottom: 48px; border-bottom: 1px solid var(--mkt-rule); }
+.mkt-phase:last-child { border-bottom: none; }
+.mkt-phase__num { font-family: var(--mkt-font-serif); font-weight: 500; font-size: 56px; line-height: 1; color: var(--mkt-accent); }
+.mkt-phase__name { font-family: var(--mkt-font-serif); font-weight: 500; font-size: 32px; line-height: 1.1; margin-bottom: 12px; }
+.mkt-phase__body { color: var(--mkt-ink-soft); margin-bottom: 12px; }
+.mkt-phase__meta { display: flex; gap: 24px; font-family: var(--mkt-font-mono); font-size: 12px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--mkt-ink-soft); }

--- a/ui/src/marketing/sections/ConsultingPhases.tsx
+++ b/ui/src/marketing/sections/ConsultingPhases.tsx
@@ -1,0 +1,40 @@
+import "./ConsultingPhases.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+
+const PHASES = [
+  { n: "01", name: "Diagnose",   window: "2 weeks",   outcome: "Process map · pain ledger · readiness signal",
+    body: "We sit with the team for two weeks. We map what actually happens day-to-day, document the points where work stalls, and produce a readiness signal that says where agents will land first." },
+  { n: "02", name: "Design",     window: "2 weeks",   outcome: "Org chart · task hierarchy · guardrails",
+    body: "We design the agent org chart, the task hierarchy that traces to a real business goal, and the guardrails — budget caps, approval gates, and the kill switch." },
+  { n: "03", name: "Deploy",     window: "4 weeks",   outcome: "Agents in production · board oversight wired",
+    body: "We ship the first agents into production. Real work. Real cost. Board oversight is wired in from day one — every action is logged and reviewable." },
+  { n: "04", name: "Operate",    window: "Ongoing",   outcome: "Weekly review · scope expansion · handoff",
+    body: "We run weekly reviews with the team that owns the workforce, expand scope as confidence builds, and eventually hand the keys back." },
+];
+
+export function ConsultingPhases() {
+  return (
+    <SectionContainer>
+      <Eyebrow>How we work</Eyebrow>
+      <h2 className="mkt-display-section" style={{ marginTop: 16, marginBottom: 64 }}>
+        Four phases, not features.
+      </h2>
+      <div className="mkt-phases">
+        {PHASES.map((p) => (
+          <div key={p.n} className="mkt-phase">
+            <div className="mkt-phase__num">{p.n}</div>
+            <div>
+              <h3 className="mkt-phase__name">{p.name}</h3>
+              <p className="mkt-phase__body">{p.body}</p>
+              <div className="mkt-phase__meta">
+                <span>{p.window}</span>
+                <span>{p.outcome}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/EngagementCards.css
+++ b/ui/src/marketing/sections/EngagementCards.css
@@ -1,0 +1,10 @@
+.mkt-eng { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+.mkt-eng-card {
+  border: 1px solid var(--mkt-rule);
+  border-radius: 12px;
+  padding: 40px;
+  background: var(--mkt-surface-cream);
+}
+.mkt-eng-card__name { font-family: var(--mkt-font-serif); font-weight: 500; font-size: 32px; margin-bottom: 16px; }
+.mkt-eng-card__body { color: var(--mkt-ink-soft); }
+@media (max-width: 800px) { .mkt-eng { grid-template-columns: 1fr; } }

--- a/ui/src/marketing/sections/EngagementCards.tsx
+++ b/ui/src/marketing/sections/EngagementCards.tsx
@@ -1,0 +1,24 @@
+import "./EngagementCards.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+
+export function EngagementCards() {
+  return (
+    <SectionContainer background="cream-2">
+      <Eyebrow>Engagement</Eyebrow>
+      <h2 className="mkt-display-section" style={{ marginTop: 16, marginBottom: 48 }}>
+        Two ways to work with us.
+      </h2>
+      <div className="mkt-eng">
+        <div className="mkt-eng-card">
+          <div className="mkt-eng-card__name">Pilot</div>
+          <div className="mkt-eng-card__body">4–6 weeks, fixed scope, fixed price. Goal: prove the workforce shipping real work in production.</div>
+        </div>
+        <div className="mkt-eng-card">
+          <div className="mkt-eng-card__name">Production</div>
+          <div className="mkt-eng-card__body">Quarterly retainer, expanding scope, embedded with your team. Goal: build the operating muscle to run agents long-term.</div>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/FinalCTA.css
+++ b/ui/src/marketing/sections/FinalCTA.css
@@ -1,0 +1,7 @@
+.mkt-final {
+  text-align: center;
+  display: grid;
+  gap: 32px;
+  justify-items: center;
+}
+.mkt-final__cta-row { display: flex; gap: 16px; flex-wrap: wrap; justify-content: center; }

--- a/ui/src/marketing/sections/FinalCTA.tsx
+++ b/ui/src/marketing/sections/FinalCTA.tsx
@@ -1,0 +1,17 @@
+import "./FinalCTA.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Button } from "../components/Button";
+
+export function FinalCTA() {
+  return (
+    <SectionContainer>
+      <div className="mkt-final">
+        <h2 className="mkt-display-section">Start running your AI company.</h2>
+        <div className="mkt-final__cta-row">
+          <Button href="/auth?mode=sign_up">Start free</Button>
+          <Button href="mailto:consulting@agentdash.com" variant="ghost">Talk to sales</Button>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/Hero.css
+++ b/ui/src/marketing/sections/Hero.css
@@ -1,0 +1,21 @@
+.mkt-hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: center;
+  padding-block: clamp(64px, 10vh, 128px);
+}
+.mkt-hero__copy { display: grid; gap: 32px; }
+.mkt-hero__cta-row { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+.mkt-hero__reassure { color: var(--mkt-ink-soft); font-size: 14px; }
+.mkt-hero__art {
+  border: 1px solid var(--mkt-rule);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 24px 48px -24px rgba(31, 30, 29, 0.18);
+  padding: 24px;
+  color: var(--mkt-ink);
+}
+@media (max-width: 900px) {
+  .mkt-hero { grid-template-columns: 1fr; }
+}

--- a/ui/src/marketing/sections/Hero.tsx
+++ b/ui/src/marketing/sections/Hero.tsx
@@ -1,0 +1,32 @@
+import "./Hero.css";
+import { Eyebrow } from "../components/Eyebrow";
+import { Button } from "../components/Button";
+import { SectionContainer } from "../components/SectionContainer";
+import { LiveBriefing } from "./LiveBriefing";
+
+export function Hero() {
+  return (
+    <SectionContainer>
+      <div className="mkt-hero">
+        <div className="mkt-hero__copy">
+          <Eyebrow>The control plane for your AI company</Eyebrow>
+          <h1 className="mkt-display-hero">
+            Run an AI workforce the way you'd run a company.
+          </h1>
+          <p className="mkt-body-lg">
+            Goals, agents, budgets, and audit trails — in one control plane your
+            board would actually approve of.
+          </p>
+          <div className="mkt-hero__cta-row">
+            <Button href="/auth?mode=sign_up">Start free</Button>
+            <Button href="#layered-descent" variant="ghost">See the architecture</Button>
+          </div>
+          <p className="mkt-hero__reassure">No credit card · Free single-seat tier</p>
+        </div>
+        <div className="mkt-hero__art">
+          <LiveBriefing />
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/HowItWorks.css
+++ b/ui/src/marketing/sections/HowItWorks.css
@@ -1,0 +1,11 @@
+.mkt-how-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 48px; }
+.mkt-how-step__num {
+  font-family: var(--mkt-font-serif);
+  font-size: 64px;
+  line-height: 1;
+  color: var(--mkt-accent);
+  margin-bottom: 16px;
+}
+.mkt-how-step__title { font-weight: 600; font-size: 20px; margin-bottom: 8px; }
+.mkt-how-step__body { color: var(--mkt-ink-soft); }
+@media (max-width: 800px) { .mkt-how-grid { grid-template-columns: 1fr; } }

--- a/ui/src/marketing/sections/HowItWorks.tsx
+++ b/ui/src/marketing/sections/HowItWorks.tsx
@@ -1,0 +1,29 @@
+import "./HowItWorks.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+
+const STEPS = [
+  { n: "01", title: "Create the company",       body: "Define the goal. AgentDash sets up the org, the budget, and the audit log." },
+  { n: "02", title: "Hire the CEO and team",     body: "Pick adapters, define reporting lines, set the heartbeat. We provide sensible defaults." },
+  { n: "03", title: "Watch the morning briefing",body: "Every day starts with a one-screen view of what your AI workforce did and what needs you." },
+];
+
+export function HowItWorks() {
+  return (
+    <SectionContainer background="cream-2">
+      <Eyebrow>How it works</Eyebrow>
+      <h2 className="mkt-display-section" style={{ marginTop: 16, marginBottom: 64 }}>
+        Three steps to a running AI company.
+      </h2>
+      <div className="mkt-how-grid">
+        {STEPS.map((s) => (
+          <div key={s.n}>
+            <div className="mkt-how-step__num">{s.n}</div>
+            <div className="mkt-how-step__title">{s.title}</div>
+            <div className="mkt-how-step__body">{s.body}</div>
+          </div>
+        ))}
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/LayeredDescent.css
+++ b/ui/src/marketing/sections/LayeredDescent.css
@@ -1,0 +1,116 @@
+.mkt-descent {
+  /* 7 layers × 100vh of scroll travel */
+  height: 700vh;
+  position: relative;
+}
+.mkt-descent__stage {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  gap: 80px;
+  padding: 0 var(--mkt-container-gutter);
+  max-width: var(--mkt-container-max);
+  margin-inline: auto;
+  --descent-progress: 0;
+  --layer-count: 7;
+  --active-index: calc(var(--descent-progress) * (var(--layer-count) - 1));
+}
+.mkt-descent__rail {
+  position: absolute;
+  left: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: grid;
+  gap: 16px;
+  font-family: var(--mkt-font-mono);
+  font-size: 11px;
+  color: var(--mkt-ink-soft);
+}
+.mkt-descent__rail-item--active {
+  color: var(--mkt-accent);
+}
+.mkt-descent__slabs {
+  position: relative;
+  height: 80vh;
+  perspective: 1200px;
+  transform-style: preserve-3d;
+}
+.mkt-descent__slab {
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--mkt-rule);
+  background: var(--mkt-surface-cream-2);
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  /* the per-slab JS sets --offset (signed integer relative to active) */
+  --offset: 0;
+  transform: translateY(calc(var(--offset) * 24px)) rotateX(calc(var(--offset) * 4deg));
+  opacity: calc(1 - min(abs(var(--offset)), 3) * 0.25);
+  transition: transform 320ms var(--mkt-ease), opacity 320ms var(--mkt-ease);
+}
+.mkt-descent__slab--active {
+  border-color: var(--mkt-accent);
+  background: var(--mkt-surface-cream);
+  z-index: 10;
+}
+.mkt-descent__slab-edge {
+  height: 4px;
+  background: var(--mkt-accent);
+  border-radius: 2px;
+  width: 48px;
+  margin-bottom: 16px;
+}
+.mkt-descent__panel {
+  display: grid;
+  gap: 24px;
+}
+.mkt-descent__panel h3 {
+  font-family: var(--mkt-font-serif);
+  font-weight: 500;
+  font-size: clamp(36px, 5vw, 56px);
+  line-height: 1.1;
+  margin: 0;
+}
+.mkt-descent__panel-diagram {
+  border: 1px solid var(--mkt-rule);
+  border-radius: 8px;
+  background: var(--mkt-surface-cream-2);
+  padding: 16px;
+  color: var(--mkt-ink);
+}
+
+/* reduced-motion fallback: no pin, no perspective, vertical stack */
+.mkt-descent--reduced {
+  height: auto;
+}
+.mkt-descent--reduced .mkt-descent__stage {
+  position: static;
+  height: auto;
+  display: block;
+  padding-block: 64px;
+}
+.mkt-descent--reduced .mkt-descent__slabs {
+  height: auto;
+  perspective: none;
+}
+.mkt-descent--reduced .mkt-descent__slab {
+  position: static;
+  transform: none;
+  opacity: 1;
+  margin-bottom: 24px;
+  transition: none;
+}
+.mkt-descent--reduced .mkt-descent__rail { display: none; }
+@media (max-width: 800px) {
+  .mkt-descent { height: auto; }
+  .mkt-descent__stage { position: static; height: auto; display: block; }
+  .mkt-descent__slabs { height: auto; perspective: none; }
+  .mkt-descent__slab { position: static; transform: none; opacity: 1; margin-bottom: 24px; }
+  .mkt-descent__rail { display: none; }
+}

--- a/ui/src/marketing/sections/LayeredDescent.layers.tsx
+++ b/ui/src/marketing/sections/LayeredDescent.layers.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { ControlPlaneDiagram } from "../diagrams/ControlPlaneDiagram";
+import { OrchestrationDiagram } from "../diagrams/OrchestrationDiagram";
+import { WorkspacesDiagram } from "../diagrams/WorkspacesDiagram";
+import { AgentPrimitivesDiagram } from "../diagrams/AgentPrimitivesDiagram";
+import { InteropDiagram } from "../diagrams/InteropDiagram";
+import { TrustSafetyDiagram } from "../diagrams/TrustSafetyDiagram";
+import { ModelServingDiagram } from "../diagrams/ModelServingDiagram";
+
+export interface DescentLayer {
+  number: string;
+  name: string;
+  oneLine: string;
+  diagram: ReactNode;
+}
+
+export const DESCENT_LAYERS: DescentLayer[] = [
+  { number: "01", name: "Control Plane",        oneLine: "Where you run your AI company.",                       diagram: <ControlPlaneDiagram /> },
+  { number: "02", name: "Orchestration",        oneLine: "Task graphs, dependencies, scheduling, approvals.",     diagram: <OrchestrationDiagram /> },
+  { number: "03", name: "Workspaces & Adapters",oneLine: "The execution environments your agents actually run in.",diagram: <WorkspacesDiagram /> },
+  { number: "04", name: "Agent Primitives",     oneLine: "Identity, memory, heartbeat, tools.",                   diagram: <AgentPrimitivesDiagram /> },
+  { number: "05", name: "Interop",              oneLine: "How agents reach humans, systems, and each other.",     diagram: <InteropDiagram /> },
+  { number: "06", name: "Trust & Safety",       oneLine: "Policies, budgets, audits, kill switch.",               diagram: <TrustSafetyDiagram /> },
+  { number: "07", name: "Model Serving",        oneLine: "Inference. Your tokens, your models.",                  diagram: <ModelServingDiagram /> },
+];

--- a/ui/src/marketing/sections/LayeredDescent.tsx
+++ b/ui/src/marketing/sections/LayeredDescent.tsx
@@ -1,0 +1,75 @@
+import "./LayeredDescent.css";
+import { useEffect, useRef } from "react";
+import { DESCENT_LAYERS } from "./LayeredDescent.layers";
+import { useDescentProgress } from "../hooks/useDescentProgress";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
+
+export function LayeredDescent() {
+  const reduced = usePrefersReducedMotion();
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  // Always subscribe; in reduced-motion mode the value is ignored because CSS
+  // overrides the slab positioning (no pin, no perspective, no transforms).
+  const progress = useDescentProgress(sectionRef);
+
+  // Active index from progress. Clamp to layer count.
+  const lastIndex = DESCENT_LAYERS.length - 1;
+  const activeIndex = Math.min(lastIndex, Math.max(0, Math.round(progress * lastIndex)));
+
+  // Write the progress var so CSS can use it for fine-grain effects later.
+  useEffect(() => {
+    const el = stageRef.current;
+    if (!el) return;
+    el.style.setProperty("--descent-progress", String(progress));
+  }, [progress]);
+
+  return (
+    <div
+      id="layered-descent"
+      ref={sectionRef}
+      className={`mkt-descent ${reduced ? "mkt-descent--reduced" : ""}`}
+      aria-label="The seven layers of the agent stack"
+    >
+      <div ref={stageRef} className="mkt-descent__stage">
+        {!reduced && (
+          <ol className="mkt-descent__rail" aria-hidden>
+            {DESCENT_LAYERS.map((l, i) => (
+              <li
+                key={l.number}
+                className={i === activeIndex ? "mkt-descent__rail-item--active" : ""}
+              >
+                {l.number} {i === activeIndex ? l.name : ""}
+              </li>
+            ))}
+          </ol>
+        )}
+
+        <div className="mkt-descent__slabs">
+          {DESCENT_LAYERS.map((layer, i) => {
+            const offset = i - activeIndex;
+            const isActive = i === activeIndex;
+            return (
+              <section
+                key={layer.number}
+                className={`mkt-descent__slab ${isActive ? "mkt-descent__slab--active" : ""}`}
+                style={{ ["--offset" as string]: String(offset) }}
+                aria-current={isActive ? "true" : undefined}
+              >
+                <div className="mkt-descent__slab-edge" aria-hidden />
+                <div className="mkt-eyebrow">{layer.number} / 07</div>
+                <h3>{layer.name}</h3>
+                <p className="mkt-body-lg">{layer.oneLine}</p>
+              </section>
+            );
+          })}
+        </div>
+
+        <div className="mkt-descent__panel" aria-hidden>
+          <div className="mkt-descent__panel-diagram">
+            {DESCENT_LAYERS[activeIndex].diagram}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/marketing/sections/LiveBriefing.css
+++ b/ui/src/marketing/sections/LiveBriefing.css
@@ -1,0 +1,311 @@
+/*
+ * LiveBriefing — premium editorial hero illustration.
+ *
+ * Single focal motion: a coral 2px indicator on the left of the active
+ * row. The indicator slides between rows on a slow cycle (~7s). The only
+ * other motion is a barely-perceptible "Live" dot pulse. Everything else
+ * is composed typography, restraint, and depth.
+ *
+ * Inherits the marketing palette (cream / warm ink / coral accent).
+ */
+
+.mkt-brief {
+  background: linear-gradient(180deg, #ffffff 0%, #fbfaf6 100%);
+  border: 1px solid var(--mkt-rule);
+  border-radius: 14px;
+  padding: 24px 28px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--mkt-ink);
+  /* layered depth: a hairline + a soft cast shadow */
+  box-shadow:
+    0 1px 0 rgba(31, 30, 29, 0.04),
+    0 22px 56px -34px rgba(31, 30, 29, 0.22);
+  font-family: var(--mkt-font-serif, "Iowan Old Style", "Palatino Linotype", Georgia, serif);
+}
+
+/* ── header ───────────────────────────────────────────────────────── */
+
+.mkt-brief__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mkt-brief__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mkt-ink-soft);
+}
+
+.mkt-brief__live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--mkt-accent);
+  box-shadow: 0 0 0 0 rgba(204, 120, 92, 0.45);
+  animation: mkt-brief-live 2.6s ease-in-out infinite;
+}
+
+@keyframes mkt-brief-live {
+  0%, 100% {
+    opacity: 0.55;
+    box-shadow: 0 0 0 0 rgba(204, 120, 92, 0);
+  }
+  50% {
+    opacity: 1;
+    box-shadow: 0 0 0 6px rgba(204, 120, 92, 0);
+  }
+}
+
+.mkt-brief__title {
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+  margin: 0;
+  color: var(--mkt-ink);
+}
+
+.mkt-brief__subtitle {
+  font-size: 13px;
+  font-style: italic;
+  color: var(--mkt-ink-soft);
+  margin: 0;
+}
+
+/* ── rule ─────────────────────────────────────────────────────────── */
+
+.mkt-brief__rule {
+  height: 1px;
+  background: var(--mkt-rule);
+  width: 100%;
+}
+
+/* ── activity rows ─────────────────────────────────────────────────── */
+
+.mkt-brief__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mkt-brief__row {
+  display: grid;
+  grid-template-columns: 4px 32px minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(232, 227, 214, 0.55);
+  position: relative;
+  transition:
+    background-color 380ms var(--mkt-ease, cubic-bezier(0.16, 1, 0.3, 1));
+}
+
+.mkt-brief__row:last-child {
+  border-bottom: none;
+}
+
+.mkt-brief__indicator {
+  width: 2px;
+  height: 28px;
+  border-radius: 1px;
+  background: var(--mkt-accent);
+  opacity: 0;
+  transform: translateX(-8px);
+  transition:
+    opacity 420ms var(--mkt-ease, cubic-bezier(0.16, 1, 0.3, 1)),
+    transform 420ms var(--mkt-ease, cubic-bezier(0.16, 1, 0.3, 1));
+}
+
+.mkt-brief__row.is-active .mkt-brief__indicator {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.mkt-brief__row.is-active .mkt-brief__activity {
+  color: var(--mkt-ink);
+}
+
+.mkt-brief__row.is-active .mkt-brief__name {
+  color: var(--mkt-ink);
+}
+
+.mkt-brief__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--mkt-rule);
+  flex-shrink: 0;
+}
+
+.mkt-brief__avatar svg {
+  display: block;
+}
+
+/* Human avatars sit on a warm cream wash with a darkened person glyph —
+ * earthy and supervisory. Agent avatars use a soft coral wash with the
+ * accent-ink robot glyph — clearly machine-driven without shouting. */
+.mkt-brief__avatar--human {
+  background: linear-gradient(180deg, #fbf6ec 0%, #f3ecda 100%);
+  border-color: #ddd1b6;
+  color: var(--mkt-ink);
+}
+
+.mkt-brief__avatar--agent {
+  background: linear-gradient(180deg, #fcf2ed 0%, #f6e6dd 100%);
+  border-color: rgba(204, 120, 92, 0.42);
+  color: var(--mkt-accent-ink, #7a3f2a);
+}
+
+.mkt-brief__body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.mkt-brief__identity {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.mkt-brief__name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--mkt-ink);
+  letter-spacing: -0.005em;
+}
+
+.mkt-brief__sep {
+  color: var(--mkt-ink-soft);
+  opacity: 0.5;
+  font-size: 11px;
+}
+
+.mkt-brief__role {
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mkt-ink-soft);
+}
+
+/* AGENT / HUMAN type chip. Coral accent for AI agents (the work doers),
+ * neutral ink for humans (the operators). Kept small and uppercase so it
+ * reads as metadata, not as a primary headline. */
+.mkt-brief__kind {
+  margin-left: 4px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 500;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+
+.mkt-brief__kind--agent {
+  color: var(--mkt-accent-ink, #7a3f2a);
+  background: rgba(204, 120, 92, 0.1);
+  border-color: rgba(204, 120, 92, 0.28);
+}
+
+.mkt-brief__kind--human {
+  color: var(--mkt-ink-soft);
+  background: rgba(31, 30, 29, 0.045);
+  border-color: rgba(31, 30, 29, 0.12);
+}
+
+.mkt-brief__activity {
+  font-size: 13px;
+  font-style: italic;
+  line-height: 1.45;
+  margin: 0;
+  color: var(--mkt-ink-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 380ms var(--mkt-ease, cubic-bezier(0.16, 1, 0.3, 1));
+}
+
+.mkt-brief__time {
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--mkt-ink-soft);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ── footer / metrics ──────────────────────────────────────────────── */
+
+.mkt-brief__footer {
+  display: flex;
+  align-items: baseline;
+  gap: 22px;
+  flex-wrap: wrap;
+  padding-top: 2px;
+}
+
+.mkt-brief__footer-label {
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mkt-ink-soft);
+}
+
+.mkt-brief__metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.mkt-brief__metric strong {
+  font-weight: 500;
+  font-size: 18px;
+  color: var(--mkt-ink);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  font-style: normal;
+}
+
+.mkt-brief__metric-label {
+  font-family: var(--mkt-font-mono, ui-monospace, "SFMono-Regular", monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--mkt-ink-soft);
+  text-transform: lowercase;
+}
+
+/* ── reduced motion ────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .mkt-brief__live-dot,
+  .mkt-brief__row,
+  .mkt-brief__indicator,
+  .mkt-brief__activity {
+    animation: none !important;
+    transition: none !important;
+  }
+  .mkt-brief__row.is-active .mkt-brief__indicator {
+    transform: none;
+  }
+}

--- a/ui/src/marketing/sections/LiveBriefing.tsx
+++ b/ui/src/marketing/sections/LiveBriefing.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { Bot, User } from "lucide-react";
+import "./LiveBriefing.css";
+
+// Editorial "Live Briefing" hero illustration. Replaces the prior animated
+// org-chart. Single restrained motion (one coral indicator sliding to the
+// active row every ~7s) + a barely-perceptible live dot. Everything else
+// is composed typography — serif names, mono labels, italic activity copy.
+//
+// The component is presentational. The data is intentionally fixed so the
+// surface reads as a real product card, not a demo loop.
+
+type BriefRow = {
+  name: string;
+  role: string;
+  kind: "human" | "agent";
+  activity: string;
+  time: string;
+};
+
+// One human (the founder, reviewing the day) + four AI agents executing
+// against the company's goals. Communicates the hybrid-team narrative
+// AgentDash sells: humans set direction, agents do the work. Avatars
+// differentiate the two (User icon for humans, Bot icon for agents).
+const ROWS: BriefRow[] = [
+  { name: "Avery", role: "CEO",   kind: "human", activity: "Reviewing Q3 priorities",            time: "9:42 AM" },
+  { name: "Mira",  role: "CMO",   kind: "agent", activity: "Drafting the launch announcement",   time: "9:38 AM" },
+  { name: "Theo",  role: "CTO",   kind: "agent", activity: "Shipping migration 0067",            time: "9:31 AM" },
+  { name: "Quinn", role: "CFO",   kind: "agent", activity: "Closing the April books",            time: "9:18 AM" },
+  { name: "Sam",   role: "Sales", kind: "agent", activity: "Qualifying 12 inbound leads",        time: "8:56 AM" },
+];
+
+const STEP_MS = 7000;
+
+export function LiveBriefing() {
+  const [activeRow, setActiveRow] = useState(0);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      setActiveRow((i) => (i + 1) % ROWS.length);
+    }, STEP_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <article className="mkt-brief" aria-label="Live AgentDash briefing">
+      <header className="mkt-brief__header">
+        <span className="mkt-brief__live">
+          <span className="mkt-brief__live-dot" aria-hidden />
+          Live · Tue 29 Apr
+        </span>
+        <h2 className="mkt-brief__title">Morning briefing</h2>
+        <p className="mkt-brief__subtitle">Five agents on shift. One needs your input.</p>
+      </header>
+
+      <div className="mkt-brief__rule" />
+
+      <ol className="mkt-brief__list">
+        {ROWS.map((row, i) => (
+          <li
+            key={row.name}
+            className={`mkt-brief__row${i === activeRow ? " is-active" : ""}`}
+            aria-current={i === activeRow ? "true" : undefined}
+          >
+            <span className="mkt-brief__indicator" aria-hidden />
+            <span
+              className={`mkt-brief__avatar mkt-brief__avatar--${row.kind}`}
+              aria-hidden
+            >
+              {row.kind === "agent" ? (
+                <Bot size={16} strokeWidth={1.5} />
+              ) : (
+                <User size={16} strokeWidth={1.5} />
+              )}
+            </span>
+            <div className="mkt-brief__body">
+              <div className="mkt-brief__identity">
+                <span className="mkt-brief__name">{row.name}</span>
+                <span className="mkt-brief__sep" aria-hidden>·</span>
+                <span className="mkt-brief__role">{row.role}</span>
+                <span
+                  className={`mkt-brief__kind mkt-brief__kind--${row.kind}`}
+                  aria-label={row.kind === "agent" ? "AI agent" : "Human"}
+                >
+                  {row.kind === "agent" ? "Agent" : "Human"}
+                </span>
+              </div>
+              <p className="mkt-brief__activity">{row.activity}</p>
+            </div>
+            <time className="mkt-brief__time" dateTime="09:42">{row.time}</time>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mkt-brief__rule" />
+
+      <footer className="mkt-brief__footer">
+        <span className="mkt-brief__footer-label">Today</span>
+        <span className="mkt-brief__metric">
+          <strong>17</strong>
+          <span className="mkt-brief__metric-label">tasks</span>
+        </span>
+        <span className="mkt-brief__metric">
+          <strong>$182</strong>
+          <span className="mkt-brief__metric-label">spent</span>
+        </span>
+        <span className="mkt-brief__metric">
+          <strong>3</strong>
+          <span className="mkt-brief__metric-label">flagged</span>
+        </span>
+      </footer>
+    </article>
+  );
+}

--- a/ui/src/marketing/sections/ReadinessBand.css
+++ b/ui/src/marketing/sections/ReadinessBand.css
@@ -1,0 +1,2 @@
+.mkt-readiness { display: grid; grid-template-columns: 1.4fr 1fr; gap: 64px; align-items: center; }
+@media (max-width: 800px) { .mkt-readiness { grid-template-columns: 1fr; } }

--- a/ui/src/marketing/sections/ReadinessBand.tsx
+++ b/ui/src/marketing/sections/ReadinessBand.tsx
@@ -1,0 +1,22 @@
+import "./ReadinessBand.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Button } from "../components/Button";
+
+export function ReadinessBand() {
+  return (
+    <SectionContainer>
+      <div className="mkt-readiness">
+        <div>
+          <h2 className="mkt-display-section">Where does your company sit on the readiness curve?</h2>
+          <p className="mkt-body-lg" style={{ color: "var(--mkt-ink-soft)", marginTop: 24 }}>
+            We built a 20-minute structured intake for our own engagements. It produces a written readiness brief
+            with the three pilots most likely to land in your first quarter.
+          </p>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <Button href="/assess">Run the assessment</Button>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/sections/ResearchBriefs.css
+++ b/ui/src/marketing/sections/ResearchBriefs.css
@@ -1,0 +1,18 @@
+.mkt-briefs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; }
+.mkt-brief {
+  border: 1px solid var(--mkt-rule);
+  border-radius: 8px;
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+  background: var(--mkt-surface-cream);
+  transition: background-color 160ms var(--mkt-ease);
+  text-decoration: none;
+  color: inherit;
+}
+.mkt-brief:hover { background: var(--mkt-surface-cream-2); }
+.mkt-brief__tag { font-family: var(--mkt-font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--mkt-ink-soft); }
+.mkt-brief__title { font-family: var(--mkt-font-serif); font-weight: 500; font-size: 22px; line-height: 1.2; }
+.mkt-brief__abstract { color: var(--mkt-ink-soft); font-size: 15px; }
+.mkt-brief__cta { color: var(--mkt-accent-ink); font-size: 14px; }
+@media (max-width: 800px) { .mkt-briefs { grid-template-columns: 1fr; } }

--- a/ui/src/marketing/sections/ResearchBriefs.tsx
+++ b/ui/src/marketing/sections/ResearchBriefs.tsx
@@ -1,0 +1,35 @@
+import "./ResearchBriefs.css";
+import { SectionContainer } from "../components/SectionContainer";
+import { Eyebrow } from "../components/Eyebrow";
+
+const BRIEFS = [
+  { tag: "FRAMEWORK", title: "The seven layers of the enterprise agent stack",
+    abstract: "A taxonomy for what's in scope when you say 'agentify the enterprise.'" },
+  { tag: "SYNTHESIS", title: "Why agent pilots stall in month two",
+    abstract: "Patterns across the dozen pilots we've watched go quiet between week six and week ten." },
+  { tag: "INDUSTRY", title: "Cross-industry agentification — what actually moved",
+    abstract: "Where measurable productivity shifted, where it didn't, and what predicts which side you land on." },
+  { tag: "FRAMEWORK", title: "Readiness signals we look for in the first call",
+    abstract: "The five questions we ask in the first thirty minutes that decide whether a pilot is worth running." },
+];
+
+export function ResearchBriefs() {
+  return (
+    <SectionContainer background="cream-2" id="research">
+      <Eyebrow>Research</Eyebrow>
+      <h2 className="mkt-display-section" style={{ marginTop: 16, marginBottom: 64 }}>
+        What we've learned mapping the agent factory landscape.
+      </h2>
+      <div className="mkt-briefs">
+        {BRIEFS.map((b) => (
+          <a key={b.title} href="#" className="mkt-brief">
+            <div className="mkt-brief__tag">{b.tag}</div>
+            <div className="mkt-brief__title">{b.title}</div>
+            <div className="mkt-brief__abstract">{b.abstract}</div>
+            <div className="mkt-brief__cta">Read brief →</div>
+          </a>
+        ))}
+      </div>
+    </SectionContainer>
+  );
+}

--- a/ui/src/marketing/tokens.css
+++ b/ui/src/marketing/tokens.css
@@ -1,0 +1,31 @@
+/*
+ * Marketing surface design tokens.
+ * Used only by ui/src/marketing/**. Do not import from product UI.
+ */
+:root {
+  --mkt-surface-cream: #faf9f5;
+  --mkt-surface-cream-2: #f3efe6;
+  --mkt-ink: #1f1e1d;
+  --mkt-ink-soft: #54524f;
+  --mkt-rule: #e8e3d6;
+  --mkt-accent: #cc785c;
+  --mkt-accent-ink: #7a3f2a;
+
+  /* spacing scale (8px base) */
+  --mkt-space-1: 8px;
+  --mkt-space-2: 16px;
+  --mkt-space-3: 24px;
+  --mkt-space-4: 32px;
+  --mkt-space-6: 48px;
+  --mkt-space-8: 64px;
+  --mkt-space-12: 96px;
+  --mkt-space-16: 128px;
+  --mkt-space-20: 160px;
+
+  /* container */
+  --mkt-container-max: 1200px;
+  --mkt-container-gutter: 32px;
+
+  /* motion */
+  --mkt-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}

--- a/ui/src/marketing/typography.css
+++ b/ui/src/marketing/typography.css
@@ -1,0 +1,75 @@
+/*
+ * Marketing type scale. Only applied within `.mkt-root` so it never leaks.
+ */
+.mkt-root {
+  font-family: var(--mkt-font-sans);
+  color: var(--mkt-ink);
+  background: var(--mkt-surface-cream);
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.mkt-root .mkt-display-hero {
+  font-family: var(--mkt-font-serif);
+  font-weight: 500;
+  font-size: clamp(48px, 7vw, 80px);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+}
+
+.mkt-root .mkt-display-section {
+  font-family: var(--mkt-font-serif);
+  font-weight: 500;
+  font-size: clamp(36px, 5vw, 56px);
+  line-height: 1.1;
+  letter-spacing: -0.005em;
+}
+
+.mkt-root .mkt-display-page {
+  font-family: var(--mkt-font-serif);
+  font-weight: 500;
+  font-size: clamp(40px, 6vw, 56px);
+  line-height: 1.05;
+}
+
+.mkt-root .mkt-mission {
+  font-family: var(--mkt-font-serif);
+  font-weight: 400;
+  font-size: clamp(28px, 4vw, 44px);
+  line-height: 1.25;
+  max-width: 28ch;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.mkt-root .mkt-body-lg {
+  font-size: 19px;
+  line-height: 1.55;
+}
+
+.mkt-root .mkt-eyebrow {
+  font-family: var(--mkt-font-mono);
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--mkt-ink-soft);
+}
+
+.mkt-root .mkt-caption {
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--mkt-ink-soft);
+}
+
+.mkt-root a { color: inherit; text-decoration: underline; text-underline-offset: 3px; }
+.mkt-root a:hover { color: var(--mkt-accent-ink); }
+
+.mkt-root *:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 4px;
+  border-radius: 2px;
+}


### PR DESCRIPTION
Replaces #85 (auto-closed when base branch was merged via #84). All commits unchanged; rebased onto main.

## Why

The v2 rebuild ported only narrow features (assess, billing, cos chat) and left the rest of the v1 user-facing UI behind:

- `/` redirected straight to dashboard — the editorial Live Briefing hero / marketing landing was gone
- `/consulting` and `/about` 404'd
- title bar said "Paperclip" everywhere
- `/assess` painted **cream cards on a dark body** because the marketing surface was rendering inside the dark dashboard shell (the "white-box-on-dark" regression the user flagged)

This restores the v1 marketing UI without touching paperclip core.

## What changed

**App routing** ([ui/src/App.tsx](ui/src/App.tsx))
- `/`, `/consulting`, `/about`, `/assess`, `/assess/history` now render **outside** `CloudAccessGate` so they live on the cream/light marketing surface, not the dark dashboard. `Landing` redirects logged-in users to `/companies` on its own.

**Theme isolation** ([ui/src/marketing/MarketingShell.css](ui/src/marketing/MarketingShell.css))
- `.mkt-root { color-scheme: light; background: var(--mkt-surface-cream); color: var(--mkt-ink); min-height: 100vh; }` so marketing pages render in cream/light regardless of `html.dark`.

**Token wiring** ([ui/src/main.tsx](ui/src/main.tsx))
- Import `marketing/tokens.css`, `fonts.css`, `typography.css` so `var(--mkt-*)` resolves. Without these `mkt-root` had `background: undefined` and inherited the dark body bg.

**Brand**
- `<title>` + `apple-mobile-web-app-title`: "Paperclip" → "AgentDash" ([ui/index.html](ui/index.html))
- `BreadcrumbContext` title suffix: " · Paperclip" → " · AgentDash" ([ui/src/context/BreadcrumbContext.tsx](ui/src/context/BreadcrumbContext.tsx))
- `localStorage` key: `paperclip.theme` → `agentdash.theme` with one-time migration from legacy key ([ui/index.html](ui/index.html), [ui/src/context/ThemeContext.tsx](ui/src/context/ThemeContext.tsx))

**.gitignore fix** ([.gitignore](.gitignore))
- Blanket `marketing/` ignore (intended for the dead Next.js tree at repo root) was also catching `ui/src/marketing/` — that's why the entire active marketing surface was untracked. Anchored the ignore with a leading slash so it only matches `/marketing` at repo root. **Adds 58 marketing files to the index** that had been silently dropped on every prior `git add`.

## Verification (`pnpm dev` on localhost:3101, dark and light modes)

| Route | Result |
|-|-|
| `/?preview=1` | renders editorial "Run an AI workforce…" hero on cream surface |
| `/consulting` | renders "We install AI workforces inside enterprises." |
| `/about` | renders "Why AgentDash exists." |
| `/assess` | marketing-themed Agent Readiness landing — **no more white box on dark** |
| `/PAP/dashboard` | dark dashboard surface, no theme bleed, title "Dashboard · AgentDash" |
| `/cos` | chat panel still works |

## Test plan
- [x] `pnpm test:run` passes
- [x] `pnpm -r typecheck` UI clean; pre-existing `plugin-host-services.ts:935,939` server errors reproduce on `origin/main` and are unrelated

## Out of scope
- Default workspace name "Paperclip" in dev DB seed (data, not branding)
- WelcomePage onboarding (v1 #68) vs v2's `OnboardingRoutePage` + `CoSConversation`
- Verify free-mail signup guard (#66) and self-serve company creation (#65)

🤖 Generated with [Claude Code](https://claude.com/claude-code)