### PR TITLE
feat(cli): make agentdash runnable from any directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Open <http://localhost:3100/cos>. The Chief of Staff is ready, no sign-up. Set `
 
 ### Run it on a real host (Mac mini, Tailscale, cloud VM)
 
+After cloning + `pnpm install`, put `agentdash` on your PATH (one-time):
+
+```sh
+pnpm install-cli
+```
+
+That symlinks `agentdash` and `paperclipai` into `/usr/local/bin` (Intel Mac), `/opt/homebrew/bin` (Apple Silicon), or `~/.local/bin` (Linux fallback) — whichever is writable first. If the chosen dir isn't on your PATH yet, the script tells you the exact `export PATH=…` line to add to your shell rc.
+
+Then from any directory:
+
 ```sh
 agentdash setup
 ```

--- a/bin/agentdash
+++ b/bin/agentdash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# AgentDash CLI wrapper — runs the workspace CLI from anywhere on the host.
+#
+# This file is meant to be symlinked onto your PATH. The user-facing
+# installer that does the symlinking is `scripts/install-cli.sh`
+# (also exposed as `pnpm install-cli`).
+#
+# The wrapper resolves through symlinks so it can live at
+# /usr/local/bin/agentdash or ~/.local/bin/agentdash — the symlink
+# target is what matters; we always exec from the actual repo root
+# so pnpm finds the workspace.
+set -e
+
+# Resolve the real path of this script even when invoked via symlink.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$( cd "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$( readlink "$SOURCE" )"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$( cd "$( dirname "$SOURCE" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# Sanity check — bail with a helpful message if the wrapper got moved
+# outside the repo or the symlink target is stale.
+if [ ! -f "$REPO_ROOT/cli/src/index.ts" ]; then
+  echo "agentdash: wrapper at $SOURCE no longer points at a valid AgentDash repo." >&2
+  echo "agentdash: re-run \`pnpm install-cli\` from a fresh clone to fix the symlink." >&2
+  exit 1
+fi
+
+# Exec via tsx so dev mode works without a build step. tsx is already a
+# dev dep of the cli package, so pnpm install is enough to make this work.
+cd "$REPO_ROOT"
+exec pnpm --silent --filter paperclipai exec tsx src/index.ts "$@"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "preflight:workspace-links": "node cli/node_modules/tsx/dist/cli.mjs scripts/ensure-workspace-package-links.ts",
+    "install-cli": "bash scripts/install-cli.sh",
     "dev": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch",
     "dev:watch": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch",
     "dev:once": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts dev",

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# AgentDash: install the `agentdash` CLI onto the user's PATH.
+#
+# Picks the best writable directory in this order:
+#   1. /usr/local/bin (Intel Mac default, common on Linux)
+#   2. /opt/homebrew/bin (Apple Silicon Mac default with Homebrew)
+#   3. ~/.local/bin (modern XDG default; works without sudo)
+#
+# Creates a symlink at <chosen-dir>/agentdash → bin/agentdash. Also
+# symlinks `paperclipai` so the legacy command name still works.
+#
+# If the chosen directory isn't on PATH, prints the export line the user
+# needs to add to their shell rc.
+set -e
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+WRAPPER="$REPO_ROOT/bin/agentdash"
+
+if [ ! -x "$WRAPPER" ]; then
+  echo "Marking $WRAPPER executable…"
+  chmod +x "$WRAPPER"
+fi
+
+CANDIDATES=(
+  "/usr/local/bin"
+  "/opt/homebrew/bin"
+  "$HOME/.local/bin"
+)
+
+# If a previous install left a symlink that points somewhere else, we'll
+# overwrite it. We never overwrite a regular file.
+choose_target() {
+  for dir in "${CANDIDATES[@]}"; do
+    # Existing dir, writable → use it.
+    if [ -d "$dir" ] && [ -w "$dir" ]; then
+      echo "$dir"
+      return 0
+    fi
+    # Doesn't exist yet but the parent is writable → create it (only for
+    # ~/.local/bin; we don't auto-create system dirs).
+    if [ "$dir" = "$HOME/.local/bin" ] && [ -w "$HOME" ]; then
+      mkdir -p "$dir"
+      echo "$dir"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! TARGET_DIR="$(choose_target)"; then
+  echo "agentdash: couldn't find a writable directory for the CLI symlink." >&2
+  echo "agentdash: tried ${CANDIDATES[*]}" >&2
+  echo "agentdash: try \`sudo bash $0\` or create one of those dirs writable." >&2
+  exit 1
+fi
+
+create_symlink() {
+  local name="$1"
+  local target="$TARGET_DIR/$name"
+
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    if [ ! -L "$target" ]; then
+      echo "agentdash: refusing to overwrite regular file at $target" >&2
+      echo "agentdash: rename or remove it first, then re-run." >&2
+      return 1
+    fi
+    rm -f "$target"
+  fi
+  ln -s "$WRAPPER" "$target"
+  echo "  ✓ $target → $WRAPPER"
+}
+
+echo "Installing AgentDash CLI symlinks into $TARGET_DIR…"
+create_symlink "agentdash"
+create_symlink "paperclipai"
+
+# PATH check — warn the user if the target dir isn't already on PATH.
+case ":$PATH:" in
+  *":$TARGET_DIR:"*)
+    echo ""
+    echo "Done. Try \`agentdash --help\` from any directory."
+    ;;
+  *)
+    echo ""
+    echo "agentdash: $TARGET_DIR isn't on your PATH yet."
+    case "$SHELL" in
+      */zsh)  RC="$HOME/.zshrc"  ;;
+      */bash) RC="$HOME/.bashrc" ;;
+      *)      RC="your shell rc" ;;
+    esac
+    echo "agentdash: add this line to $RC and re-open your terminal:"
+    echo ""
+    echo "    export PATH=\"$TARGET_DIR:\$PATH\""
+    echo ""
+    ;;
+esac


