### PR TITLE
feat(cli): make `agentdash setup` truly frictionless (2 prompts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,29 +57,33 @@ When `STRIPE_SECRET_KEY` is set in production, the Free / Pro caps enforce as de
 
 ## First-run setup on a real host (`agentdash setup`)
 
-Use this path when you're deploying AgentDash to a host you'll actually serve from — a Mac mini on your LAN, a workstation behind Tailscale, a cloud VM. The CLI ships an `agentdash setup` wizard that walks the three things `pnpm dev` skips for local-trusted dev:
+Use this path when you're deploying AgentDash to a host you'll actually serve from — a Mac mini on your LAN, a workstation behind Tailscale, a cloud VM.
 
 ```sh
-agentdash onboard           # one-time: database, LLM, storage, secrets
-agentdash setup             # then: server reachability + CEO invite + adapter
+agentdash setup
 ```
 
-`agentdash setup` runs three subcommands you can also invoke individually:
+That's it. Two prompts:
 
-| Subcommand | What it does |
-|---|---|
-| `agentdash setup server` | Picks the bind mode. Auto-detects Tailscale via `tailscale ip -4` and defaults to `tailnet` when found, falling back to `loopback` otherwise. Updates `allowedHostnames`. |
-| `agentdash setup bootstrap` | Generates the one-time CEO invite URL (only meaningful in `authenticated` mode), prints it, and opens it in the default browser. Use `--no-open` to skip the auto-open. |
-| `agentdash setup adapter` | Lets you pick an initial agent adapter (Claude Code, Codex, Cursor, etc.) and prints the install command for adapters that need a separate CLI binary. |
+1. **Pick an adapter** for your first agent (Claude Code / Codex / Hermes / Cursor / Gemini / OpenCode / Pi / ACPX / OpenClaw / process / http). The wizard runs `<adapter-binary> --version` to verify it's installed; if it's not, it prints the exact install command and lets you keep going.
+2. **Your email** — used as `AGENTDASH_BOOTSTRAP_EMAIL` so the workspace name + email-domain claim derive cleanly on first boot.
 
-Useful flags:
+Everything else (embedded Postgres, local-disk storage, local-encrypted secrets, loopback bind, local_trusted mode, info logging) uses safe defaults. If the host has no config yet, the wizard writes one in place.
 
+Non-interactive (CI / scripted):
 ```sh
-agentdash setup --yes                  # non-interactive, accept detected defaults
-agentdash setup --bind tailnet         # force a specific bind mode
-agentdash setup --no-open              # don't auto-launch the browser for the invite
-agentdash setup --skip-adapter         # partial run
+agentdash setup --yes --email you@yourdomain.com
+agentdash setup --yes --email you@yourdomain.com --adapter hermes_local
 ```
+
+Re-run a single step later:
+```sh
+agentdash setup adapter            # pick + verify a different adapter
+agentdash setup server             # switch bind mode (loopback / lan / tailnet)
+agentdash setup bootstrap          # re-issue the CEO invite (authenticated mode only)
+```
+
+> **`agentdash onboard`** is the legacy advanced wizard (full database / LLM / storage / secrets prompts). Use it only if you need to override the defaults — most operators won't.
 
 ---
 

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -329,6 +329,12 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
 
   printPaperclipCliBanner();
   p.intro(pc.bgCyan(pc.black(" paperclipai onboard ")));
+  // AgentDash: most first-time users want the lighter `agentdash setup`
+  // wizard. `onboard` is the advanced path with full database / LLM /
+  // storage / secrets prompts. Surface the nudge once so it's discoverable.
+  p.log.info(
+    `${pc.dim("Most users only need")} ${pc.cyan("agentdash setup")} ${pc.dim("— pick adapter + email, safe defaults for everything else.")}`,
+  );
   const configPath = resolveConfigPath(opts.config);
   const instance = describeLocalInstancePaths(resolvePaperclipInstanceId());
   p.log.message(

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,25 +1,25 @@
-// AgentDash: first-run wizard. Closes GH #94.
+// AgentDash: frictionless first-run wizard. Closes GH #94 + the cleanup
+// the user asked for after #96 ("we need a frictionless way for user to
+// get started").
 //
-// `agentdash setup` is the canonical first-run path. It orchestrates three
-// focused subcommands:
+// The default `agentdash setup` flow is two steps, period:
 //
-//   setup server     — Tailscale-aware bind mode + allowed hostnames
-//   setup bootstrap  — generate the CEO invite and open it in the browser
-//   setup adapter    — pick + install an initial agent adapter
+//   1. Pick an adapter — verify its binary is on PATH; if not, print the
+//      install command and the line that failed.
+//   2. Ask for the founding user's email — used as
+//      AGENTDASH_BOOTSTRAP_EMAIL so the workspace name + emailDomain
+//      derive cleanly on first boot.
 //
-// Plain `agentdash setup` runs all three in order. Each subcommand is also
-// runnable on its own so a user can revisit a step later (e.g. add an
-// adapter after the server is up).
+// Everything else uses safe defaults — embedded Postgres, local-disk
+// storage, local-encrypted secrets, loopback bind, local_trusted mode,
+// info logging. If the user wants to tune any of those, the existing
+// `agentdash onboard` (the older paperclip-inherited wizard) and the
+// per-section subcommands below stay around as escape hatches.
 //
-// Design notes:
-// - The server step is a SLIM alternative to `agentdash onboard` for users
-//   who only need bind/host config. Power users still have `onboard` for
-//   database/LLM/storage prompts.
-// - The bootstrap step calls `bootstrapCeoInvite()` directly (which now
-//   returns the invite URL) and opens it in the browser unless --no-open.
-// - The adapter step doesn't actually install adapter packages globally
-//   (paperclip core's responsibility) — it prints the canonical install
-//   command for the chosen adapter so the user knows what to run.
+// Subcommands kept for re-running a single step later:
+//   setup server     — switch bind mode (loopback / lan / tailnet)
+//   setup bootstrap  — re-issue the CEO invite for authenticated mode
+//   setup adapter    — pick + verify a different adapter
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import {
@@ -31,8 +31,18 @@ import {
 import { configExists, readConfig, resolveConfigPath, writeConfig } from "../config/store.js";
 import { buildPresetServerConfig, detectTailnetBindHost } from "../config/server-bind.js";
 import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
+import { mergePaperclipEnvEntries, resolvePaperclipEnvFile, ensureAgentJwtSecret } from "../config/env.js";
 import { openUrlInBrowser } from "../utils/open-url.js";
 import { printPaperclipCliBanner } from "../utils/banner.js";
+import { ADAPTER_CHECKS, checkAdapterBinary, findAdapterCheck } from "../utils/adapter-check.js";
+import { defaultStorageConfig } from "../prompts/storage.js";
+import { defaultSecretsConfig } from "../prompts/secrets.js";
+import {
+  resolveDefaultBackupDir,
+  resolveDefaultEmbeddedPostgresDir,
+  resolveDefaultLogsDir,
+  resolvePaperclipInstanceId,
+} from "../config/home.js";
 import type { PaperclipConfig } from "../config/schema.js";
 
 interface CommonOpts {
@@ -57,43 +67,225 @@ interface AdapterOpts extends CommonOpts {
 }
 
 interface SetupAllOpts extends CommonOpts {
-  bind?: BindMode;
-  port?: number;
-  open?: boolean;
-  skipAdapter?: boolean;
-  skipBootstrap?: boolean;
+  email?: string;
+  adapter?: string;
 }
 
-const ADAPTER_CHOICES: Array<{ value: AgentAdapterType; label: string; install?: string }> = [
-  { value: "claude_local", label: "Claude Code (local)", install: "npm install -g @anthropic-ai/claude-code" },
-  { value: "codex_local", label: "Codex (local)", install: "npm install -g @openai/codex" },
-  { value: "cursor", label: "Cursor (local)" },
-  { value: "gemini_local", label: "Gemini (local)" },
-  { value: "opencode_local", label: "OpenCode (local)" },
-  { value: "pi_local", label: "Pi (local)" },
-  { value: "acpx_local", label: "ACPX (local)" },
-  { value: "openclaw_gateway", label: "OpenClaw (gateway)" },
-  { value: "process", label: "Generic process adapter" },
-  { value: "http", label: "Generic HTTP adapter" },
-];
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-// ---------- setup server ----------
+// ---------- safe-defaults config builder ----------
+
+/**
+ * Build a minimal, valid PaperclipConfig from scratch — used when the user
+ * runs `agentdash setup` on a fresh machine with no prior config. Mirrors
+ * what `agentdash onboard` produces in quickstart-loopback mode but skips
+ * every prompt.
+ */
+function buildDefaultConfig(): PaperclipConfig {
+  const instanceId = resolvePaperclipInstanceId();
+  const { server, auth } = buildPresetServerConfig("loopback", {
+    port: 3100,
+    allowedHostnames: ["localhost", "127.0.0.1"],
+    serveUi: true,
+  });
+  return {
+    $meta: {
+      version: 1,
+      updatedAt: new Date().toISOString(),
+      source: "onboard",
+    },
+    database: {
+      mode: "embedded-postgres",
+      embeddedPostgresDataDir: resolveDefaultEmbeddedPostgresDir(instanceId),
+      embeddedPostgresPort: 54329,
+      backup: {
+        enabled: true,
+        intervalMinutes: 60,
+        retentionDays: 7,
+        dir: resolveDefaultBackupDir(instanceId),
+      },
+    },
+    logging: {
+      mode: "file",
+      logDir: resolveDefaultLogsDir(instanceId),
+    },
+    server,
+    telemetry: { enabled: true },
+    auth,
+    storage: defaultStorageConfig(),
+    secrets: defaultSecretsConfig(),
+  };
+}
+
+// ---------- step 1: pick + verify adapter ----------
+
+interface AdapterPickResult {
+  type: AgentAdapterType;
+  ok: boolean;
+  detail?: string;
+  fix?: string;
+}
+
+async function pickAndVerifyAdapter(opts: { yes?: boolean; preselected?: string }): Promise<AdapterPickResult | null> {
+  let selected: AgentAdapterType;
+
+  if (opts.preselected) {
+    if (!AGENT_ADAPTER_TYPES.includes(opts.preselected as (typeof AGENT_ADAPTER_TYPES)[number])) {
+      p.log.error(`Unknown adapter type ${pc.cyan(opts.preselected)}. Known: ${AGENT_ADAPTER_TYPES.join(", ")}`);
+      return null;
+    }
+    selected = opts.preselected as AgentAdapterType;
+    p.log.info(`Adapter: ${pc.cyan(selected)}`);
+  } else if (opts.yes) {
+    // Default to claude_local in non-interactive mode — it's the most common
+    // first-time pick. The user can change later in the dashboard.
+    selected = "claude_local";
+    p.log.info(`Adapter: ${pc.cyan(selected)} (default in --yes mode)`);
+  } else {
+    const picked = await p.select({
+      message: "Pick the adapter for your first agent:",
+      options: ADAPTER_CHECKS.map((spec) => ({
+        value: spec.type,
+        label: spec.label,
+        hint: spec.command ? pc.dim(`runs \`${spec.command}\``) : pc.dim("configured later"),
+      })),
+      initialValue: "claude_local",
+    });
+    if (p.isCancel(picked)) {
+      p.cancel("Setup cancelled.");
+      return null;
+    }
+    selected = picked as AgentAdapterType;
+  }
+
+  const spec = findAdapterCheck(selected);
+  if (!spec) {
+    return { type: selected, ok: true };
+  }
+
+  const result = checkAdapterBinary(spec);
+  switch (result.status) {
+    case "configured":
+      p.log.success(`${spec.label} ready  ${pc.dim(`(${result.detail})`)}`);
+      return { type: selected, ok: true, detail: result.detail };
+    case "manual":
+      p.log.info(`${spec.label} — ${pc.dim(result.detail ?? "configure when you hire your first agent")}`);
+      return { type: selected, ok: true, detail: result.detail };
+    case "missing":
+    case "errored":
+      p.log.warn(`${spec.label} not ready: ${result.detail}`);
+      if (result.fix) {
+        p.log.message(`  ${pc.cyan("Fix:")} ${result.fix}`);
+      }
+      p.log.message(pc.dim("  You can keep going and install it later — agents using this adapter will fail to run until then."));
+      return { type: selected, ok: false, detail: result.detail, fix: result.fix };
+  }
+}
+
+// ---------- step 2: get founding user's email ----------
+
+async function getFounderEmail(opts: { yes?: boolean; email?: string }): Promise<string | null> {
+  if (opts.email) {
+    if (!EMAIL_RE.test(opts.email)) {
+      p.log.error(`${pc.cyan(opts.email)} doesn't look like a valid email.`);
+      return null;
+    }
+    p.log.info(`Founding user: ${pc.cyan(opts.email)}`);
+    return opts.email;
+  }
+  if (opts.yes) {
+    p.log.error("Refusing to run --yes without --email — the founding user's email is required.");
+    return null;
+  }
+  const value = await p.text({
+    message: "Your email (used as the founding user / company owner):",
+    placeholder: "you@yourdomain.com",
+    validate: (v) => (EMAIL_RE.test(v.trim()) ? undefined : "Please enter a valid email."),
+  });
+  if (p.isCancel(value)) {
+    p.cancel("Setup cancelled.");
+    return null;
+  }
+  return value.trim();
+}
+
+// ---------- top-level orchestrator ----------
+
+export async function setup(opts: SetupAllOpts): Promise<void> {
+  printPaperclipCliBanner();
+  p.intro(pc.cyan("AgentDash setup"));
+
+  const configPath = resolveConfigPath(opts.config);
+  const hadConfig = configExists(configPath);
+  if (!hadConfig) {
+    const fresh = buildDefaultConfig();
+    writeConfig(fresh, configPath);
+    p.log.info(`Wrote a fresh config at ${pc.dim(configPath)} with safe defaults (loopback, embedded Postgres, local storage).`);
+  }
+
+  // Step 1 — adapter
+  const adapter = await pickAndVerifyAdapter({ yes: opts.yes, preselected: opts.adapter });
+  if (!adapter) return;
+
+  // Step 2 — email
+  const email = await getFounderEmail({ yes: opts.yes, email: opts.email });
+  if (!email) return;
+
+  // Persist email + JWT secret
+  const envPath = resolvePaperclipEnvFile(opts.config);
+  mergePaperclipEnvEntries(
+    {
+      AGENTDASH_BOOTSTRAP_EMAIL: email,
+      AGENTDASH_DEFAULT_ADAPTER: adapter.type,
+    },
+    envPath,
+  );
+  ensureAgentJwtSecret(opts.config);
+  p.log.success(`Saved founding-user email and adapter preference to ${pc.dim(envPath)}`);
+
+  // Done — print next steps
+  p.outro(pc.green("Setup complete."));
+  console.log("");
+  console.log(pc.bold("Next:"));
+  console.log(`  ${pc.cyan("pnpm dev")}`);
+  console.log(`  Open ${pc.cyan("http://localhost:3100/cos")} — your Chief of Staff is ready.`);
+  if (!adapter.ok) {
+    console.log("");
+    console.log(pc.yellow(`  ⚠  ${adapter.type} isn't installed yet — agents using it will fail until you fix it.`));
+    if (adapter.fix) console.log(`    ${pc.cyan("Fix:")} ${adapter.fix}`);
+  }
+}
+
+// ---------- subcommands (escape hatches for re-running a step) ----------
+
+export async function setupAdapter(opts: AdapterOpts): Promise<void> {
+  if (!opts.yes) {
+    printPaperclipCliBanner();
+    p.intro(pc.cyan("Re-pick adapter"));
+  }
+  const result = await pickAndVerifyAdapter({ yes: opts.yes, preselected: opts.type });
+  if (!result) return;
+  // Persist the chosen adapter type so the dashboard can default to it.
+  mergePaperclipEnvEntries({ AGENTDASH_DEFAULT_ADAPTER: result.type }, resolvePaperclipEnvFile(opts.config));
+  if (!opts.yes) p.outro(pc.green("Done."));
+}
 
 export async function setupServer(opts: ServerOpts): Promise<void> {
   const configPath = resolveConfigPath(opts.config);
   if (!configExists(configPath)) {
-    p.log.error(`No config found at ${pc.dim(configPath)}.`);
-    p.log.message(`Run ${pc.cyan("agentdash onboard")} first to create the base config (database, LLM, storage), then come back to ${pc.cyan("agentdash setup")}.`);
+    p.log.error(`No config at ${pc.dim(configPath)}. Run ${pc.cyan("agentdash setup")} first.`);
     return;
   }
   const existing = readConfig(configPath);
   if (!existing) {
-    p.log.error(`Config at ${pc.dim(configPath)} could not be parsed.`);
+    p.log.error(`Config at ${pc.dim(configPath)} couldn't be parsed.`);
     return;
   }
 
-  if (!opts.yes) printPaperclipCliBanner();
-  p.log.info(pc.cyan("Server reachability"));
+  if (!opts.yes) {
+    printPaperclipCliBanner();
+    p.intro(pc.cyan("Server reachability"));
+  }
 
   const detectedTailnet = detectTailnetBindHost();
   const detectedBind: BindMode = opts.bind
@@ -102,16 +294,15 @@ export async function setupServer(opts: ServerOpts): Promise<void> {
   let bind: BindMode;
   if (opts.yes || opts.bind) {
     bind = detectedBind;
-    p.log.info(`Using bind mode ${pc.cyan(bind)}${detectedTailnet ? ` (Tailscale detected at ${pc.dim(detectedTailnet)})` : ""}`);
+    p.log.info(`Bind: ${pc.cyan(bind)}${detectedTailnet ? ` ${pc.dim(`(Tailscale at ${detectedTailnet})`)}` : ""}`);
   } else {
-    const choices: Array<{ value: BindMode; label: string; hint?: string }> = [
-      { value: "loopback", label: "loopback (localhost only)", hint: "Single-machine dev. local_trusted mode — no auth." },
-      { value: "lan", label: "lan (any IP)", hint: "Reachable from your LAN. Authenticated mode." },
-      { value: "tailnet", label: "tailnet (Tailscale)", hint: detectedTailnet ? `Detected: ${detectedTailnet}` : "No Tailscale detected — falls back to loopback at runtime." },
-    ];
     const picked = await p.select({
       message: "How should the server be reachable?",
-      options: choices,
+      options: [
+        { value: "loopback", label: "loopback (localhost only)", hint: "Single-machine, no auth." },
+        { value: "lan", label: "lan (any IP)", hint: "Reachable from your LAN." },
+        { value: "tailnet", label: "tailnet (Tailscale)", hint: detectedTailnet ? `Detected: ${detectedTailnet}` : "Falls back to loopback if no Tailscale." },
+      ],
       initialValue: detectedBind === "custom" ? "loopback" : detectedBind,
     });
     if (p.isCancel(picked)) {
@@ -122,26 +313,19 @@ export async function setupServer(opts: ServerOpts): Promise<void> {
   }
 
   if (bind === "custom") {
-    p.log.warn("Custom bind hosts aren't supported by `setup server` — use `agentdash onboard` for advanced server config.");
+    p.log.warn("Custom hosts: use `agentdash onboard` for advanced server config.");
     return;
   }
 
   const port = opts.port ?? existing.server.port ?? 3100;
   const allowedHostnames = collectAllowedHostnames(existing, detectedTailnet, bind);
-
   const { server, auth } = buildPresetServerConfig(bind, {
     port,
     allowedHostnames,
     serveUi: existing.server.serveUi ?? true,
   });
-
-  const next: PaperclipConfig = { ...existing, server, auth };
-  writeConfig(next, configPath);
-  p.log.success(`Wrote server config to ${pc.dim(configPath)}`);
-  p.log.message(`Bind: ${pc.cyan(bind)}  Host: ${pc.cyan(server.host)}  Port: ${pc.cyan(String(server.port))}`);
-  if (allowedHostnames.length > 0) {
-    p.log.message(`Allowed hostnames: ${pc.dim(allowedHostnames.join(", "))}`);
-  }
+  writeConfig({ ...existing, server, auth }, configPath);
+  p.log.success(`Server: bind=${pc.cyan(bind)} host=${pc.cyan(server.host)} port=${pc.cyan(String(server.port))}`);
 }
 
 function collectAllowedHostnames(existing: PaperclipConfig, tailnet: string | undefined, bind: BindMode): string[] {
@@ -152,108 +336,22 @@ function collectAllowedHostnames(existing: PaperclipConfig, tailnet: string | un
   return Array.from(set);
 }
 
-// ---------- setup bootstrap ----------
-
 export async function setupBootstrap(opts: BootstrapOpts): Promise<void> {
   if (!opts.yes) {
     printPaperclipCliBanner();
-    p.log.info(pc.cyan("Bootstrap CEO invite"));
+    p.intro(pc.cyan("Bootstrap CEO invite"));
   }
-
   const result = await bootstrapCeoInvite({
     config: opts.config,
     force: opts.force,
     expiresHours: opts.expiresHours,
     baseUrl: opts.baseUrl,
   });
-
   if (result.status !== "created" || !result.inviteUrl) return;
-
   const shouldOpen = opts.open ?? true;
   if (shouldOpen) {
     const opened = openUrlInBrowser(result.inviteUrl);
-    if (opened) {
-      p.log.message(pc.dim("Opened the invite URL in your browser."));
-    } else {
-      p.log.warn("Could not auto-open the URL — copy/paste it from above.");
-    }
-  } else {
-    p.log.message(pc.dim("Skipping browser auto-open (--no-open)."));
+    if (opened) p.log.message(pc.dim("Opened in your browser."));
+    else p.log.warn("Couldn't auto-open — copy/paste the URL above.");
   }
-}
-
-// ---------- setup adapter ----------
-
-export async function setupAdapter(opts: AdapterOpts): Promise<void> {
-  if (!opts.yes) {
-    printPaperclipCliBanner();
-    p.log.info(pc.cyan("Adapter selection"));
-  }
-
-  let adapter: AgentAdapterType | "skip";
-  if (opts.type) {
-    if (!AGENT_ADAPTER_TYPES.includes(opts.type as (typeof AGENT_ADAPTER_TYPES)[number])) {
-      p.log.error(`Unknown adapter type ${pc.cyan(opts.type)}. Known: ${AGENT_ADAPTER_TYPES.join(", ")}`);
-      return;
-    }
-    adapter = opts.type as AgentAdapterType;
-  } else if (opts.yes) {
-    p.log.info("Skipping adapter selection in --yes mode. Run `agentdash setup adapter` interactively to pick one.");
-    return;
-  } else {
-    const picked = await p.select({
-      message: "Pick an initial adapter to use for your first agent:",
-      options: [
-        { value: "skip" as const, label: "Skip — pick later from the dashboard" },
-        ...ADAPTER_CHOICES.map((c) => ({ value: c.value, label: c.label, hint: c.install })),
-      ],
-      initialValue: "skip" as const,
-    });
-    if (p.isCancel(picked)) {
-      p.cancel("Setup cancelled.");
-      return;
-    }
-    adapter = picked as AgentAdapterType | "skip";
-  }
-
-  if (adapter === "skip") {
-    p.log.message(pc.dim("Skipped. You can hire an agent and pick its adapter from the dashboard."));
-    return;
-  }
-
-  const choice = ADAPTER_CHOICES.find((c) => c.value === adapter);
-  p.log.success(`Selected ${pc.cyan(choice?.label ?? adapter)}.`);
-  if (choice?.install) {
-    p.log.message(`Install the adapter binary if you haven't:`);
-    p.log.message(`  ${pc.cyan(choice.install)}`);
-  }
-  p.log.message(`When you hire your first agent in the dashboard, set ${pc.cyan("adapterType")} to ${pc.cyan(adapter)}.`);
-}
-
-// ---------- setup (orchestrator) ----------
-
-export async function setup(opts: SetupAllOpts): Promise<void> {
-  printPaperclipCliBanner();
-  p.log.info(pc.cyan("First-run setup"));
-
-  // 1. Server
-  await setupServer({ config: opts.config, yes: opts.yes, bind: opts.bind, port: opts.port });
-
-  // 2. Bootstrap (only meaningful when server is in authenticated mode)
-  if (!opts.skipBootstrap) {
-    const cfg = readConfig(resolveConfigPath(opts.config));
-    if (cfg?.server.deploymentMode === "authenticated") {
-      await setupBootstrap({ config: opts.config, yes: opts.yes, open: opts.open });
-    } else {
-      p.log.info(pc.dim("Skipping bootstrap step — local_trusted mode doesn't need a CEO invite."));
-    }
-  }
-
-  // 3. Adapter
-  if (!opts.skipAdapter) {
-    await setupAdapter({ config: opts.config, yes: opts.yes });
-  }
-
-  p.log.success("Setup complete.");
-  p.log.message(`Next: ${pc.cyan("pnpm dev")} (or ${pc.cyan("agentdash run")}) to start the server.`);
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -49,7 +49,7 @@ program.hook("preAction", (_thisCommand, actionCommand) => {
 
 program
   .command("onboard")
-  .description("Interactive first-run setup wizard")
+  .description("Advanced setup wizard (database / LLM / storage). Most users want `agentdash setup` instead.")
   .option("-c, --config <path>", "Path to config file")
   .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
   .option("--bind <mode>", "Quickstart reachability preset (loopback, lan, tailnet)")
@@ -57,25 +57,31 @@ program
   .option("--run", "Start Paperclip immediately after saving config", false)
   .action(onboard);
 
-// AgentDash: focused first-run wizard with subcommands (closes GH #94).
-// `setup` (no arg) runs server -> bootstrap -> adapter in order. Each
-// subcommand is also runnable standalone for re-running a single step.
+// AgentDash: frictionless first-run wizard. Two prompts (adapter + email)
+// + safe defaults autowritten if no config exists. Subcommands stay
+// available as escape hatches for re-running a single step.
 const setupCmd = program
   .command("setup")
-  .description("AgentDash first-run wizard (server, bootstrap, adapter)")
+  .description("AgentDash first-run wizard — pick adapter + founding user email")
   .option("-c, --config <path>", "Path to config file")
   .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
-  .option("--bind <mode>", "Reachability preset (loopback, lan, tailnet)")
-  .option("--port <number>", "Server port", (value) => Number(value))
-  .option("-y, --yes", "Non-interactive — accept detected defaults", false)
-  .option("--no-open", "Don't auto-open the bootstrap invite in the browser")
-  .option("--skip-adapter", "Skip the adapter selection step", false)
-  .option("--skip-bootstrap", "Skip the CEO bootstrap step", false)
+  .option("--email <address>", "Founding user email (skips the prompt)")
+  .option("--adapter <type>", "Adapter type to use for the first agent (skips the prompt)")
+  .option("-y, --yes", "Non-interactive — requires --email; defaults adapter to claude_local", false)
   .action(setup);
 
 setupCmd
+  .command("adapter")
+  .description("Pick + verify an agent adapter (re-run after install)")
+  .option("-c, --config <path>", "Path to config file")
+  .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
+  .option("--type <adapter>", "Adapter type (e.g. claude_local, codex_local, hermes_local, cursor)")
+  .option("-y, --yes", "Non-interactive — requires --type", false)
+  .action(setupAdapter);
+
+setupCmd
   .command("server")
-  .description("Configure server reachability (bind mode + Tailscale + allowed hostnames)")
+  .description("Switch server bind mode (loopback / lan / tailnet)")
   .option("-c, --config <path>", "Path to config file")
   .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
   .option("--bind <mode>", "Reachability preset (loopback, lan, tailnet)")
@@ -85,7 +91,7 @@ setupCmd
 
 setupCmd
   .command("bootstrap")
-  .description("Generate the bootstrap CEO invite and open it in the browser")
+  .description("Generate the CEO invite (authenticated mode only) and open in the browser")
   .option("-c, --config <path>", "Path to config file")
   .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
   .option("--force", "Create new invite even if admin already exists", false)
@@ -94,15 +100,6 @@ setupCmd
   .option("--no-open", "Don't auto-open the invite URL in the browser")
   .option("-y, --yes", "Non-interactive", false)
   .action(setupBootstrap);
-
-setupCmd
-  .command("adapter")
-  .description("Pick + install an initial agent adapter")
-  .option("-c, --config <path>", "Path to config file")
-  .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
-  .option("--type <adapter>", "Adapter type (e.g. claude_local, codex_local, cursor)")
-  .option("-y, --yes", "Non-interactive — skip if no --type given", false)
-  .action(setupAdapter);
 
 program
   .command("doctor")

--- a/cli/src/utils/adapter-check.ts
+++ b/cli/src/utils/adapter-check.ts
@@ -1,0 +1,80 @@
+// AgentDash: lightweight adapter-binary probe used by `agentdash setup`.
+// Doesn't import server-side adapter packages; just checks that the
+// underlying CLI binary is reachable on PATH so we can give the user a
+// clear "install this" message before they hire their first agent.
+import { spawnSync } from "node:child_process";
+
+export interface AdapterCheckSpec {
+  type: string;
+  label: string;
+  /** Binary to probe with `<command> <versionArg>`. */
+  command?: string;
+  versionArg?: string;
+  /** Shown when the probe fails. */
+  install?: string;
+  /** When true, the probe always reports "configured later" — used for
+   *  generic transports (process / http / openclaw_gateway) where the
+   *  binary check doesn't apply. */
+  manual?: boolean;
+}
+
+export interface AdapterCheckResult {
+  ok: boolean;
+  /** "configured" — binary detected and runs `--version`.
+   *  "missing"    — binary not on PATH.
+   *  "errored"    — binary on PATH but exits non-zero.
+   *  "manual"     — adapter is configured later (gateway URL, custom command). */
+  status: "configured" | "missing" | "errored" | "manual";
+  detail?: string;
+  fix?: string;
+}
+
+export const ADAPTER_CHECKS: AdapterCheckSpec[] = [
+  { type: "claude_local", label: "Claude Code (local)", command: "claude", versionArg: "--version", install: "npm install -g @anthropic-ai/claude-code" },
+  { type: "codex_local", label: "Codex (local)", command: "codex", versionArg: "--version", install: "npm install -g @openai/codex" },
+  { type: "hermes_local", label: "Hermes Agent (local)", command: "hermes", versionArg: "--version", install: "pip install hermes-agent  (then run `hermes setup`)" },
+  { type: "cursor", label: "Cursor (local)", command: "cursor", versionArg: "--version", install: "Install the Cursor desktop app from https://cursor.sh and ensure `cursor` is on PATH (Cursor → 'Install cursor command' from the Command Palette)" },
+  { type: "gemini_local", label: "Gemini (local)", command: "gemini", versionArg: "--version", install: "Install Gemini CLI per Google's docs and ensure it's on PATH" },
+  { type: "opencode_local", label: "OpenCode (local)", command: "opencode", versionArg: "--version", install: "Install OpenCode from https://opencode.ai" },
+  { type: "pi_local", label: "Pi (local)", command: "pi", versionArg: "--version", install: "Install Pi CLI per its docs and ensure it's on PATH" },
+  { type: "acpx_local", label: "ACPX (local)", command: "acpx", versionArg: "--version", install: "Install the ACPX CLI per its docs" },
+  { type: "openclaw_gateway", label: "OpenClaw (gateway)", manual: true, install: "Configure the gateway URL when you hire your first agent in the dashboard." },
+  { type: "process", label: "Generic process adapter", manual: true, install: "Configure the process command when you hire your first agent." },
+  { type: "http", label: "Generic HTTP adapter", manual: true, install: "Configure the HTTP endpoint when you hire your first agent." },
+];
+
+const PROBE_TIMEOUT_MS = 4000;
+
+export function checkAdapterBinary(spec: AdapterCheckSpec): AdapterCheckResult {
+  if (spec.manual || !spec.command) {
+    return { status: "manual", ok: true, detail: spec.install };
+  }
+  const probe = spawnSync(spec.command, [spec.versionArg ?? "--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: PROBE_TIMEOUT_MS,
+  });
+  if (probe.error && (probe.error as NodeJS.ErrnoException).code === "ENOENT") {
+    return {
+      status: "missing",
+      ok: false,
+      detail: `\`${spec.command}\` not found on PATH`,
+      fix: spec.install,
+    };
+  }
+  if (probe.status !== 0) {
+    const stderr = (probe.stderr ?? "").trim().split("\n")[0] ?? "";
+    return {
+      status: "errored",
+      ok: false,
+      detail: `\`${spec.command} ${spec.versionArg ?? "--version"}\` exited ${probe.status ?? "?"}${stderr ? ` — ${stderr}` : ""}`,
+      fix: spec.install,
+    };
+  }
+  const version = (probe.stdout ?? "").trim().split("\n")[0] ?? "";
+  return { status: "configured", ok: true, detail: version || "ok" };
+}
+
+export function findAdapterCheck(type: string): AdapterCheckSpec | null {
+  return ADAPTER_CHECKS.find((spec) => spec.type === type) ?? null;
+}

--- a/doc/LAUNCH.md
+++ b/doc/LAUNCH.md
@@ -4,7 +4,7 @@ How to take AgentDash from a clean clone to your first paying customer. Read top
 
 The local-trusted dev experience (`pnpm dev` → `localhost:3100/cos`) needs none of this. Everything below is for a real cloud deployment with a real signed-up user paying through Stripe.
 
-> **Cloud container vs bare-metal host.** This doc covers the **cloud container path** — Railway / Fly / Render running the [Dockerfile](../Dockerfile), env vars set through the platform's dashboard. If you're instead running on a bare-metal host you control directly (Mac mini on your LAN, a workstation behind Tailscale, an EC2/Lightsail VM you SSH into), use `agentdash onboard` then `agentdash setup` — the wizard handles bind mode, Tailscale auto-detect, allowed hostnames, the CEO invite, and adapter selection interactively. See the README's *First-run setup on a real host* section. The Stripe + Anthropic env vars (steps 3–4 below) still apply to the bare-metal path; the wizard handles steps 1–2.
+> **Cloud container vs bare-metal host.** This doc covers the **cloud container path** — Railway / Fly / Render running the [Dockerfile](../Dockerfile), env vars set through the platform's dashboard. If you're instead running on a bare-metal host you control directly (Mac mini on your LAN, a workstation behind Tailscale, an EC2/Lightsail VM you SSH into), `agentdash setup` is enough — two prompts (pick adapter + email) and safe defaults for everything else. See the README's *First-run setup on a real host* section. The Stripe + Anthropic env vars (steps 3–4 below) still apply to the bare-metal path if you want billing + real Claude replies; the wizard handles bind mode, allowed hostnames, and the founding-user identity.
 
 ---
 


### PR DESCRIPTION
Following user feedback after [#96](https://github.com/thetangstr/agentdash/pull/96), collapse the first-run experience to the actual minimum a user needs to get going on a fresh host.

## The new `agentdash setup`

Two prompts, period:

1. **Pick an adapter** — wizard runs `<adapter-binary> --version` to verify it's installed, prints the exact install command if not, and lets you keep going.
2. **Your email** — used as `AGENTDASH_BOOTSTRAP_EMAIL` so the workspace name + emailDomain claim derive cleanly on first boot.

Everything else (embedded Postgres, local-disk storage, local-encrypted secrets, loopback bind, `local_trusted` mode, info logging) uses **safe defaults**. If no config exists, the wizard writes one — **no need to run `agentdash onboard` first**.

## Adapter check

[cli/src/utils/adapter-check.ts](cli/src/utils/adapter-check.ts) — probes via `spawnSync(<command>, ['--version'])` with a 4s timeout, returns typed result `{ status, ok, detail, fix }`:

| status | meaning |
|---|---|
| `configured` | binary on PATH and runs cleanly — `✓ Claude Code (local) ready  (1.2.3)` |
| `missing` | binary not on PATH — prints install command (`npm install -g @anthropic-ai/claude-code`) |
| `errored` | binary on PATH but exits non-zero — surfaces stderr first line + install hint |
| `manual` | generic transport (process / http / openclaw_gateway) — no probe, configured later |

## CLI surface

```
agentdash setup                          # the 2-prompt orchestrator
agentdash setup --yes --email you@co.com # non-interactive
agentdash setup --yes --email you@co.com --adapter hermes_local

agentdash setup adapter                  # re-pick + verify (after install)
agentdash setup server                   # switch bind mode (loopback / lan / tailnet)
agentdash setup bootstrap                # re-issue CEO invite (authenticated mode only)
```

## What about `agentdash onboard`?
Stays for power users who need to override database / LLM / storage / secrets prompts. The command's description in `--help` is updated to point most users at `agentdash setup`, and the `onboard` flow itself prints a one-line nudge after the intro banner.

## Docs
- [README.md](README.md) — Quickstart "First-run setup on a real host" section rewritten around the 2-prompt flow
- [doc/LAUNCH.md](doc/LAUNCH.md) — bare-metal callout no longer requires running `onboard` first

## Verification
- `pnpm --filter paperclipai typecheck` — Done, exit 0
- `pnpm -r typecheck` — server, ui, cli, plugins all Done
- `pnpm --filter paperclipai build` — Done
- `agentdash setup --help` smoke-tested via tsx — registers cleanly with `--email` / `--adapter` / `--yes` on the orchestrator and the four section subcommands

## Out of scope (filed separately)
- "Single company per installation" constraint with a dev override — backlog issue filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)