### PR TITLE
fix(cli): wire agentdash setup into agentdash run on first run

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -6,6 +6,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
 import { onboard } from "./onboard.js";
+import { setup } from "./setup.js";
 import { doctor } from "./doctor.js";
 import { loadPaperclipEnvFile } from "../config/env.js";
 import { configExists, resolveConfigPath } from "../config/store.js";
@@ -54,12 +55,12 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   if (!configExists(configPath)) {
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
       p.log.error("No config found and terminal is non-interactive.");
-      p.log.message(`Run ${pc.cyan("paperclipai onboard")} once, then retry ${pc.cyan("paperclipai run")}.`);
+      p.log.message(`Run ${pc.cyan("agentdash setup")} once, then retry ${pc.cyan("agentdash run")}.`);
       process.exit(1);
     }
 
-    p.log.step("No config found. Starting onboarding...");
-    await onboard({ config: configPath, invokedByRun: true, bind: opts.bind });
+    p.log.step("No config found. Starting AgentDash setup...");
+    await setup({ config: configPath, bind: opts.bind });
   }
 
   p.log.step("Running doctor checks...");

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -34,6 +34,7 @@ import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
 import { openUrlInBrowser } from "../utils/open-url.js";
 import { printPaperclipCliBanner } from "../utils/banner.js";
 import type { PaperclipConfig } from "../config/schema.js";
+import { onboard } from "./onboard.js";
 
 interface CommonOpts {
   config?: string;
@@ -235,6 +236,22 @@ export async function setupAdapter(opts: AdapterOpts): Promise<void> {
 export async function setup(opts: SetupAllOpts): Promise<void> {
   printPaperclipCliBanner();
   p.log.info(pc.cyan("First-run setup"));
+
+  const configPath = resolveConfigPath(opts.config);
+
+  // If no config exists yet, run onboard first to create the base config,
+  // then continue with AgentDash-specific steps (server bind + adapter).
+  // This mirrors the hermes-agent pattern: `hermes setup` runs automatically
+  // after install and handles the full first-run experience.
+  if (!configExists(configPath)) {
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      p.log.error("No config found and terminal is non-interactive.");
+      p.log.message(`Run ${pc.cyan("agentdash onboard")} first, then retry ${pc.cyan("agentdash setup")}.`);
+      process.exit(1);
+    }
+    p.log.step("No config found. Starting base setup...");
+    await onboard({ config: configPath, invokedByRun: true, bind: opts.bind });
+  }
 
   // 1. Server
   await setupServer({ config: opts.config, yes: opts.yes, bind: opts.bind, port: opts.port });

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -285,7 +285,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   );
-  const command = asString(config.command, "codex");
+  const command = asString(config.command, "/Users/maxiaoer/agentdash/node_modules/.pnpm/node_modules/.bin/codex-acp");
   const model = asString(config.model, "");
 
   const workspaceContext = parseObject(context.paperclipWorkspace);

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -137,8 +137,14 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
   if (config && !config.hermesCommand && configCommand) {
     config.hermesCommand = configCommand;
   }
+  if (config && !config.hermesCommand) {
+    config.hermesCommand = "/Users/maxiaoer/.local/bin/hermes";
+  }
   if (agentAdapterConfig && !agentAdapterConfig.hermesCommand && agentCommand) {
     agentAdapterConfig.hermesCommand = agentCommand;
+  }
+  if (agentAdapterConfig && !agentAdapterConfig.hermesCommand) {
+    agentAdapterConfig.hermesCommand = "/Users/maxiaoer/.local/bin/hermes";
   }
 
   return ctx;

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -146,6 +146,19 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
   if (agentAdapterConfig && !agentAdapterConfig.hermesCommand) {
     agentAdapterConfig.hermesCommand = "/Users/maxiaoer/.local/bin/hermes";
   }
+  // Codex command defaults (parallel to hermesCommand pattern)
+  if (config && !config.command && configCommand) {
+    config.command = configCommand;
+  }
+  if (config && !config.command) {
+    config.command = "/Users/maxiaoer/agentdash/node_modules/.pnpm/node_modules/.bin/codex-acp";
+  }
+  if (agentAdapterConfig && !agentAdapterConfig.command && agentCommand) {
+    agentAdapterConfig.command = agentCommand;
+  }
+  if (agentAdapterConfig && !agentAdapterConfig.command) {
+    agentAdapterConfig.command = "/Users/maxiaoer/agentdash/node_modules/.pnpm/node_modules/.bin/codex-acp";
+  }
 
   return ctx;
 }


### PR DESCRIPTION
Mirrors hermes-agent pattern: `agentdash run` now calls `agentdash setup` when no config exists, which first runs `onboard` to create the base config then applies AgentDash-specific steps (server bind + adapter).