### PR TITLE
feat(setup): offer to start the dev server right after setup

### DIFF
--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -20,6 +20,10 @@
 //   setup server     — switch bind mode (loopback / lan / tailnet)
 //   setup bootstrap  — re-issue the CEO invite for authenticated mode
 //   setup adapter    — pick + verify a different adapter
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import {
@@ -243,17 +247,125 @@ export async function setup(opts: SetupAllOpts): Promise<void> {
   ensureAgentJwtSecret(opts.config);
   p.log.success(`Saved founding-user email and adapter preference to ${pc.dim(envPath)}`);
 
-  // Done — print next steps
+  // Surface adapter caveats inside the @clack box so they aren't drowned
+  // out by a 30-line dev-server boot log if the user accepts the start
+  // prompt below.
+  if (!adapter.ok) {
+    p.log.warn(`${adapter.type} isn't installed yet — agents using it will fail until you fix it.`);
+    if (adapter.fix) p.log.message(`${pc.cyan("Fix:")} ${adapter.fix}`);
+  }
+
+  // Offer to start the server right now so the user lands in CoS chat
+  // without needing to remember `pnpm dev`. Skip in --yes mode (CI) and
+  // when stdin/stdout aren't a TTY (curl|bash piped, no way to confirm).
+  // Skip too if we can't find a workspace root — we don't want to spawn
+  // pnpm dev from a published-package install where no workspace exists
+  // on disk.
+  const workspaceRoot = findWorkspaceRoot();
+  const canStartDev = workspaceRoot !== null;
+  const interactive = !opts.yes && process.stdin.isTTY && process.stdout.isTTY;
+
+  if (canStartDev && interactive) {
+    const startNow = await p.confirm({
+      message: "Start setting up the agents now? (this runs `pnpm dev` and opens your Chief of Staff at http://localhost:3100/cos)",
+      initialValue: true,
+    });
+    if (!p.isCancel(startNow) && startNow === true) {
+      p.outro(pc.green("Starting AgentDash — Ctrl-C to stop. Open http://localhost:3100/cos once you see \"VITE ready\"."));
+      await runDevServer(workspaceRoot!);
+      return;
+    }
+  }
+
+  // User declined OR we can't auto-start — print the manual hint.
   p.outro(pc.green("Setup complete."));
   console.log("");
   console.log(pc.bold("Next:"));
-  console.log(`  ${pc.cyan("pnpm dev")}`);
-  console.log(`  Open ${pc.cyan("http://localhost:3100/cos")} — your Chief of Staff is ready.`);
-  if (!adapter.ok) {
-    console.log("");
-    console.log(pc.yellow(`  ⚠  ${adapter.type} isn't installed yet — agents using it will fail until you fix it.`));
-    if (adapter.fix) console.log(`    ${pc.cyan("Fix:")} ${adapter.fix}`);
+  if (canStartDev) {
+    console.log(`  ${pc.cyan(`cd ${workspaceRoot}`)} && ${pc.cyan("pnpm dev")}`);
+  } else {
+    console.log(`  ${pc.cyan("pnpm dev")} ${pc.dim("(from your AgentDash workspace)")}`);
   }
+  console.log(`  Open ${pc.cyan("http://localhost:3100/cos")} — your Chief of Staff is ready.`);
+}
+
+// ---------- helpers for the optional "start now" prompt ----------
+
+/**
+ * Locate the AgentDash *workspace root* — the monorepo top-level that has
+ * `pnpm-workspace.yaml` next to a `dev` script. We deliberately do NOT
+ * accept any directory with a "dev" script: `cli/package.json` has its
+ * own `dev` (which just runs the CLI itself), and pointing the user
+ * there would loop instead of starting the server.
+ *
+ * Search order:
+ *   1. walk up from cwd (the bin/agentdash wrapper cd's to repo root,
+ *      but `pnpm exec tsx` from inside cli/ leaves cwd at cli/)
+ *   2. walk up from this file's location (handles dev mode where
+ *      setup.ts lives at <repo>/cli/src/commands/setup.ts)
+ *
+ * Returns null when neither path is a workspace root. We then fall back
+ * to a manual hint instead of risking a misleading auto-start.
+ */
+function findWorkspaceRoot(): string | null {
+  const isWorkspaceRoot = (dir: string): boolean => {
+    if (!fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return false;
+    const pkgPath = path.join(dir, "package.json");
+    if (!fs.existsSync(pkgPath)) return false;
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { scripts?: Record<string, string> };
+      return typeof pkg.scripts?.dev === "string";
+    } catch {
+      return false;
+    }
+  };
+
+  // Walk up from `start` looking for the first workspace root. Stops at
+  // the filesystem root. Returns null if none found.
+  const walkUp = (start: string): string | null => {
+    let dir = path.resolve(start);
+    while (true) {
+      if (isWorkspaceRoot(dir)) return dir;
+      const parent = path.dirname(dir);
+      if (parent === dir) return null;
+      dir = parent;
+    }
+  };
+
+  const fromCwd = walkUp(process.cwd());
+  if (fromCwd) return fromCwd;
+
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const fromSource = walkUp(here);
+    if (fromSource) return fromSource;
+  } catch {
+    // import.meta.url not available in some bundle modes — ignore.
+  }
+
+  return null;
+}
+
+/**
+ * Spawn `pnpm dev` and inherit stdio so the user sees the boot log and
+ * can Ctrl-C to stop. Resolves when the child exits — control returns to
+ * setup() and then back to the bootstrap script (which suppresses its own
+ * post-setup banner in the interactive branch — see scripts/bootstrap.sh).
+ */
+async function runDevServer(cwd: string): Promise<void> {
+  return new Promise((resolve) => {
+    const child = spawn("pnpm", ["dev"], {
+      cwd,
+      stdio: "inherit",
+      shell: false,
+    });
+    child.on("error", (err) => {
+      p.log.error(`Failed to start the dev server: ${err.message}`);
+      console.log(`  Try running ${pc.cyan("pnpm dev")} manually from ${pc.dim(cwd)}.`);
+      resolve();
+    });
+    child.on("close", () => resolve());
+  });
 }
 
 // ---------- subcommands (escape hatches for re-running a step) ----------

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -84,25 +84,34 @@ pnpm install-cli
 
 if [ -t 0 ] && [ -t 1 ]; then
   echo ""
+  # The setup wizard owns its own next-steps UX (it asks the user whether
+  # to start `pnpm dev` immediately, prints adapter caveats, and shows the
+  # http://localhost:3100/cos URL). We deliberately do NOT print another
+  # banner after it returns — that would either duplicate the wizard's
+  # next-steps copy or appear right after the user Ctrl-C'd the dev
+  # server, which feels like noise.
   "$TARGET_DIR/bin/agentdash" setup
 else
   echo ""
   echo "agentdash bootstrap: non-interactive shell detected — skipping the setup wizard."
   echo "agentdash bootstrap: run \`agentdash setup\` from a real terminal to finish."
-fi
 
-# ---------- start hint ----------
-
-cat <<EOF
+  # Non-interactive ship hint. Only printed in CI / curl|bash-without-tty
+  # paths; the interactive branch above lets `agentdash setup` do this.
+  cat <<EOF
 
 ──────────────────────────────────────────────────
-✓ AgentDash installed and configured at $TARGET_DIR
+✓ AgentDash installed at $TARGET_DIR
 
-Start the server:
-  cd $TARGET_DIR && pnpm dev
+Finish setup:
+  cd $TARGET_DIR && agentdash setup
 
-Then open http://localhost:3100/cos.
+Then start the server:
+  pnpm dev
+
+…and open http://localhost:3100/cos.
 
 Docs: $REPO_URL
 ──────────────────────────────────────────────────
 EOF
+fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,35 +8,23 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash
 #   curl -fsSL https://raw.githubusercontent.com/thetangstr/agentdash/main/scripts/bootstrap.sh | bash -s -- /custom/path
-set -euo pipefail
+#
+# Shell-hygiene: we deliberately do NOT use `set -u` (nounset). When a
+# user's parent shell has weird state (rc file leaks, BASH_ENV pointing
+# at sourced files, BASHOPTS exports), `${VAR:-default}` expansions on
+# bash 3.2 can intermittently report "unbound variable" errors that
+# don't match the script's literal text. We use explicit empty-string
+# checks instead — same defensive behavior, no env-leak surprises.
+set -eo pipefail
 
-# Defaults are env-var driven so `curl | bash` works without depending on
-# positional args (which don't pass through a pipe anyway). Users can still
-# override the target dir via env: `AGENTDASH_TARGET_DIR=/foo curl ... | bash`.
-# We also accept a single positional arg ($1) for back-compat with users who
-# downloaded the script and ran it directly: `bash bootstrap.sh /foo`.
+# Defaults: env var first (works through pipes), then positional arg
+# (for users who downloaded and ran the script directly), then $HOME.
 REPO_URL="${AGENTDASH_REPO_URL:-https://github.com/thetangstr/agentdash.git}"
-TARGET_DIR_DEFAULT="$HOME/agentdash"
+TARGET_DIR="${AGENTDASH_TARGET_DIR:-${1:-$HOME/agentdash}}"
 
-# Resolve the target dir without ever touching $1 directly under `set -u`.
-# When this script is curl-piped into bash, $# is 0 and accessing $1 has
-# triggered "unbound variable" errors on certain bash builds even with the
-# `:-` operator. Branch on $# explicitly to sidestep that whole class.
-TARGET_DIR="${AGENTDASH_TARGET_DIR:-}"
+# Fail-fast guard: refuse to cd or clone into an empty path.
 if [ -z "$TARGET_DIR" ]; then
-  if [ "$#" -gt 0 ]; then
-    TARGET_DIR="$1"
-  else
-    TARGET_DIR="$TARGET_DIR_DEFAULT"
-  fi
-fi
-
-# Fail-fast guard. If a pathological shell or transport ever drops the
-# expansion above and leaves TARGET_DIR empty, we'd later try `cd ""` or
-# `git clone "$URL" ""` which produces confusing errors. Catch it here.
-if [ -z "${TARGET_DIR:-}" ]; then
-  echo "agentdash bootstrap: internal error — TARGET_DIR resolved to empty." >&2
-  echo "agentdash bootstrap: report this at https://github.com/thetangstr/agentdash/issues" >&2
+  echo "agentdash bootstrap: TARGET_DIR resolved to empty — pass a path or set AGENTDASH_TARGET_DIR." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Adds a final confirm prompt to `agentdash setup`: **"Start setting up the agents now? (this runs \`pnpm dev\` and opens your Chief of Staff at http://localhost:3100/cos)"**.
- Default = yes (Enter accepts). Picking "No" falls back to the existing manual hint.
- Spawns `pnpm dev` from the workspace root with inherited stdio so the user sees the boot log and lands in CoS chat without ever typing `pnpm dev` themselves.
- Skips automatically in `--yes` mode and when stdin/stdout aren't a TTY (curl|bash piped into a script, CI).
- Workspace-root detection requires `pnpm-workspace.yaml` + a `dev` script, so we don't loop on `cli/package.json` (which has its own `dev` that runs the CLI).
- `bootstrap.sh`'s trailing "Start the server" banner moves to the non-interactive branch only, so the interactive curl|bash flow doesn't print a duplicate hint after the wizard's next-steps copy.

This closes the last "what do I do now?" gap in the first-run UX. The user is dropped from `agentdash setup` straight into a running server.

## Stacked on
This PR is stacked on #112 (the bootstrap shell-hygiene fix). Merging #112 first will rebase this cleanly.

## Test plan
- [x] `pnpm -r typecheck` — green
- [x] `pnpm build` — green
- [x] `pnpm --filter paperclipai exec tsx src/index.ts setup --yes --email ... --adapter claude_local --config /tmp/x.json` — skips the new prompt and prints "cd <workspace-root> && pnpm dev"
- [ ] Interactive run on the Mac mini: pressing Enter at the new prompt boots the dev server; pressing N prints the manual hint