### PR TITLE
docs: surface `agentdash setup` wizard in README + LAUNCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ When `STRIPE_SECRET_KEY` is set in production, the Free / Pro caps enforce as de
 
 ---
 
+## First-run setup on a real host (`agentdash setup`)
+
+Use this path when you're deploying AgentDash to a host you'll actually serve from — a Mac mini on your LAN, a workstation behind Tailscale, a cloud VM. The CLI ships an `agentdash setup` wizard that walks the three things `pnpm dev` skips for local-trusted dev:
+
+```sh
+agentdash onboard           # one-time: database, LLM, storage, secrets
+agentdash setup             # then: server reachability + CEO invite + adapter
+```
+
+`agentdash setup` runs three subcommands you can also invoke individually:
+
+| Subcommand | What it does |
+|---|---|
+| `agentdash setup server` | Picks the bind mode. Auto-detects Tailscale via `tailscale ip -4` and defaults to `tailnet` when found, falling back to `loopback` otherwise. Updates `allowedHostnames`. |
+| `agentdash setup bootstrap` | Generates the one-time CEO invite URL (only meaningful in `authenticated` mode), prints it, and opens it in the default browser. Use `--no-open` to skip the auto-open. |
+| `agentdash setup adapter` | Lets you pick an initial agent adapter (Claude Code, Codex, Cursor, etc.) and prints the install command for adapters that need a separate CLI binary. |
+
+Useful flags:
+
+```sh
+agentdash setup --yes                  # non-interactive, accept detected defaults
+agentdash setup --bind tailnet         # force a specific bind mode
+agentdash setup --no-open              # don't auto-launch the browser for the invite
+agentdash setup --skip-adapter         # partial run
+```
+
+---
+
 ## Going to production
 
 [doc/LAUNCH.md](doc/LAUNCH.md) is the dependency-ordered checklist from a clean clone to first paying customer:

--- a/doc/LAUNCH.md
+++ b/doc/LAUNCH.md
@@ -4,6 +4,8 @@ How to take AgentDash from a clean clone to your first paying customer. Read top
 
 The local-trusted dev experience (`pnpm dev` → `localhost:3100/cos`) needs none of this. Everything below is for a real cloud deployment with a real signed-up user paying through Stripe.
 
+> **Cloud container vs bare-metal host.** This doc covers the **cloud container path** — Railway / Fly / Render running the [Dockerfile](../Dockerfile), env vars set through the platform's dashboard. If you're instead running on a bare-metal host you control directly (Mac mini on your LAN, a workstation behind Tailscale, an EC2/Lightsail VM you SSH into), use `agentdash onboard` then `agentdash setup` — the wizard handles bind mode, Tailscale auto-detect, allowed hostnames, the CEO invite, and adapter selection interactively. See the README's *First-run setup on a real host* section. The Stripe + Anthropic env vars (steps 3–4 below) still apply to the bare-metal path; the wizard handles steps 1–2.
+
 ---
 
 ## 1. Pick a cloud host and provision Postgres


### PR DESCRIPTION
The setup wizard shipped in [#96](https://github.com/thetangstr/agentdash/pull/96) (closes [#94](https://github.com/thetangstr/agentdash/issues/94)) but neither the README quickstart nor the launch checklist mentioned it. New users had no way to discover that the bind-mode + Tailscale + CEO-invite + adapter steps are now a single `agentdash setup` instead of a manual env-var dance.

## README
Adds a **"First-run setup on a real host (`agentdash setup`)"** section right after Quickstart. Calls out:
- `pnpm dev` is for hacking on the codebase locally
- `agentdash onboard` + `agentdash setup` is the path for any host that's actually serving — Mac mini, Tailscale workstation, cloud VM

Documents the three subcommands (`server` / `bootstrap` / `adapter`) and the useful flags (`--yes`, `--bind`, `--no-open`, `--skip-adapter`).

## LAUNCH.md
Adds a callout right after the intro explaining the two deployment paths:

- **Cloud container** (Railway / Fly / Render with Dockerfile + env vars in the platform UI) — the rest of LAUNCH.md
- **Bare-metal host** (any host you SSH into directly) — `agentdash onboard` + `agentdash setup`

The Stripe + Anthropic env vars (steps 3–4) still apply to the bare-metal path; the wizard handles steps 1–2 (bind, bootstrap) interactively instead of needing the env-var dance.

Doc-only. No code changes. Every md/dir link in both files still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)