### PR TITLE
feat(cos): wire real Claude API for CoS chat replies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,6 +506,9 @@ importers:
 
   server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.92.0
+        version: 0.92.0(zod@3.25.76)
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.994.0
@@ -870,6 +873,15 @@ packages:
 
   '@anthropic-ai/sdk@0.81.0':
     resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/sdk@0.92.0':
+    resolution: {integrity: sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -6859,6 +6871,12 @@ snapshots:
       - supports-color
 
   '@anthropic-ai/sdk@0.81.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@anthropic-ai/sdk@0.92.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -43,6 +43,7 @@
     "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-acpx-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -9,6 +9,7 @@ import {
   cosReplier,
   agentSummoner,
 } from "../services/index.js";
+import { anthropicLLM } from "../services/anthropic-llm.js";
 
 export function conversationRoutes(db: Db) {
   const router = Router();
@@ -20,11 +21,6 @@ export function conversationRoutes(db: Db) {
       const all = await agents.list(companyId);
       return all.find((a: any) => a.role === "chief_of_staff") ?? null;
     },
-  };
-
-  const llmStub = async (_input: any): Promise<string> => {
-    // TODO: wire real LLM (Anthropic SDK). Stub for now.
-    return "Got it. (stub reply — wire real LLM in onboarding plan)";
   };
 
   const dispatcher = conversationDispatch({
@@ -40,7 +36,10 @@ export function conversationRoutes(db: Db) {
         execute: async () => ({ output: "Stub agent reply" }),
       }),
     }),
-    replier: cosReplier({ conversations: svc, llm: llmStub } as any),
+    // anthropicLLM auto-falls back to a stub when ANTHROPIC_API_KEY is unset
+    // (so dev without keys still works); when set, it calls Claude with prompt
+    // caching on the system prompt.
+    replier: cosReplier({ conversations: svc, llm: anthropicLLM } as any),
     cosResolver,
   });
 

--- a/server/src/services/anthropic-llm.ts
+++ b/server/src/services/anthropic-llm.ts
@@ -1,0 +1,52 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface LLMInput {
+  system: string;
+  messages: ChatMessage[];
+}
+
+const STUB_REPLY = "Got it. (stub reply — set ANTHROPIC_API_KEY to wire real Claude)";
+
+// Singleton client + cached env state. The client itself is cheap to recreate, but
+// caching it keeps SDK keepalive sockets warm across requests.
+let cachedClient: Anthropic | null = null;
+function getClient(): Anthropic | null {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) return null;
+  if (!cachedClient) cachedClient = new Anthropic({ apiKey: key });
+  return cachedClient;
+}
+
+/**
+ * CoS chat reply adapter. Returns a string for the assistant's next turn.
+ *
+ * Falls back to a stub when ANTHROPIC_API_KEY is unset so local dev works
+ * without keys. The system prompt is sent with a cache_control breakpoint so
+ * repeated turns within the same conversation hit the prompt cache (~90%
+ * cheaper on input tokens after the first call).
+ */
+export async function anthropicLLM(input: LLMInput): Promise<string> {
+  const client = getClient();
+  if (!client) return STUB_REPLY;
+
+  const response = await client.messages.create({
+    model: "claude-opus-4-7",
+    max_tokens: 1024,
+    thinking: { type: "disabled" },
+    system: [{ type: "text", text: input.system, cache_control: { type: "ephemeral" } }],
+    messages: input.messages,
+  });
+
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n")
+    .trim();
+
+  return text || STUB_REPLY;
+}


### PR DESCRIPTION
Replaces the inline \`llmStub\` in [conversations.ts](server/src/routes/conversations.ts) with a real Anthropic SDK adapter. This is the literal core feature of AgentDash — talking to a CoS through the dashboard — and shipping it without an LLM behind it has been the biggest blocker to launch.

## How it works

- **\`ANTHROPIC_API_KEY\` unset** — returns a stub message (\`"Got it. (stub reply — set ANTHROPIC_API_KEY to wire real Claude)"\`) so local dev without keys still works.
- **\`ANTHROPIC_API_KEY\` set** — calls \`claude-opus-4-7\` with the conversation history. Thinking is disabled (\`thinking: {type: "disabled"}\`) for chat-reply latency. The system prompt is sent with \`cache_control: ephemeral\` so repeated turns within the same conversation hit the prompt cache (~90% cheaper on input tokens after the first call).

## What landed

- New file: [server/src/services/anthropic-llm.ts](server/src/services/anthropic-llm.ts) — singleton \`Anthropic\` client behind \`getClient()\` so SDK keepalive sockets stay warm across requests.
- Modified: [server/src/routes/conversations.ts](server/src/routes/conversations.ts) — \`llmStub\` deleted; \`replier: cosReplier({ conversations: svc, llm: anthropicLLM })\`.
- Modified: \`server/package.json\` + \`pnpm-lock.yaml\` — added \`@anthropic-ai/sdk\`.

## Why these specific knobs
- **Model**: \`claude-opus-4-7\` (latest most-capable; matches CLAUDE.md default)
- **Thinking disabled**: chat replies need to feel fast; thinking adds 2-10s of latency for marginal quality gain on conversational replies
- **Prompt caching**: the CoS \`COS_SYSTEM_PROMPT\` is constant across turns, and conversation history grows as a strict prefix — caching is a perfect fit
- **\`max_tokens: 1024\`**: chat replies should be concise; cap prevents long monologues

## Verification
- \`pnpm -r typecheck\` — server, ui, cli, plugins all \`Done\`, exit 0
- \`pnpm test:run\` — 2,665 tests pass / 1 skipped (exit 0). In-test stderr about \`listAdapterModelProfiles\` mock + \`queue unavailable\` + \`continuation recovery\` are pre-existing test-fixture warnings unrelated to this change — same output as before #88.
- \`pnpm build\` — server + ui + cli all built, exit 0

## Out of scope
- Companies-wide CoS personality / brand voice in the system prompt (current prompt is the AgentDash baseline)
- LLM call observability / token-usage tracking on the response (the SDK returns it; not surfacing yet)
- Real LLM wired for **agent execution** (separate path through adapters; this PR is only the CoS chat path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)