### PR TITLE
fix(cli): rebrand the banner to AGENTDASH with paperclip credit line

### DIFF
--- a/cli/src/utils/banner.ts
+++ b/cli/src/utils/banner.ts
@@ -1,22 +1,27 @@
 import pc from "picocolors";
 
-const PAPERCLIP_ART = [
-  "██████╗  █████╗ ██████╗ ███████╗██████╗  ██████╗██╗     ██╗██████╗ ",
-  "██╔══██╗██╔══██╗██╔══██╗██╔════╝██╔══██╗██╔════╝██║     ██║██╔══██╗",
-  "██████╔╝███████║██████╔╝█████╗  ██████╔╝██║     ██║     ██║██████╔╝",
-  "██╔═══╝ ██╔══██║██╔═══╝ ██╔══╝  ██╔══██╗██║     ██║     ██║██╔═══╝ ",
-  "██║     ██║  ██║██║     ███████╗██║  ██║╚██████╗███████╗██║██║     ",
-  "╚═╝     ╚═╝  ╚═╝╚═╝     ╚══════╝╚═╝  ╚═╝ ╚═════╝╚══════╝╚═╝╚═╝     ",
+const AGENTDASH_ART = [
+  " █████╗  ██████╗ ███████╗███╗   ██╗████████╗██████╗  █████╗ ███████╗██╗  ██╗",
+  "██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝██╔══██╗██╔══██╗██╔════╝██║  ██║",
+  "███████║██║  ███╗█████╗  ██╔██╗ ██║   ██║   ██║  ██║███████║███████╗███████║",
+  "██╔══██║██║   ██║██╔══╝  ██║╚██╗██║   ██║   ██║  ██║██╔══██║╚════██║██╔══██║",
+  "██║  ██║╚██████╔╝███████╗██║ ╚████║   ██║   ██████╔╝██║  ██║███████║██║  ██║",
+  "╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝   ╚═════╝ ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝",
 ] as const;
 
-const TAGLINE = "Open-source orchestration for zero-human companies";
+const TAGLINE = "A CoS-led, multi-human AI workspace";
+const ATTRIBUTION = "Built on Paperclip's open-source agent harness · github.com/paperclipai/paperclip";
 
+// Function name kept as-is for back-compat with the many existing callers
+// (db-backup, doctor, worktree, onboard, setup). The branding inside is
+// AgentDash; the credit line names Paperclip explicitly.
 export function printPaperclipCliBanner(): void {
   const lines = [
     "",
-    ...PAPERCLIP_ART.map((line) => pc.cyan(line)),
-    pc.blue("  ───────────────────────────────────────────────────────"),
+    ...AGENTDASH_ART.map((line) => pc.cyan(line)),
+    pc.blue("  ──────────────────────────────────────────────────────────────────────────"),
     pc.bold(pc.white(`  ${TAGLINE}`)),
+    pc.dim(`  ${ATTRIBUTION}`),
     "",
   ];
 


### PR DESCRIPTION
User report from a real install on the Mac mini: `agentdash setup` shows a giant **PAPERCLIP** banner instead of AGENTDASH. Jarring, contradicts everything else AgentDash-branded around it (the prompt header, the wizard text, the help output).

## Change
- [cli/src/utils/banner.ts](cli/src/utils/banner.ts) — replace `PAPERCLIP_ART` → `AGENTDASH_ART` (same block-letter style, slightly wider since AGENTDASH has 9 letters too).
- New tagline: *"A CoS-led, multi-human AI workspace"*.
- New attribution line below: *"Built on Paperclip's open-source agent harness · github.com/paperclipai/paperclip"* — explicit credit so the upstream relationship is visible at every banner print.

Function name `printPaperclipCliBanner` stays as-is — 7 callers across db-backup / doctor / worktree / onboard / setup, and renaming it adds churn without changing user-visible output.

## Verification
`pnpm --filter paperclipai typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)