### PR TITLE
feat(install): add create-agentdash npm package for `npx create-agentdash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,26 @@ Open <http://localhost:3100/cos>. The Chief of Staff is ready, no sign-up. Set `
 
 ### Run it on a real host (Mac mini, Tailscale, cloud VM)
 
-One-line install (clone + deps + CLI on PATH):
+```sh
+npx create-agentdash
+```
+
+Defaults to `~/agentdash`; pass a custom path with `npx create-agentdash /your/path`. Requires Node 20+, pnpm, and git.
+
+Equivalent shell-only flow if you'd rather not use npx:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash
 ```
 
-Defaults to `~/agentdash`; pass a custom path with `bash -s -- /your/path`. Requires Node 20+, pnpm, and git.
-
-If you already have the repo cloned:
+Or if you've already cloned the repo:
 
 ```sh
 pnpm install
 pnpm install-cli      # symlinks `agentdash` into /usr/local/bin, /opt/homebrew/bin, or ~/.local/bin
 ```
 
-Then from any directory:
+After any of those, from any directory:
 
 ```sh
 agentdash setup

--- a/packages/create-agentdash/README.md
+++ b/packages/create-agentdash/README.md
@@ -1,0 +1,42 @@
+# create-agentdash
+
+Bootstrap [AgentDash](https://github.com/thetangstr/agentdash) on your machine in one command.
+
+```sh
+npx create-agentdash
+```
+
+Defaults to `~/agentdash`. Pass a custom path:
+
+```sh
+npx create-agentdash /path/to/your/workspace
+```
+
+## What it does
+
+1. Pre-flight checks (Node ≥ 20, git, pnpm)
+2. `git clone` the public AgentDash repo
+3. `pnpm install` (workspace deps)
+4. `pnpm install-cli` (symlinks `agentdash` into `/usr/local/bin`, `/opt/homebrew/bin`, or `~/.local/bin`)
+5. Tells you to run `agentdash setup` — a 2-prompt wizard (pick adapter + your email)
+
+## Prerequisites
+
+- Node 20+ — install via [nodejs.org](https://nodejs.org), nvm, fnm, or asdf
+- pnpm — `npm install -g pnpm` or `corepack enable && corepack prepare pnpm@latest --activate`
+- git — usually already installed; otherwise `brew install git` / `apt install git`
+
+## After it runs
+
+```sh
+agentdash setup       # configure adapter + founding user email
+cd ~/agentdash
+pnpm dev              # start the server
+# open http://localhost:3100/cos
+```
+
+If `agentdash` isn't on your PATH yet, the install step prints the exact `export PATH=…` line you need to add to your shell rc.
+
+## License
+
+MIT — same as AgentDash. See the [main repo](https://github.com/thetangstr/agentdash).

--- a/packages/create-agentdash/bin/cli.mjs
+++ b/packages/create-agentdash/bin/cli.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// create-agentdash — npx-friendly AgentDash bootstrapper.
+//
+// What it does:
+//   1. Pre-flight: git, node ≥ 20, pnpm
+//   2. git clone the public AgentDash repo to a target dir
+//   3. pnpm install (workspace deps)
+//   4. pnpm install-cli (symlinks `agentdash` onto PATH)
+//   5. Tells you to run `agentdash setup`
+//
+// This file ships in the published `create-agentdash` npm package and
+// is invoked by `npx create-agentdash [target-dir]`.
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const REPO_URL = process.env.AGENTDASH_REPO_URL ?? "https://github.com/thetangstr/agentdash.git";
+const DEFAULT_TARGET = resolve(homedir(), "agentdash");
+
+function log(msg) {
+  process.stdout.write(`agentdash: ${msg}\n`);
+}
+function err(msg) {
+  process.stderr.write(`agentdash: ${msg}\n`);
+}
+
+function bail(msg, exitCode = 1) {
+  err(msg);
+  process.exit(exitCode);
+}
+
+function requireCmd(cmd, hint) {
+  const probe = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  if (probe.error || probe.status !== 0) {
+    bail(`\`${cmd}\` is required but not found. ${hint}`);
+  }
+}
+
+function checkNodeVersion() {
+  const major = parseInt(process.versions.node.split(".")[0], 10);
+  if (major < 20) {
+    bail(`Node ${process.version} is too old — AgentDash requires Node 20+.`);
+  }
+}
+
+function runStep(label, cmd, args, opts = {}) {
+  log(label);
+  return new Promise((resolveStep, rejectStep) => {
+    const child = spawn(cmd, args, { stdio: "inherit", ...opts });
+    child.on("error", rejectStep);
+    child.on("exit", (code) => {
+      if (code === 0) resolveStep();
+      else rejectStep(new Error(`${cmd} ${args.join(" ")} exited ${code ?? "?"}`));
+    });
+  });
+}
+
+async function main() {
+  // Argv: [node, cli.mjs, ...userArgs]
+  const userArgs = process.argv.slice(2);
+  const targetArg = userArgs.find((arg) => !arg.startsWith("-"));
+  const targetDir = resolve(targetArg ?? DEFAULT_TARGET);
+
+  checkNodeVersion();
+  requireCmd("git", "Install with your OS package manager (e.g. `brew install git`).");
+  requireCmd("pnpm", "Install with `npm install -g pnpm` or `corepack enable && corepack prepare pnpm@latest --activate`.");
+
+  // 1. Clone
+  if (existsSync(targetDir)) {
+    if (!existsSync(`${targetDir}/.git`)) {
+      bail(`${targetDir} exists but isn't a git repo. Pick a different path or remove it.`);
+    }
+    await runStep(`updating existing checkout at ${targetDir}…`, "git", ["-C", targetDir, "pull", "--ff-only"]);
+  } else {
+    await runStep(`cloning into ${targetDir}…`, "git", ["clone", REPO_URL, targetDir]);
+  }
+
+  // 2. pnpm install
+  await runStep("installing workspace dependencies (pnpm install)…", "pnpm", ["install", "--silent"], { cwd: targetDir });
+
+  // 3. pnpm install-cli — puts `agentdash` on PATH
+  await runStep("linking the CLI onto your PATH…", "pnpm", ["install-cli"], { cwd: targetDir });
+
+  // 4. Done
+  process.stdout.write(`
+──────────────────────────────────────────────────
+✓ AgentDash installed at ${targetDir}
+
+Next:
+  agentdash setup       (2 prompts: pick adapter + your email)
+
+Then:
+  cd ${targetDir} && pnpm dev
+  open http://localhost:3100/cos
+
+If \`agentdash\` isn't on your PATH yet, the install-cli step above
+already printed the \`export PATH=…\` line you need to add to your
+shell rc.
+
+Docs: ${REPO_URL.replace(/\.git$/, "")}
+──────────────────────────────────────────────────
+`);
+}
+
+main().catch((error) => {
+  err(error?.message ?? String(error));
+  process.exit(1);
+});

--- a/packages/create-agentdash/package.json
+++ b/packages/create-agentdash/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "create-agentdash",
+  "version": "0.1.0",
+  "description": "Bootstrap AgentDash on your machine: clone the repo, install deps, link the CLI to PATH, and chain into `agentdash setup`.",
+  "type": "module",
+  "bin": {
+    "create-agentdash": "./bin/cli.mjs"
+  },
+  "files": [
+    "bin/"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "agentdash",
+    "agents",
+    "ai",
+    "cli",
+    "create"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/thetangstr/agentdash",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thetangstr/agentdash.git",
+    "directory": "packages/create-agentdash"
+  },
+  "bugs": {
+    "url": "https://github.com/thetangstr/agentdash/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Now that the repo is public, builds the npx-style installer the user asked for. Both `agentdash` and `create-agentdash` are unclaimed on npm at PR time.

## What's new

`packages/create-agentdash/` — new workspace package, no dependencies, single ESM bin script.

| File | Role |
|---|---|
| [bin/cli.mjs](packages/create-agentdash/bin/cli.mjs) | Pre-flight (Node ≥ 20, git, pnpm), git-clone the public repo, `pnpm install`, `pnpm install-cli`, print next-step instructions. Idempotent — fast-forwards if target exists. |
| [package.json](packages/create-agentdash/package.json) | `name: create-agentdash`, `bin: { create-agentdash: ./bin/cli.mjs }`, `publishConfig.access: public`. |
| [README.md](packages/create-agentdash/README.md) | npm-page-facing usage + prerequisites. |

## UX after we publish to npm

```sh
npx create-agentdash                       # default ~/agentdash
npx create-agentdash /path/to/workspace    # custom
```

Root [README.md](README.md) updated to lead with `npx create-agentdash`. The shell-only `curl | bash` and pre-cloned (`pnpm install && pnpm install-cli`) paths stay as alternates.

## Verification

- `node --check packages/create-agentdash/bin/cli.mjs` — clean
- Smoke-tested `node packages/create-agentdash/bin/cli.mjs /tmp/agentdash-test` — ran past pre-flight, anonymously cloned the public repo, started `pnpm install` before timeout (full run is what npx will do).
- `pnpm install` at the repo root after adding the package — clean, no dep churn (the new package has no dependencies, just a bin entry).

## Publishing (next step, separate from this PR)

```sh
cd packages/create-agentdash
npm login                # one-time
npm publish              # publishes to npmjs.com under the unclaimed name
```

This PR ships the **code only** — actual `npm publish` requires an npm account. The README's `npx create-agentdash` command will start working the moment that publish runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)