### PR TITLE
chore(brand): finish AgentDash rebrand of bootstrap email + localStorage keys

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -201,7 +201,7 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const LOCAL_BOARD_USER_ID = "local-board";
-  const LOCAL_BOARD_USER_EMAIL = "local@paperclip.local";
+  const LOCAL_BOARD_USER_EMAIL = "local@agentdash.local";
   const LOCAL_BOARD_USER_NAME = "Board";
   
   async function ensureLocalTrustedBoardPrincipal(db: any): Promise<void> {

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -116,6 +116,9 @@ function deriveEmailDomain(email: string | null | undefined): string | null {
 function companyNameFromEmail(email: string | null | undefined): string {
   const domain = deriveEmailDomain(email);
   if (!domain) return "My Workspace";
+  // AgentDash bootstrap: the local-trusted seed email lives at agentdash.local
+  // and "Agentdash" (lower 'd') reads off-brand. Map it to the proper casing.
+  if (domain === "agentdash.local") return "AgentDash Workspace";
   const root = domain.split(".")[0];
   return root.charAt(0).toUpperCase() + root.slice(1);
 }

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -41,7 +41,22 @@ import { scheduleMainContentFocus } from "../lib/main-content-focus";
 import { cn } from "../lib/utils";
 import { NotFoundPage } from "../pages/NotFound";
 
-const INSTANCE_SETTINGS_MEMORY_KEY = "paperclip.lastInstanceSettingsPath";
+const INSTANCE_SETTINGS_MEMORY_KEY = "agentdash.lastInstanceSettingsPath";
+const LEGACY_INSTANCE_SETTINGS_MEMORY_KEY = "paperclip.lastInstanceSettingsPath";
+
+if (typeof window !== "undefined") {
+  try {
+    if (!window.localStorage.getItem(INSTANCE_SETTINGS_MEMORY_KEY)) {
+      const legacy = window.localStorage.getItem(LEGACY_INSTANCE_SETTINGS_MEMORY_KEY);
+      if (legacy) {
+        window.localStorage.setItem(INSTANCE_SETTINGS_MEMORY_KEY, legacy);
+        window.localStorage.removeItem(LEGACY_INSTANCE_SETTINGS_MEMORY_KEY);
+      }
+    }
+  } catch {
+    // best-effort
+  }
+}
 
 function readRememberedInstanceSettingsPath(): string {
   if (typeof window === "undefined") return DEFAULT_INSTANCE_SETTINGS_PATH;

--- a/ui/src/context/CompanyContext.test.tsx
+++ b/ui/src/context/CompanyContext.test.tsx
@@ -153,7 +153,7 @@ describe("CompanyProvider", () => {
   });
 
   it("does not expose a stale stored company id before companies load", async () => {
-    localStorage.setItem("paperclip.selectedCompanyId", "stale-company");
+    localStorage.setItem("agentdash.selectedCompanyId", "stale-company");
     mockCompaniesApi.list.mockImplementation(() => new Promise(() => {}));
     const seen: Array<string | null> = [];
 
@@ -171,7 +171,7 @@ describe("CompanyProvider", () => {
   });
 
   it("replaces a stale stored company id with the first loaded company", async () => {
-    localStorage.setItem("paperclip.selectedCompanyId", "stale-company");
+    localStorage.setItem("agentdash.selectedCompanyId", "stale-company");
     queryClient.setQueryData(queryKeys.companies.all, {
       companies: [makeCompany("company-1")],
       unauthorized: false,
@@ -190,6 +190,6 @@ describe("CompanyProvider", () => {
     });
 
     expect(seen).toEqual([null, "company-1"]);
-    expect(localStorage.getItem("paperclip.selectedCompanyId")).toBe("company-1");
+    expect(localStorage.getItem("agentdash.selectedCompanyId")).toBe("company-1");
   });
 });

--- a/ui/src/context/CompanyContext.tsx
+++ b/ui/src/context/CompanyContext.tsx
@@ -32,7 +32,24 @@ interface CompanyContextValue {
   }) => Promise<Company>;
 }
 
-const STORAGE_KEY = "paperclip.selectedCompanyId";
+const STORAGE_KEY = "agentdash.selectedCompanyId";
+const LEGACY_STORAGE_KEY = "paperclip.selectedCompanyId";
+
+// One-time migration of the legacy paperclip.* key. Runs at module init so the
+// first localStorage read in the provider sees the migrated value.
+if (typeof window !== "undefined") {
+  try {
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
+      if (legacy) {
+        localStorage.setItem(STORAGE_KEY, legacy);
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+      }
+    }
+  } catch {
+    // localStorage can throw in privacy-mode iframes; the migration is best-effort.
+  }
+}
 
 const CompanyContext = createContext<CompanyContextValue | null>(null);
 

--- a/ui/src/hooks/useCompanyPageMemory.ts
+++ b/ui/src/hooks/useCompanyPageMemory.ts
@@ -8,7 +8,22 @@ import {
   sanitizeRememberedPathForCompany,
 } from "../lib/company-page-memory";
 
-const STORAGE_KEY = "paperclip.companyPaths";
+const STORAGE_KEY = "agentdash.companyPaths";
+const LEGACY_STORAGE_KEY = "paperclip.companyPaths";
+
+if (typeof window !== "undefined") {
+  try {
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
+      if (legacy) {
+        localStorage.setItem(STORAGE_KEY, legacy);
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+      }
+    }
+  } catch {
+    // best-effort
+  }
+}
 
 function getCompanyPaths(): Record<string, string> {
   try {

--- a/ui/src/lib/agent-order.ts
+++ b/ui/src/lib/agent-order.ts
@@ -1,8 +1,32 @@
 import type { Agent } from "@paperclipai/shared";
 
-export const AGENT_ORDER_UPDATED_EVENT = "paperclip:agent-order-updated";
-const AGENT_ORDER_STORAGE_PREFIX = "paperclip.agentOrder";
+export const AGENT_ORDER_UPDATED_EVENT = "agentdash:agent-order-updated";
+const AGENT_ORDER_STORAGE_PREFIX = "agentdash.agentOrder";
+const LEGACY_AGENT_ORDER_STORAGE_PREFIX = "paperclip.agentOrder";
 const ANONYMOUS_USER_ID = "anonymous";
+
+// One-time migration of legacy paperclip.agentOrder:<companyId>:<userId> keys.
+if (typeof window !== "undefined") {
+  try {
+    const legacyKeys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(`${LEGACY_AGENT_ORDER_STORAGE_PREFIX}:`)) {
+        legacyKeys.push(key);
+      }
+    }
+    for (const legacyKey of legacyKeys) {
+      const newKey = `${AGENT_ORDER_STORAGE_PREFIX}${legacyKey.slice(LEGACY_AGENT_ORDER_STORAGE_PREFIX.length)}`;
+      if (!localStorage.getItem(newKey)) {
+        const value = localStorage.getItem(legacyKey);
+        if (value !== null) localStorage.setItem(newKey, value);
+      }
+      localStorage.removeItem(legacyKey);
+    }
+  } catch {
+    // best-effort
+  }
+}
 
 type AgentOrderUpdatedDetail = {
   storageKey: string;

--- a/ui/src/lib/project-order.ts
+++ b/ui/src/lib/project-order.ts
@@ -1,8 +1,32 @@
 import type { Project } from "@paperclipai/shared";
 
-export const PROJECT_ORDER_UPDATED_EVENT = "paperclip:project-order-updated";
-const PROJECT_ORDER_STORAGE_PREFIX = "paperclip.projectOrder";
+export const PROJECT_ORDER_UPDATED_EVENT = "agentdash:project-order-updated";
+const PROJECT_ORDER_STORAGE_PREFIX = "agentdash.projectOrder";
+const LEGACY_PROJECT_ORDER_STORAGE_PREFIX = "paperclip.projectOrder";
 const ANONYMOUS_USER_ID = "anonymous";
+
+// One-time migration of legacy paperclip.projectOrder:<companyId>:<userId> keys.
+if (typeof window !== "undefined") {
+  try {
+    const legacyKeys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(`${LEGACY_PROJECT_ORDER_STORAGE_PREFIX}:`)) {
+        legacyKeys.push(key);
+      }
+    }
+    for (const legacyKey of legacyKeys) {
+      const newKey = `${PROJECT_ORDER_STORAGE_PREFIX}${legacyKey.slice(LEGACY_PROJECT_ORDER_STORAGE_PREFIX.length)}`;
+      if (!localStorage.getItem(newKey)) {
+        const value = localStorage.getItem(legacyKey);
+        if (value !== null) localStorage.setItem(newKey, value);
+      }
+      localStorage.removeItem(legacyKey);
+    }
+  } catch {
+    // best-effort
+  }
+}
 
 type ProjectOrderUpdatedDetail = {
   storageKey: string;


### PR DESCRIPTION
Per [CLAUDE.md](CLAUDE.md), AgentDash storage/identity should use the \`agentdash.*\` prefix. The earlier marketing PR ([#86](https://github.com/thetangstr/agentdash/pull/86)) only migrated \`agentdash.theme\`; this finishes the sweep.

## Bootstrap workspace name (server-side)

- [\`server/src/index.ts:204\`](server/src/index.ts) — \`LOCAL_BOARD_USER_EMAIL\`: \`local@paperclip.local\` → \`local@agentdash.local\`. The local-trusted seed user's email feeds \`companyNameFromEmail()\` in the onboarding orchestrator, so the default workspace name on first boot now reads "AgentDash Workspace" instead of "Paperclip".
- [\`server/src/services/onboarding-orchestrator.ts\`](server/src/services/onboarding-orchestrator.ts) — \`companyNameFromEmail()\` maps \`agentdash.local\` → \`"AgentDash Workspace"\` explicitly so the brand reads cleanly (otherwise the lowercase root would derive "Agentdash").

Existing dev DBs with the old "Paperclip" workspace are unaffected — users can rename via Company Settings.

## localStorage keys (UI, all with one-time legacy migration)

| Old | New |
|---|---|
| \`paperclip.selectedCompanyId\` | \`agentdash.selectedCompanyId\` |
| \`paperclip.lastInstanceSettingsPath\` | \`agentdash.lastInstanceSettingsPath\` |
| \`paperclip.companyPaths\` | \`agentdash.companyPaths\` |
| \`paperclip.agentOrder:*\` (prefix) | \`agentdash.agentOrder:*\` |
| \`paperclip.projectOrder:*\` (prefix) | \`agentdash.projectOrder:*\` |

Migration runs at module init: copies the legacy value into the new key (if the new key isn't already set) and removes the legacy key. Best-effort — wrapped in try/catch for privacy-mode iframes that throw on \`localStorage\`.

## CustomEvent names (internal only)
- \`paperclip:agent-order-updated\` → \`agentdash:agent-order-updated\`
- \`paperclip:project-order-updated\` → \`agentdash:project-order-updated\`

No persistence impact; both dispatch and listen sites use the same exported constant.

## Audit confirmed in-scope (no work needed)

| v1 PR | v2 status |
|---|---|
| [v1 #65](https://github.com/thetangstr/agentdash/pull/65) self-serve company creation | already present at [\`server/src/routes/companies.ts:283\`](server/src/routes/companies.ts) — comment "AgentDash (AGE-104): no instance-admin gate here…" |
| [v1 #66](https://github.com/thetangstr/agentdash/pull/66) free-mail signup guard | middleware already imported and wired ([\`server/src/app.ts:182\`](server/src/app.ts), [\`server/src/index.ts:622\`](server/src/index.ts)) |

## Verification
- \`pnpm -r typecheck\`: server, ui, cli, plugins all "Done", exit 0
- \`pnpm test:run\`: 6/6 pass
- Manual sweep: no remaining \`paperclip\.\w+\` string literals in \`ui/src/\` outside the \`LEGACY_*_KEY\` constants used by the migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)