### PR TITLE
feat(auth): port marketing LiveBriefing visual to the auth page

### DIFF
--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -5,7 +5,12 @@ import { authApi } from "../api/auth";
 import { queryKeys } from "../lib/queryKeys";
 import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
-import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
+import { LiveBriefing } from "../marketing/sections/LiveBriefing";
+// LiveBriefing's "Live · Tue 29 Apr" hero card is the same illustration
+// the marketing landing page uses. tokens.css / typography.css are
+// loaded globally from main.tsx; we just need the section's own styles
+// for the brief card itself.
+import "../marketing/sections/LiveBriefing.css";
 import { Sparkles } from "lucide-react";
 
 type AuthMode = "sign_in" | "sign_up";
@@ -182,9 +187,16 @@ export function AuthPage() {
         </div>
       </div>
 
-      {/* Right half — ASCII art animation (hidden on mobile) */}
-      <div className="hidden md:block w-1/2 overflow-hidden">
-        <AsciiArtAnimation />
+      {/* Right half — Live Briefing card from the marketing landing page
+          (one human + four AI agents, with a slow coral row indicator).
+          Wrapped in `mkt-root` so the marketing typography vars
+          (`--mkt-rule`, `--mkt-ink`, `--mkt-font-serif`, etc.) resolve
+          for the LiveBriefing styles. Hidden on mobile to keep the form
+          column readable on small viewports. */}
+      <div className="hidden md:flex w-1/2 items-center justify-center overflow-hidden bg-surface-page px-12">
+        <div className="mkt-root w-full max-w-xl">
+          <LiveBriefing />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
User asked: replace the auth-page ASCII animation with the visual from our landing page. They're staring at "Welcome back" trying to sign up and the right-column ASCII swirl wasn't selling the product.

Drops `AsciiArtAnimation` from `Auth.tsx` and wires `LiveBriefing` from `ui/src/marketing/sections` — the same hero card the landing page uses ("Live · Tue 29 Apr", one human CEO + four AI agents, a slow coral row indicator that cycles every 7s).

### Implementation notes
- LiveBriefing's CSS uses marketing CSS variables (`--mkt-rule`, `--mkt-ink`, serif/mono font stacks) scoped under `.mkt-root` in `ui/src/marketing/typography.css`. Wrapping the panel in `<div className="mkt-root">` makes those variables resolve.
- `tokens.css` / `fonts.css` / `typography.css` are already loaded globally from `ui/src/main.tsx` — only the section's own `LiveBriefing.css` needs importing.
- The right column is now centered with flex + `max-w-xl` so the briefing card breathes regardless of viewport width. Still hidden on mobile.
- `AsciiArtAnimation` stays in the codebase — the storybook stories at `ui/storybook/stories/data-viz-misc.stories.tsx` still reference it.

## Test plan
- [x] `pnpm --filter @paperclipai/ui typecheck` — green
- [ ] User: refresh `/?mode=sign_up` on the Mac mini, confirm the right column shows the same "Live · Tue 29 Apr" briefing card as `agentdash.com`