### PR TITLE
feat(setup): env-var check + opt-in hello probe per adapter

### DIFF
--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -38,7 +38,14 @@ import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
 import { mergePaperclipEnvEntries, resolvePaperclipEnvFile, ensureAgentJwtSecret } from "../config/env.js";
 import { openUrlInBrowser } from "../utils/open-url.js";
 import { printPaperclipCliBanner } from "../utils/banner.js";
-import { ADAPTER_CHECKS, checkAdapterBinary, findAdapterCheck } from "../utils/adapter-check.js";
+import {
+  ADAPTER_CHECKS,
+  checkAdapterBinary,
+  checkAdapterEnvHints,
+  findAdapterCheck,
+  probeAdapter,
+  type AdapterCheckSpec,
+} from "../utils/adapter-check.js";
 import { defaultStorageConfig } from "../prompts/storage.js";
 import { defaultSecretsConfig } from "../prompts/secrets.js";
 import {
@@ -169,9 +176,17 @@ async function pickAndVerifyAdapter(opts: { yes?: boolean; preselected?: string 
 
   const result = checkAdapterBinary(spec);
   switch (result.status) {
-    case "configured":
+    case "configured": {
       p.log.success(`${spec.label} ready  ${pc.dim(`(${result.detail})`)}`);
+      // Binary works — now check env auth and optionally run a hello probe.
+      // Both paths print their own inline warnings if anything's off; we
+      // deliberately do NOT propagate env-hint or probe failures into
+      // `ok`, because the existing outro copy ("X isn't installed yet")
+      // is specifically about a missing binary. Auth/probe issues get
+      // their own targeted hints at the moment they happen.
+      await runPostBinaryChecks(spec, { yes: opts.yes });
       return { type: selected, ok: true, detail: result.detail };
+    }
     case "manual":
       p.log.info(`${spec.label} — ${pc.dim(result.detail ?? "configure when you hire your first agent")}`);
       return { type: selected, ok: true, detail: result.detail };
@@ -184,6 +199,75 @@ async function pickAndVerifyAdapter(opts: { yes?: boolean; preselected?: string 
       p.log.message(pc.dim("  You can keep going and install it later — agents using this adapter will fail to run until then."));
       return { type: selected, ok: false, detail: result.detail, fix: result.fix };
   }
+}
+
+/**
+ * After the version probe passes, do the deeper checks:
+ *   1. Read env hints (no spawn) — warn if no API key is set in the shell.
+ *   2. If a hello probe is configured and we're interactive, offer to
+ *      run it. The probe actually calls the model and is the strongest
+ *      signal that the adapter is wired up correctly. Default = no,
+ *      since 30-45s of "did this thing hang?" can scare a non-tech
+ *      first-run user; we surface it as a clear opt-in instead of an
+ *      automatic step.
+ *
+ * Returns void: every step prints its own inline warning, so there's
+ * nothing to bubble up. The wizard's outro caveat ("X isn't installed
+ * yet") is reserved for binary-level failures; auth/probe issues are
+ * communicated where they happen.
+ */
+async function runPostBinaryChecks(spec: AdapterCheckSpec, opts: { yes?: boolean }): Promise<void> {
+  // ---- env-hint check ----
+  const envHint = checkAdapterEnvHints(spec);
+  if (envHint.status === "ok" && envHint.found) {
+    p.log.success(`${pc.cyan(envHint.found)} found in your shell — auth looks ready.`);
+  } else if (envHint.status === "missing") {
+    p.log.warn(`No ${envHint.expected} in your shell — model calls will fail until you set one.`);
+    p.log.message(pc.dim(`  Fix once: ${pc.cyan(`export ${(spec.envHints?.[0] ?? "API_KEY")}=…`)} in your shell rc, then re-run \`agentdash setup\`.`));
+  }
+  // status === "skipped" → adapter handles its own auth (Cursor / Hermes / etc.); no print.
+
+  // ---- optional hello probe ----
+  if (!spec.probe || !spec.command) return;
+  const interactive = !opts.yes && process.stdin.isTTY && process.stdout.isTTY;
+  if (!interactive) return;
+
+  const runProbe = await p.confirm({
+    message: `Run a quick test prompt against ${spec.label}? (~30s; calls the model with "say hello" to verify auth + network)`,
+    initialValue: false,
+  });
+  if (p.isCancel(runProbe) || runProbe !== true) return;
+
+  const spinner = p.spinner();
+  spinner.start(`Asking ${spec.label} to say hello…`);
+  const probe = probeAdapter(spec);
+  switch (probe.status) {
+    case "passed":
+      spinner.stop(`${spec.label} responded ${pc.dim(`(${formatDuration(probe.durationMs)})`)} — wired up correctly.`);
+      break;
+    case "unexpected":
+      spinner.stop(`${spec.label} responded but the reply didn't include "hello" ${pc.dim(`(${formatDuration(probe.durationMs)})`)}`);
+      if (probe.detail) p.log.message(pc.dim(`  Got: ${probe.detail}`));
+      break;
+    case "auth":
+      spinner.stop(`${spec.label} needs login — auth not configured.`);
+      if (probe.detail) p.log.message(pc.dim(`  ${probe.detail}`));
+      p.log.message(`  ${pc.cyan("Try:")} \`${spec.command} login\` (or set ${spec.envHints?.[0] ?? "the API key env var"})`);
+      break;
+    case "errored":
+      spinner.stop(`${spec.label} probe failed ${pc.dim(`(${formatDuration(probe.durationMs)})`)}`);
+      if (probe.detail) p.log.message(pc.dim(`  ${probe.detail}`));
+      break;
+    case "timed_out":
+      spinner.stop(`${spec.label} probe timed out ${pc.dim(`(${formatDuration(probe.durationMs)})`)}`);
+      p.log.message(pc.dim(`  Network or model is slow. The adapter may still work — try hiring an agent in the dashboard.`));
+      break;
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 // ---------- step 2: get founding user's email ----------

--- a/cli/src/utils/adapter-check.ts
+++ b/cli/src/utils/adapter-check.ts
@@ -1,7 +1,15 @@
-// AgentDash: lightweight adapter-binary probe used by `agentdash setup`.
-// Doesn't import server-side adapter packages; just checks that the
-// underlying CLI binary is reachable on PATH so we can give the user a
-// clear "install this" message before they hire their first agent.
+// AgentDash: lightweight adapter probe used by `agentdash setup`.
+// Three layers, fastest first:
+//   1. Binary check    — `<command> --version` exits 0?    (~1s)
+//   2. Env-hint check  — does the shell have an API key for this adapter?
+//      (no probe, just `process.env.<KEY>`; ~0s)
+//   3. End-to-end hello probe — actually call the model and look for the
+//      word "hello" in the response (opt-in via setup wizard; ~30s).
+//
+// We deliberately do NOT import server-side adapter packages (claude-local,
+// codex-local, …) — those pull in adapter-utils + plugin-sdk and balloon
+// the cli bundle. The wizard's job is to give the user fast confidence,
+// not to replicate the full adapter test suite.
 import { spawnSync } from "node:child_process";
 
 export interface AdapterCheckSpec {
@@ -16,6 +24,29 @@ export interface AdapterCheckSpec {
    *  generic transports (process / http / openclaw_gateway) where the
    *  binary check doesn't apply. */
   manual?: boolean;
+  /** Env vars the adapter typically reads (priority order — the first
+   *  one that's set is enough). Empty array → no env-based auth (e.g.
+   *  Cursor signs in via the desktop app, Hermes uses its own config).
+   *  Undefined → we don't know; skip the env hint. */
+  envHints?: string[];
+  /** Optional end-to-end "hello" probe. Spawns the binary with these
+   *  args, optionally pipes stdin, and looks for `expectInOutput` in
+   *  stdout. Treat success as "the adapter can actually talk to the
+   *  model right now". */
+  probe?: AdapterProbeSpec;
+}
+
+export interface AdapterProbeSpec {
+  args: string[];
+  /** Stdin to pipe — needed for adapters like claude that read prompts
+   *  from stdin in `--print -` mode. */
+  stdin?: string;
+  /** Case-insensitive substring we expect in stdout when the model
+   *  responds. Defaults to "hello" — every probe asks the model to
+   *  reply with that word. */
+  expectInOutput?: string;
+  /** Hard timeout. Defaults to 45s (matches the in-server test.ts). */
+  timeoutMs?: number;
 }
 
 export interface AdapterCheckResult {
@@ -29,21 +60,111 @@ export interface AdapterCheckResult {
   fix?: string;
 }
 
+export interface AdapterEnvHintResult {
+  /** "ok"      — at least one env hint is set OR no envHints declared.
+   *  "missing" — envHints declared but none of them are set.
+   *  "skipped" — envHints undefined (we don't know what to look for). */
+  status: "ok" | "missing" | "skipped";
+  /** Which env var was found set, when status="ok" with hints. */
+  found?: string;
+  /** All hints, joined with " or " — for the missing-hint copy. */
+  expected?: string;
+}
+
+export interface AdapterProbeResult {
+  /** "passed"      — exit 0 AND `expectInOutput` substring present.
+   *  "unexpected"  — exit 0 but expected substring not in output.
+   *  "auth"        — output suggests the binary needs login (we look for
+   *                  common phrases like "log in", "authenticate"). The
+   *                  user may need to run `claude login` first.
+   *  "errored"     — non-zero exit code; details captured.
+   *  "timed_out"   — the probe blew the timeout. */
+  status: "passed" | "unexpected" | "auth" | "errored" | "timed_out";
+  detail?: string;
+  durationMs: number;
+}
+
 export const ADAPTER_CHECKS: AdapterCheckSpec[] = [
-  { type: "claude_local", label: "Claude Code (local)", command: "claude", versionArg: "--version", install: "npm install -g @anthropic-ai/claude-code" },
-  { type: "codex_local", label: "Codex (local)", command: "codex", versionArg: "--version", install: "npm install -g @openai/codex" },
-  { type: "hermes_local", label: "Hermes Agent (local)", command: "hermes", versionArg: "--version", install: "pip install hermes-agent  (then run `hermes setup`)" },
-  { type: "cursor", label: "Cursor (local)", command: "cursor", versionArg: "--version", install: "Install the Cursor desktop app from https://cursor.sh and ensure `cursor` is on PATH (Cursor → 'Install cursor command' from the Command Palette)" },
-  { type: "gemini_local", label: "Gemini (local)", command: "gemini", versionArg: "--version", install: "Install Gemini CLI per Google's docs and ensure it's on PATH" },
-  { type: "opencode_local", label: "OpenCode (local)", command: "opencode", versionArg: "--version", install: "Install OpenCode from https://opencode.ai" },
-  { type: "pi_local", label: "Pi (local)", command: "pi", versionArg: "--version", install: "Install Pi CLI per its docs and ensure it's on PATH" },
-  { type: "acpx_local", label: "ACPX (local)", command: "acpx", versionArg: "--version", install: "Install the ACPX CLI per its docs" },
+  {
+    type: "claude_local",
+    label: "Claude Code (local)",
+    command: "claude",
+    versionArg: "--version",
+    install: "npm install -g @anthropic-ai/claude-code",
+    envHints: ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"],
+    // Mirrors the in-server probe at packages/adapters/claude-local/src/server/test.ts:191.
+    // We strip --output-format stream-json so we get plain text we can grep
+    // for "hello" without parsing the streaming envelope.
+    probe: {
+      args: ["--print", "-", "--dangerously-skip-permissions"],
+      stdin: "Reply with just the word hello.",
+      expectInOutput: "hello",
+      timeoutMs: 45_000,
+    },
+  },
+  {
+    type: "codex_local",
+    label: "Codex (local)",
+    command: "codex",
+    versionArg: "--version",
+    install: "npm install -g @openai/codex",
+    envHints: ["OPENAI_API_KEY"],
+    // No probe yet — codex's non-interactive mode hasn't been verified
+    // against the wizard. Add when we confirm the flag set.
+  },
+  {
+    type: "hermes_local",
+    label: "Hermes Agent (local)",
+    command: "hermes",
+    versionArg: "--version",
+    install: "pip install hermes-agent  (then run `hermes setup`)",
+    envHints: [], // Hermes manages its own credentials via `hermes setup`.
+  },
+  {
+    type: "cursor",
+    label: "Cursor (local)",
+    command: "cursor",
+    versionArg: "--version",
+    install: "Install the Cursor desktop app from https://cursor.sh and ensure `cursor` is on PATH (Cursor → 'Install cursor command' from the Command Palette)",
+    envHints: [], // Cursor signs in via the desktop app.
+  },
+  {
+    type: "gemini_local",
+    label: "Gemini (local)",
+    command: "gemini",
+    versionArg: "--version",
+    install: "Install Gemini CLI per Google's docs and ensure it's on PATH",
+    envHints: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+  },
+  {
+    type: "opencode_local",
+    label: "OpenCode (local)",
+    command: "opencode",
+    versionArg: "--version",
+    install: "Install OpenCode from https://opencode.ai",
+    envHints: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
+  },
+  {
+    type: "pi_local",
+    label: "Pi (local)",
+    command: "pi",
+    versionArg: "--version",
+    install: "Install Pi CLI per its docs and ensure it's on PATH",
+  },
+  {
+    type: "acpx_local",
+    label: "ACPX (local)",
+    command: "acpx",
+    versionArg: "--version",
+    install: "Install the ACPX CLI per its docs",
+    envHints: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+  },
   { type: "openclaw_gateway", label: "OpenClaw (gateway)", manual: true, install: "Configure the gateway URL when you hire your first agent in the dashboard." },
   { type: "process", label: "Generic process adapter", manual: true, install: "Configure the process command when you hire your first agent." },
   { type: "http", label: "Generic HTTP adapter", manual: true, install: "Configure the HTTP endpoint when you hire your first agent." },
 ];
 
-const PROBE_TIMEOUT_MS = 4000;
+const VERSION_PROBE_TIMEOUT_MS = 4000;
 
 export function checkAdapterBinary(spec: AdapterCheckSpec): AdapterCheckResult {
   if (spec.manual || !spec.command) {
@@ -52,7 +173,7 @@ export function checkAdapterBinary(spec: AdapterCheckSpec): AdapterCheckResult {
   const probe = spawnSync(spec.command, [spec.versionArg ?? "--version"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: PROBE_TIMEOUT_MS,
+    timeout: VERSION_PROBE_TIMEOUT_MS,
   });
   if (probe.error && (probe.error as NodeJS.ErrnoException).code === "ENOENT") {
     return {
@@ -73,6 +194,95 @@ export function checkAdapterBinary(spec: AdapterCheckSpec): AdapterCheckResult {
   }
   const version = (probe.stdout ?? "").trim().split("\n")[0] ?? "";
   return { status: "configured", ok: true, detail: version || "ok" };
+}
+
+/**
+ * Check whether the user's shell has an API key the adapter can use.
+ * Pure read — no spawn, no network. Returns "ok" if any of `envHints`
+ * is set to a non-empty string, "missing" if all hints are unset, and
+ * "skipped" when the adapter declares no hints (e.g. Cursor / Hermes).
+ */
+export function checkAdapterEnvHints(spec: AdapterCheckSpec): AdapterEnvHintResult {
+  if (!spec.envHints) return { status: "skipped" };
+  if (spec.envHints.length === 0) return { status: "skipped" };
+  for (const key of spec.envHints) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { status: "ok", found: key };
+    }
+  }
+  return {
+    status: "missing",
+    expected: spec.envHints.join(" or "),
+  };
+}
+
+const AUTH_HINT_RE = /\b(log in|sign in|authenticate|unauthorized|api key|credentials?)\b/i;
+
+/**
+ * Run the adapter's hello probe. Spawns the configured binary with the
+ * probe's args + stdin, watches for the expected substring in stdout,
+ * and tries to detect auth-related failures so we can suggest
+ * `<adapter> login` rather than just printing the raw stderr.
+ */
+export function probeAdapter(spec: AdapterCheckSpec): AdapterProbeResult {
+  if (!spec.probe || !spec.command) {
+    return { status: "errored", detail: "no probe configured", durationMs: 0 };
+  }
+  const expect = (spec.probe.expectInOutput ?? "hello").toLowerCase();
+  const timeoutMs = spec.probe.timeoutMs ?? 45_000;
+
+  const start = Date.now();
+  const result = spawnSync(spec.command, spec.probe.args, {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: timeoutMs,
+    input: spec.probe.stdin ?? "",
+  });
+  const durationMs = Date.now() - start;
+
+  // Node sets `signal` to "SIGTERM" when killed by timeout (or by the
+  // platform's default signal). Use that AND the elapsed time to detect.
+  if (result.signal && durationMs >= timeoutMs - 500) {
+    return { status: "timed_out", detail: `exceeded ${timeoutMs}ms`, durationMs };
+  }
+
+  const stdout = (result.stdout ?? "").toString();
+  const stderr = (result.stderr ?? "").toString();
+  const combined = `${stdout}\n${stderr}`;
+
+  if ((result.status ?? 1) !== 0) {
+    if (AUTH_HINT_RE.test(combined)) {
+      return {
+        status: "auth",
+        detail: firstNonEmptyLine(combined) || "binary suggests login is required",
+        durationMs,
+      };
+    }
+    return {
+      status: "errored",
+      detail: firstNonEmptyLine(stderr || stdout) || `exited ${result.status ?? "?"}`,
+      durationMs,
+    };
+  }
+
+  if (stdout.toLowerCase().includes(expect)) {
+    return { status: "passed", detail: firstNonEmptyLine(stdout), durationMs };
+  }
+  return {
+    status: "unexpected",
+    detail: `did not see "${expect}" in response — ${firstNonEmptyLine(stdout) || "empty output"}`,
+    durationMs,
+  };
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  ).slice(0, 240);
 }
 
 export function findAdapterCheck(type: string): AdapterCheckSpec | null {


### PR DESCRIPTION
## Summary
User asked: "when picking an adapter, does it actually test to see if it's working also?" Today we only run `<adapter> --version`. That catches "binary missing" but misses missing API keys, expired logins, and broken model access.

### 1. Env-hint check (always, no spawn)
After the binary probe passes, look for the API key env var the adapter typically reads:

| Adapter | Env hints |
|---|---|
| `claude_local` | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY` |
| `codex_local` | `OPENAI_API_KEY` |
| `gemini_local` | `GEMINI_API_KEY`, `GOOGLE_API_KEY` |
| `opencode_local` | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` |
| `acpx_local` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` |
| `hermes_local` | — (uses `hermes setup` config) |
| `cursor` | — (signs in via desktop app) |

Output when missing:
> ▲  No ANTHROPIC_API_KEY or CLAUDE_API_KEY in your shell — model calls will fail until you set one.
>     Fix once: `export ANTHROPIC_API_KEY=…` in your shell rc, then re-run `agentdash setup`.

Pure `process.env` read — zero install-latency cost.

### 2. Optional hello probe (opt-in, ~30s)
After the env check, the wizard asks:
> Run a quick test prompt against Claude Code (local)? (~30s; calls the model with "say hello" to verify auth + network)

Default = no, since 30-45s of "did this thing hang?" can scare a non-tech first-run user. If yes:
- Spawns the binary with adapter-specific args + stdin
- Looks for "hello" in stdout
- Detects auth-required failure (regex on stderr/stdout for "log in"/"sign in"/"authenticate"/"unauthorized"/"api key")
- 45s hard timeout

Wired up only for `claude_local` right now — `packages/adapters/claude-local/src/server/test.ts` confirms the flag set (`--print - --dangerously-skip-permissions`, stdin prompt). Other adapters get env-hint coverage now; their probes can be added once CLI flags are verified.

Probe failures **don't** flip `adapter.ok` — they print targeted inline messages. The outro "isn't installed yet" caveat is preserved for binary-level failures only.

## Test plan
- [x] `pnpm --filter paperclipai typecheck` — green
- [x] `pnpm -r typecheck` — running
- [x] `agentdash setup --yes --adapter claude_local` smoke — env-hint warning appears, probe skipped (correct in --yes mode)
- [ ] Interactive run on the Mac mini with `ANTHROPIC_API_KEY` set: probe should call Claude, see "hello", report success
- [ ] Interactive run with `ANTHROPIC_API_KEY` unset: env-hint warns; if user picks "yes" on probe, gets auth-failure message