### PR TITLE
fix(bootstrap): drop set -u to survive leaky parent shells

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,35 +8,23 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash
 #   curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash -s -- /custom/path
-set -euo pipefail
+#
+# Shell-hygiene: we deliberately do NOT use `set -u` (nounset). When a
+# user's parent shell has weird state (rc file leaks, BASH_ENV pointing
+# at sourced files, BASHOPTS exports), `${VAR:-default}` expansions on
+# bash 3.2 can intermittently report "unbound variable" errors that
+# don't match the script's literal text. We use explicit empty-string
+# checks instead — same defensive behavior, no env-leak surprises.
+set -eo pipefail
 
-# Defaults are env-var driven so `curl | bash` works without depending on
-# positional args (which don't pass through a pipe anyway). Users can still
-# override the target dir via env: `AGENTDASH_TARGET_DIR=/foo curl ... | bash`.
-# We also accept a single positional arg ($1) for back-compat with users who
-# downloaded the script and ran it directly: `bash bootstrap.sh /foo`.
+# Defaults: env var first (works through pipes), then positional arg
+# (for users who downloaded and ran the script directly), then $HOME.
 REPO_URL="${AGENTDASH_REPO_URL:-https://github.com/thetangstr/agentdash.git}"
-TARGET_DIR_DEFAULT="$HOME/agentdash"
+TARGET_DIR="${AGENTDASH_TARGET_DIR:-${1:-$HOME/agentdash}}"
 
-# Resolve the target dir without ever touching $1 directly under `set -u`.
-# When this script is curl-piped into bash, $# is 0 and accessing $1 has
-# triggered "unbound variable" errors on certain bash builds even with the
-# `:-` operator. Branch on $# explicitly to sidestep that whole class.
-TARGET_DIR="${AGENTDASH_TARGET_DIR:-}"
+# Fail-fast guard: refuse to cd or clone into an empty path.
 if [ -z "$TARGET_DIR" ]; then
-  if [ "$#" -gt 0 ]; then
-    TARGET_DIR="$1"
-  else
-    TARGET_DIR="$TARGET_DIR_DEFAULT"
-  fi
-fi
-
-# Fail-fast guard. If a pathological shell or transport ever drops the
-# expansion above and leaves TARGET_DIR empty, we'd later try `cd ""` or
-# `git clone "$URL" ""` which produces confusing errors. Catch it here.
-if [ -z "${TARGET_DIR:-}" ]; then
-  echo "agentdash bootstrap: internal error — TARGET_DIR resolved to empty." >&2
-  echo "agentdash bootstrap: report this at https://github.com/thetangstr/agentdash/issues" >&2
+  echo "agentdash bootstrap: TARGET_DIR resolved to empty — pass a path or set AGENTDASH_TARGET_DIR." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Removes `set -u` from `scripts/bootstrap.sh` so the curl|bash one-liner survives users whose interactive shells have rc-file leaks, BASH_ENV exports, or BASHOPTS state that contaminates `${VAR:-default}` expansion on bash 3.2 (macOS).
- Collapses TARGET_DIR resolution back to a single-line default chain — without `-u`, `${1:-default}` is safe again.
- Keeps the explicit empty-string guard so the script still fails fast if TARGET_DIR somehow ends up empty.

This matches what `scripts/install-cli.sh` already does (just `set -e`) and removes the entire class of env-leak failures users hit on the Mac mini.

## Test plan
- [x] `bash -n scripts/bootstrap.sh` — syntax OK
- [ ] `curl -fsSL .../bootstrap.sh | bash` from the Mac mini interactive shell that previously failed with `TARGET_DIR?: unbound variable`
- [x] Clean shell (`env -i ... bash`) still works