### PR TITLE
fix(typecheck): unblock pnpm build (Company projection + AssessHistoryPage queryKey)

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -58,6 +58,8 @@ export function companyService(db: Db) {
     name: companies.name,
     description: companies.description,
     status: companies.status,
+    pauseReason: companies.pauseReason,
+    pausedAt: companies.pausedAt,
     issuePrefix: companies.issuePrefix,
     issueCounter: companies.issueCounter,
     budgetMonthlyCents: companies.budgetMonthlyCents,

--- a/ui/src/pages/AssessHistoryPage.tsx
+++ b/ui/src/pages/AssessHistoryPage.tsx
@@ -1,7 +1,6 @@
 import { useCompany } from "../context/CompanyContext";
 import { useQuery } from "@tanstack/react-query";
 import { assessApi } from "../api/assess";
-import { queryKeys } from "../lib/queryKeys";
 import { useNavigate } from "../lib/router";
 import { MarkdownBody } from "../components/MarkdownBody";
 import { MarketingShell } from "../marketing/MarketingShell";
@@ -12,7 +11,7 @@ export function AssessHistoryPage() {
   const navigate = useNavigate();
 
   const { data, isLoading } = useQuery({
-    queryKey: queryKeys.agentResearch.assessment(selectedCompanyId!),
+    queryKey: ["assess", "company-assessment", selectedCompanyId],
     queryFn: () => assessApi.getAssessment(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });


### PR DESCRIPTION
After [#86](https://github.com/thetangstr/agentdash/pull/86) untangled the \`marketing/\` \`.gitignore\` rule, \`pnpm -r typecheck\` and \`pnpm build\` started reporting two pre-existing errors that were previously masked.

## Fixes

### server/src/services/companies.ts
The \`companySelection\` projection omitted \`pauseReason\` and \`pausedAt\`. The casts \`(await companies.list()) as Company[]\` in [server/src/services/plugin-host-services.ts:935,939](server/src/services/plugin-host-services.ts) failed with \`missing properties from type 'Company': pauseReason, pausedAt\`. The shared \`Company\` interface ([packages/shared/src/types/company.ts](packages/shared/src/types/company.ts)) requires both, and they are real schema fields on the \`companies\` table ([packages/db/src/schema/companies.ts:11-12](packages/db/src/schema/companies.ts)). Added them to the projection so the cast is valid and plugin hosts get the full \`Company\` shape.

### ui/src/pages/AssessHistoryPage.tsx
Used \`queryKeys.agentResearch.assessment(...)\` but \`queryKeys\` has no \`agentResearch\` namespace anywhere ([ui/src/lib/queryKeys.ts](ui/src/lib/queryKeys.ts)). Other assess pages key themselves with inline arrays like \`["assess", "projects", companyId]\` ([AssessPage.tsx:25](ui/src/pages/AssessPage.tsx), [CompanyWizard.tsx:129](ui/src/pages/assess/CompanyWizard.tsx)). Switched this query to \`["assess", "company-assessment", selectedCompanyId]\` to match the pattern, and dropped the unused \`queryKeys\` import.

## Why these were previously invisible
- \`AssessHistoryPage.tsx\` lived in the tracked tree but no entry-point imported it from inside a typechecked route until #86 wired \`/assess/history\` into \`App.tsx\`.
- \`pauseReason\` / \`pausedAt\` were added to the schema later; the projection was never updated. The cast site is plugin-host-only, which doesn't run during normal dev so nobody noticed.

## Verification
- \`pnpm -r typecheck\` — server, ui, cli all "Done", **exit 0**
- \`pnpm test:run\` — 6/6 pass
- \`pnpm build\` — server + ui + cli all built, **exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)