### PR TITLE
feat(cli): wire `agentdash run` into `agentdash setup` on first run

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
-import { onboard } from "./onboard.js";
+import { setup } from "./setup.js";
 import { doctor } from "./doctor.js";
 import { loadPaperclipEnvFile } from "../config/env.js";
 import { configExists, resolveConfigPath } from "../config/store.js";
@@ -54,12 +54,12 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   if (!configExists(configPath)) {
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
       p.log.error("No config found and terminal is non-interactive.");
-      p.log.message(`Run ${pc.cyan("paperclipai onboard")} once, then retry ${pc.cyan("paperclipai run")}.`);
+      p.log.message(`Run ${pc.cyan("agentdash setup")} once, then retry ${pc.cyan("agentdash run")}.`);
       process.exit(1);
     }
 
-    p.log.step("No config found. Starting onboarding...");
-    await onboard({ config: configPath, invokedByRun: true, bind: opts.bind });
+    p.log.step("No config found. Starting AgentDash setup...");
+    await setup({ config: configPath });
   }
 
   p.log.step("Running doctor checks...");


### PR DESCRIPTION
Cherry-picked from [#100](https://github.com/thetangstr/agentdash/pull/100) — the genuinely useful change without the user-specific path commits.

## Change

`cli/src/commands/run.ts`:
- Replace `await onboard(...)` with `await setup(...)` in the no-config branch
- Update the non-interactive error hint to use the `agentdash setup` command name

## Why not just merge #100

The other two commits in #100 hardcoded `/Users/maxiaoer/.local/bin/hermes` and `/Users/maxiaoer/agentdash/node_modules/.../codex-acp` — paths that only exist on the author's machine. Plus the branch was forked off pre-many-recent-merges, so merging it directly would delete ~860 lines of session work (the bin wrapper, install-cli, bootstrap.sh, create-agentdash, banner rebrand, etc.).

Closing #100 with this PR as the cherry-pick.

## Verified

`pnpm --filter paperclipai typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)