### PR TITLE
feat(setup,server): friendlier email explainer + tailnet fallback

### DIFF
--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -201,8 +201,21 @@ async function getFounderEmail(opts: { yes?: boolean; email?: string }): Promise
     p.log.error("Refusing to run --yes without --email — the founding user's email is required.");
     return null;
   }
+  // Explain BEFORE asking — users (rightly) get suspicious when an installer
+  // wants their email and the prompt doesn't say what it'll be used for.
+  // No email is ever sent: there's no nodemailer/resend/smtp dependency in
+  // the codebase. The address only exists locally for naming + first-user
+  // identity. Verified via grep on this branch (2026-05-03).
+  p.note(
+    [
+      `${pc.bold("Names your workspace")} — we use the part after the @ (so ${pc.cyan("you@acme.com")} → "Acme").`,
+      `${pc.bold("You're the first member")}, with full access.`,
+      `${pc.bold("Saved on this computer only.")} ${pc.bold(pc.green("No email is ever sent."))}`,
+    ].join("\n"),
+    "About this email",
+  );
   const value = await p.text({
-    message: "Your email (used as the founding user / company owner):",
+    message: "Your email:",
     placeholder: "you@yourdomain.com",
     validate: (v) => (EMAIL_RE.test(v.trim()) ? undefined : "Please enter a valid email."),
   });

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -275,12 +275,32 @@ export function loadConfig(): Config {
   if (bindValidationErrors.length > 0) {
     throw new Error(bindValidationErrors[0]);
   }
-  const resolvedBind = resolveRuntimeBind({
+  let resolvedBind = resolveRuntimeBind({
     bind,
     host: configuredHost,
     customBindHost,
     tailnetBindHost,
   });
+  // Graceful degrade: a previous `agentdash setup` run may have saved
+  // server.bind=tailnet while Tailscale was up, but Tailscale isn't
+  // running right now (laptop sleep, daemon stopped, MagicDNS off, …).
+  // Hard-failing the boot leaves the user staring at a stack trace with
+  // no obvious recovery. Drop back to loopback so the dashboard still
+  // works on http://localhost:3100, and warn loudly so the user knows
+  // to re-run `agentdash setup server` if they wanted tailnet exposure.
+  // Other resolveRuntimeBind errors (e.g. custom bind without a host)
+  // are still real misconfigurations — we re-throw those below.
+  if (resolvedBind.errors.length > 0 && bind === "tailnet" && !tailnetBindHost) {
+    console.warn(
+      "[paperclip] server.bind=tailnet but Tailscale isn't running on this machine — falling back to loopback (http://localhost:3100). Re-run `agentdash setup server` to pick a different bind once Tailscale is back up.",
+    );
+    resolvedBind = resolveRuntimeBind({
+      bind: "loopback",
+      host: configuredHost,
+      customBindHost,
+      tailnetBindHost,
+    });
+  }
   if (resolvedBind.errors.length > 0) {
     throw new Error(resolvedBind.errors[0]);
   }


### PR DESCRIPTION
## Summary
Two install-flow fixes the user hit on the Mac mini, bundled.

### 1. Friendlier email explainer
Adds a `p.note` block before the email question so non-tech users see what the address is for:

> **About this email**
> Names your workspace — we use the part after the @ (so `you@acme.com` → "Acme").
> You're the first member, with full access.
> Saved on this computer only. **No email is ever sent.**

Plain language, no "founding user / owner role" jargon. Confirmed by `grep -rn "nodemailer\|resend\|smtp"` — there's no email-sending code anywhere in the repo.

### 2. Tailnet bind graceful-fallback
User report: fresh `agentdash setup` on a Mac mini wrote `server.bind=tailnet` (Tailscale was reachable at config-write time), then `pnpm dev` later crashed with:

```
Error: server.bind=tailnet requires a detected Tailscale address or PAPERCLIP_TAILNET_BIND_HOST
    at loadConfig (server/src/config.ts:285:11)
```

Now: when `bind=tailnet` but Tailscale isn't currently running, fall back to loopback with a `console.warn`, so the dashboard works on http://localhost:3100 and the user knows to re-run `agentdash setup server` once Tailscale is back. Other `resolveRuntimeBind` errors (custom bind without host, etc.) are still real misconfigurations and still throw.

## Test plan
- [x] `pnpm --filter paperclipai --filter @paperclipai/server typecheck` — green
- [x] `agentdash setup --yes` smoke — succeeds
- [x] Manual: with `bind=tailnet` + no Tailscale, server now boots on loopback with warning instead of crashing
- [ ] User: re-run on the Mac mini, confirm the email explainer shows + `pnpm dev` boots cleanly