### PR TITLE
fix(marketing): scroll on long pages + give /assess a real CTA

### DIFF
--- a/ui/src/marketing/MarketingShell.css
+++ b/ui/src/marketing/MarketingShell.css
@@ -8,6 +8,18 @@
   min-height: 100vh;
 }
 
+/* AgentDash: marketing pages need normal page scroll. The dashboard sets
+   `html, body { height: 100%; overflow: hidden }` so its inner panes scroll
+   independently — but that clips long marketing pages (Landing, Consulting,
+   About, Assess) at the viewport. When a `.mkt-root` is mounted, restore
+   normal browser scroll. Uses `:has()` (Chrome 105+, Safari 15.4+, Firefox
+   121+ — all current). */
+html:has(.mkt-root),
+body:has(.mkt-root) {
+  height: auto;
+  overflow: auto;
+}
+
 .mkt-skip-link {
   position: absolute;
   top: -100px;

--- a/ui/src/pages/AssessPage.tsx
+++ b/ui/src/pages/AssessPage.tsx
@@ -6,9 +6,13 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useCompany } from "../context/CompanyContext";
 import { assessApi, type ProjectAssessmentSummary } from "../api/assess";
+import { authApi } from "../api/auth";
+import { healthApi } from "../api/health";
+import { queryKeys } from "../lib/queryKeys";
 import { MarketingShell } from "../marketing/MarketingShell";
 import { SectionContainer } from "../marketing/components/SectionContainer";
 import { Eyebrow } from "../marketing/components/Eyebrow";
+import { Button } from "../marketing/components/Button";
 import { CompanyWizard } from "./assess/CompanyWizard";
 import { ProjectWizard } from "./assess/ProjectWizard";
 import { ModeChooser, type AssessmentMode } from "./assess/ModeChooser";
@@ -19,6 +23,23 @@ export function AssessPage() {
   const { selectedCompany } = useCompany();
   const companyId = selectedCompany?.id;
   const [mode, setMode] = useState<AssessmentMode | null>(null);
+
+  // Auth-state detection — mirror the Landing page pattern so anonymous
+  // visitors hitting /assess directly get a sensible CTA instead of a
+  // dead-end "Select a company first" wall.
+  const healthQuery = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+    retry: false,
+  });
+  const isAuthenticatedMode = healthQuery.data?.deploymentMode === "authenticated";
+  const sessionQuery = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    enabled: isAuthenticatedMode,
+    retry: false,
+  });
+  const loggedIn = !isAuthenticatedMode || Boolean(sessionQuery.data);
 
   // Load past project assessments so we can show them on the chooser.
   const projectsQuery = useQuery<ProjectAssessmentSummary[]>({
@@ -39,17 +60,56 @@ export function AssessPage() {
   /*  No-company guard                                                  */
   /* ---------------------------------------------------------------- */
   if (!companyId) {
+    // Wait for auth resolution before rendering — otherwise the page flickers
+    // from "Try it free" to "Create your workspace" once the session loads.
+    if (healthQuery.isLoading || (isAuthenticatedMode && sessionQuery.isLoading)) {
+      return (
+        <MarketingShell>
+          <SectionContainer>
+            <Eyebrow>Agent Readiness Assessment</Eyebrow>
+          </SectionContainer>
+        </MarketingShell>
+      );
+    }
+
+    if (!loggedIn) {
+      // Anonymous visitor — offer sign-up. Most likely path: someone hit
+      // /assess from the marketing nav before they have an account.
+      return (
+        <MarketingShell>
+          <SectionContainer>
+            <Eyebrow>Agent Readiness Assessment</Eyebrow>
+            <h1 className="mkt-display-page" style={{ marginTop: 16, marginBottom: 16 }}>
+              Try it free.
+            </h1>
+            <p className="mkt-body-lg" style={{ color: "var(--mkt-ink-soft)", maxWidth: "60ch" }}>
+              The readiness assessment is scoped to a workspace. Sign up — the Free tier covers
+              one workspace and one Chief of Staff agent, no credit card needed.
+            </p>
+            <div style={{ marginTop: 32, display: "flex", gap: 16, flexWrap: "wrap" }}>
+              <Button href="/auth?mode=sign_up">Start free</Button>
+              <Button href="/auth" variant="ghost">Sign in</Button>
+            </div>
+          </SectionContainer>
+        </MarketingShell>
+      );
+    }
+
+    // Logged in, but no company yet — push them through onboarding.
     return (
       <MarketingShell>
         <SectionContainer>
           <Eyebrow>Agent Readiness Assessment</Eyebrow>
           <h1 className="mkt-display-page" style={{ marginTop: 16, marginBottom: 16 }}>
-            Select a company first.
+            Create your workspace first.
           </h1>
           <p className="mkt-body-lg" style={{ color: "var(--mkt-ink-soft)", maxWidth: "60ch" }}>
-            The assessment is scoped to a company. Pick or create one from the company switcher,
-            then come back to run a readiness analysis.
+            The assessment is scoped to a workspace. Set yours up — it takes about 30 seconds —
+            and the Chief of Staff will walk you back here.
           </p>
+          <div style={{ marginTop: 32, display: "flex", gap: 16, flexWrap: "wrap" }}>
+            <Button href="/onboarding">Create your workspace</Button>
+          </div>
         </SectionContainer>
       </MarketingShell>
     );


### PR DESCRIPTION
Two related bugs from [#86](https://github.com/thetangstr/agentdash/pull/86)'s marketing surface restoration that the user hit on first deploy.

## 1. Long marketing pages didn't scroll
The dashboard sets `html, body { height: 100%; overflow: hidden }` ([ui/src/index.css](ui/src/index.css)) so its inner panes scroll independently. That same rule clipped Landing / Consulting / About / Assess at the viewport — content past 100vh was physically unreachable.

**Fix:** scope an override behind `:has(.mkt-root)` so only marketing routes get normal browser scroll. Dashboard CSS untouched.

```css
html:has(.mkt-root),
body:has(.mkt-root) {
  height: auto;
  overflow: auto;
}
```

`:has()` is supported on Chrome 105+, Safari 15.4+, Firefox 121+ — all current.

## 2. /assess showed a dead-end "Select a company first" wall
Anonymous visitor hits `/assess` (or a logged-in user without a company) → page rendered the title + a paragraph and nothing else. No button, no link, no path forward. The user flagged this exactly: *"Assessment page doesn't have a button or anything to get started. Or maybe if it needs to sign in then it should say try it and it should ask you to sign in."*

**Fix:** detect auth state with the same pattern `Landing.tsx` uses (`healthQuery` + `sessionQuery`), then branch:

| State | What renders |
|---|---|
| Loading auth | Just the eyebrow (no title yet — prevents flicker) |
| **Anonymous** | "Try it free." + **Start free** (→ `/auth?mode=sign_up`) + **Sign in** (→ `/auth`) |
| **Logged in, no company** | "Create your workspace first." + **Create your workspace** (→ `/onboarding`) |
| **Has company** | unchanged — falls through to the existing ModeChooser |

## Verification
- `pnpm -r typecheck` — Done, exit 0
- `pnpm test:run` — passing
- `pnpm --filter @paperclipai/ui build` — Done, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)