### PR TITLE
feat(install): one-line bootstrap via curl | bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ Open <http://localhost:3100/cos>. The Chief of Staff is ready, no sign-up. Set `
 
 ### Run it on a real host (Mac mini, Tailscale, cloud VM)
 
-After cloning + `pnpm install`, put `agentdash` on your PATH (one-time):
+One-line install (clone + deps + CLI on PATH):
 
 ```sh
-pnpm install-cli
+curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash
 ```
 
-That symlinks `agentdash` and `paperclipai` into `/usr/local/bin` (Intel Mac), `/opt/homebrew/bin` (Apple Silicon), or `~/.local/bin` (Linux fallback) — whichever is writable first. If the chosen dir isn't on your PATH yet, the script tells you the exact `export PATH=…` line to add to your shell rc.
+Defaults to `~/agentdash`; pass a custom path with `bash -s -- /your/path`. Requires Node 20+, pnpm, and git.
+
+If you already have the repo cloned:
+
+```sh
+pnpm install
+pnpm install-cli      # symlinks `agentdash` into /usr/local/bin, /opt/homebrew/bin, or ~/.local/bin
+```
 
 Then from any directory:
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# AgentDash one-line bootstrap (`curl | bash`).
+#
+# Clones the repo to a target dir, installs deps, links the CLI to your
+# PATH, and chains into `agentdash setup`. Works on any Mac or Linux box
+# with node ≥ 20, pnpm, git.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash -s -- /custom/path
+set -euo pipefail
+
+REPO_URL="${AGENTDASH_REPO_URL:-https://github.com/thetangstr/agentdash.git}"
+TARGET_DIR="${1:-$HOME/agentdash}"
+
+# ---------- prereq checks ----------
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "agentdash bootstrap: \`$cmd\` is required but not found." >&2
+    echo "agentdash bootstrap: $hint" >&2
+    exit 1
+  fi
+}
+
+require_cmd git "Install with your OS package manager (e.g. \`brew install git\`, \`apt install git\`)."
+require_cmd node "Install Node.js 20+ from https://nodejs.org or via nvm/fnm/asdf."
+require_cmd pnpm "Install with \`npm install -g pnpm\` or \`corepack enable && corepack prepare pnpm@latest --activate\`."
+
+# Node ≥ 20 — `node --version` outputs "v20.x.x" or similar.
+NODE_MAJOR="$(node --version | sed -E 's/^v([0-9]+)\..*/\1/')"
+if [ "${NODE_MAJOR:-0}" -lt 20 ]; then
+  echo "agentdash bootstrap: Node 20+ required (you have $(node --version))." >&2
+  exit 1
+fi
+
+# ---------- clone ----------
+
+if [ -e "$TARGET_DIR" ]; then
+  if [ ! -d "$TARGET_DIR/.git" ]; then
+    echo "agentdash bootstrap: $TARGET_DIR exists but isn't a git repo. Pick a different path or remove it." >&2
+    exit 1
+  fi
+  echo "agentdash bootstrap: $TARGET_DIR already cloned — pulling latest…"
+  git -C "$TARGET_DIR" pull --ff-only
+else
+  echo "agentdash bootstrap: cloning into $TARGET_DIR…"
+  git clone "$REPO_URL" "$TARGET_DIR"
+fi
+
+cd "$TARGET_DIR"
+
+# ---------- install ----------
+
+echo "agentdash bootstrap: installing workspace dependencies (pnpm install)…"
+pnpm install --silent
+
+echo "agentdash bootstrap: linking the CLI onto your PATH…"
+pnpm install-cli
+
+# ---------- next steps ----------
+
+cat <<EOF
+
+──────────────────────────────────────────────────
+✓ AgentDash installed at $TARGET_DIR
+
+Next:
+  agentdash setup       # 2 prompts: pick adapter + your email
+
+Then:
+  cd $TARGET_DIR && pnpm dev
+  open http://localhost:3100/cos
+
+If \`agentdash\` isn't found, the install-cli step above already printed
+the \`export PATH=…\` line you need to add to your shell rc.
+
+Docs: $REPO_URL
+──────────────────────────────────────────────────
+EOF


### PR DESCRIPTION
Honest follow-up to the user's "can we do a npx install" ask.

Real `npx agentdash` requires us to publish to npm — we don't have that infrastructure yet (no npm org, no release workflow). What we CAN ship today, no infra required, is the equivalent UX via `curl | bash`.

## Usage

```sh
curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash
```

Custom target dir:
```sh
curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash -s -- /your/path
```

## What it does

| Step | Behavior |
|---|---|
| Pre-flight | Checks for git, node ≥ 20, pnpm. Bails with install hints if any are missing. |
| Clone | Idempotent — if the target dir exists as a git repo, fast-forwards instead of re-cloning. |
| Install | `pnpm install` for workspace deps. |
| Link | `pnpm install-cli` from [#104](https://github.com/thetangstr/agentdash/pull/104) — puts `agentdash` on PATH. |
| Next steps | Prints the `agentdash setup` command to run, and points at the install-cli output for the `export PATH=…` line if needed. |

## README

Quickstart "Run it on a real host" now leads with the one-liner. The pre-cloned `pnpm install && pnpm install-cli` path stays as the secondary option for users who already have the repo.

## Verification

- `bash -n scripts/bootstrap.sh` — syntax clean
- Smoke test against a real fresh machine is next step (can't exercise here without trashing the working tree)

## Future: actual `npx agentdash`

Requires (separate PR / decision):
1. Set up an npm org (claim `agentdash` or similar)
2. Set up a release workflow (GitHub Actions → npm publish on tag)
3. Restructure deps so the published `agentdash` package can clone the repo or vendor the workspace at install time

🤖 Generated with [Claude Code](https://claude.com/claude-code)