### PR DESCRIPTION
Following user feedback ("can we add a path updater so agentdash can be started from any location"), add a one-command installer that puts `agentdash` and `paperclipai` on the user's PATH.

## UX

After clone:

```sh
pnpm install
pnpm install-cli      # one-time, picks the first writable bin dir
agentdash setup       # then from anywhere
```

## What's new

| File | Role |
|---|---|
| [bin/agentdash](bin/agentdash) | Bash wrapper that resolves through symlinks, cd's to the repo root, and exec's `pnpm --filter paperclipai exec tsx src/index.ts "$@"`. No build step needed; tsx is already a dev dependency. Bails with a clear "wrapper got moved" message if its symlink target is stale. |
| [scripts/install-cli.sh](scripts/install-cli.sh) | Picks the first writable dir from `/usr/local/bin` (Intel Mac), `/opt/homebrew/bin` (Apple Silicon), `~/.local/bin` (Linux fallback). Symlinks `agentdash` **and** `paperclipai` for back-compat. Refuses to overwrite regular files. Detects whether the target is on PATH and prints the exact `export PATH=…` line for the user's shell rc if not. |
| [package.json](package.json) | Adds `pnpm install-cli` npm script. |
| [README.md](README.md) | Quickstart "Run it on a real host" section now leads with `pnpm install-cli` before `agentdash setup`. |

## Why a wrapper, not a global pnpm link

`pnpm link --global` works but pnpm's symlink layout breaks when running the bundled `cli/dist/index.js` directly (we hit `ERR_MODULE_NOT_FOUND: zod` earlier this session). The wrapper sidesteps that by always exec'ing through pnpm's workspace-aware runner — same code path that works in dev — so the CLI sees the right node_modules layout regardless of where the user invoked it from.

## Verification

- Ran on this machine: `pnpm install-cli` symlinked into `/opt/homebrew/bin`
- `cd /tmp && agentdash --version` → `0.3.1` ✓
- `cd /tmp && agentdash setup --help` → renders the 2-prompt wizard help cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)