### PR TITLE
fix(bootstrap): skip the setup chain in non-TTY environments

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -60,12 +60,21 @@ pnpm install --silent
 echo "agentdash bootstrap: linking the CLI onto your PATH…"
 pnpm install-cli
 
-# ---------- chain into setup ----------
+# ---------- chain into setup (interactive only) ----------
 # Call the wrapper by absolute path so we don't depend on the symlink
-# we just created being on PATH in this exact shell session.
+# we just created being on PATH in this exact shell session. Skip
+# automatically in non-TTY environments (CI, Docker without -it,
+# `curl | bash` in scripts) so the bootstrap succeeds cleanly even
+# when no human is at the terminal.
 
-echo ""
-"$TARGET_DIR/bin/agentdash" setup
+if [ -t 0 ] && [ -t 1 ]; then
+  echo ""
+  "$TARGET_DIR/bin/agentdash" setup
+else
+  echo ""
+  echo "agentdash bootstrap: non-interactive shell detected — skipping the setup wizard."
+  echo "agentdash bootstrap: run \`agentdash setup\` from a real terminal to finish."
+fi
 
 # ---------- start hint ----------
 


### PR DESCRIPTION
User asked to verify the install works from a clean Docker box. End-to-end test passed for the install steps (clone + pnpm install + install-cli + CLI binary all clean), but the bootstrap chains into `agentdash setup` which is a clack-based interactive wizard. In non-TTY environments (CI, `docker run` without `-it`, `curl | bash` inside a script) clack hangs waiting for arrow keys.

Detect TTY presence (`[ -t 0 ] && [ -t 1 ]`) at the chain point: if either stdin or stdout isn't a terminal, print a "non-interactive shell detected — run `agentdash setup` from a real terminal to finish" message and exit cleanly. Real-user `curl | bash` in an actual shell still gets the auto-chain.

## Test evidence

Fresh `node:20-bookworm` container, `bash -x` trace:

```
[ env ] node: v20.20.2  pnpm: 10.33.2  git: git version 2.39.5

[ install ]
+ git clone https://github.com/thetangstr/agentdash.git /root/agentdash  ✓
+ pnpm install --silent                                                    ✓
+ pnpm install-cli
  ✓ /usr/local/bin/agentdash → /root/agentdash/bin/agentdash
  ✓ /usr/local/bin/paperclipai → /root/agentdash/bin/agentdash

[ verify ]
+ agentdash --version  →  0.3.1                                            ✓
+ agentdash setup --yes --email founder@example.com --adapter claude_local
  ●  Founding user: founder@example.com
  ◆  Saved founding-user email and adapter preference
  └  Setup complete.                                                       ✓
+ ls ~/.paperclip/instances/default/  →  config.json + .env                ✓
```

The new AGENTDASH banner from [#108](https://github.com/thetangstr/agentdash/pull/108) renders correctly in the trace too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)