### PR TITLE
feat(auth): Resend-backed email + password reset flow

### DIFF
--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -12,6 +12,8 @@ import {
 } from "@paperclipai/db";
 import type { Config } from "../config.js";
 import { resolvePaperclipInstanceId } from "../home-paths.js";
+import { sendEmail, resetPasswordEmailTemplate, welcomeEmailTemplate } from "./email.js";
+import { logger } from "../middleware/logger.js";
 
 export type BetterAuthSessionUser = {
   id: string;
@@ -119,6 +121,44 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
       enabled: true,
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
+      // Better Auth fires this when the user requests a password reset
+      // via /api/auth/forget-password. The `url` it builds points at
+      // /api/auth/reset-password?token=… on the auth server itself.
+      // We rewrite it to /reset-password?token=… so the SPA's reset
+      // page handles the token; that page POSTs back to /api/auth.
+      sendResetPassword: async ({ user, url }: { user: { email: string }; url: string }) => {
+        const appUrl = derivePublicAppUrl(publicUrl);
+        const resetUrl = appUrl
+          ? `${appUrl}/reset-password?${extractQuery(url)}`
+          : url; // fallback: use whatever Better Auth built
+        const { subject, html, text } = resetPasswordEmailTemplate({ resetUrl });
+        await sendEmail({ to: user.email, subject, html, text });
+      },
+    },
+    // Welcome email after a fresh sign-up. We hook the user create
+    // event so we don't need a separate verification flow — the user
+    // is already authenticated when this fires, and the email is just
+    // a nice-to-have.
+    databaseHooks: {
+      user: {
+        create: {
+          after: async (user: { email: string; name: string | null }) => {
+            try {
+              const appUrl = derivePublicAppUrl(publicUrl) ?? "http://localhost:3100";
+              const { subject, html, text } = welcomeEmailTemplate({
+                name: user.name,
+                appUrl,
+              });
+              await sendEmail({ to: user.email, subject, html, text });
+            } catch (err) {
+              logger.warn(
+                { error: err instanceof Error ? err.message : String(err) },
+                "[email] welcome email hook failed",
+              );
+            }
+          },
+        },
+      },
     },
     advanced: buildBetterAuthAdvancedOptions({ disableSecureCookies: isHttpOnly }),
   };
@@ -128,6 +168,30 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
   }
 
   return betterAuth(authConfig);
+}
+
+/**
+ * Better Auth's `baseURL` points at the auth API root (typically the
+ * same origin the SPA serves from). We send users to the SPA's reset
+ * page, not the auth API, so the React route can POST back to
+ * /api/auth/reset-password with the token. Strip any /api suffix and
+ * fall back to localhost when no public URL is configured.
+ */
+function derivePublicAppUrl(publicUrl: string | undefined): string | null {
+  if (!publicUrl) return null;
+  const trimmed = publicUrl.trim().replace(/\/+$/, "");
+  return trimmed.replace(/\/api$/, "");
+}
+
+/**
+ * Extract just the query string from a Better Auth-generated URL so we
+ * can re-attach it to the SPA route. Better Auth produces URLs like
+ * `https://host/api/auth/reset-password?token=…`; we want just
+ * `token=…` to hand off to /reset-password on the SPA.
+ */
+function extractQuery(url: string): string {
+  const idx = url.indexOf("?");
+  return idx >= 0 ? url.slice(idx + 1) : "";
 }
 
 export function createBetterAuthHandler(auth: BetterAuthInstance): RequestHandler {

--- a/server/src/auth/email.ts
+++ b/server/src/auth/email.ts
@@ -1,0 +1,193 @@
+// AgentDash: Resend-backed transactional email for Better Auth.
+//
+// Why a fetch-based wrapper instead of the `resend` SDK:
+//   - Resend's REST API is one endpoint (`POST /emails`); the SDK adds
+//     ~200 KB of dep tree we don't need.
+//   - Lets us be defensive: when `RESEND_API_KEY` isn't set we log a
+//     warning and silently no-op instead of crashing on a missing
+//     constructor. That's important in local_trusted dev where users
+//     never have a Resend account.
+//
+// Env vars:
+//   RESEND_API_KEY              — required to actually send. No-op when unset.
+//   AGENTDASH_EMAIL_FROM        — sender address (default: "AgentDash <onboarding@resend.dev>").
+//                                 Use Resend's `onboarding@resend.dev` shared
+//                                 sender for testing without a verified domain;
+//                                 swap to your own domain for production.
+//   AGENTDASH_EMAIL_REPLY_TO    — optional Reply-To address.
+//
+// Failure mode: any error inside sendEmail() is caught and logged. We
+// never let an email failure abort the auth flow — sign-up/reset still
+// succeed, the user just doesn't get the email. Better than 500s.
+
+import { logger } from "../middleware/logger.js";
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+const DEFAULT_FROM = "AgentDash <onboarding@resend.dev>";
+
+export interface SendEmailInput {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface SendEmailResult {
+  status: "sent" | "skipped" | "failed";
+  messageId?: string;
+  error?: string;
+}
+
+/**
+ * Send an email via Resend. Returns a structured result rather than
+ * throwing, so callers can log + continue without an aborted auth flow.
+ *
+ * If RESEND_API_KEY is unset (the local_trusted / dev case), we log
+ * once at info level and return { status: "skipped" }. The reset link
+ * or welcome message can still be inspected in the server logs at the
+ * call site (see better-auth.ts wiring).
+ */
+export async function sendEmail(input: SendEmailInput): Promise<SendEmailResult> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) {
+    logger.info(
+      { to: input.to, subject: input.subject },
+      "[email] RESEND_API_KEY not set — skipping outbound email. Set RESEND_API_KEY to enable.",
+    );
+    return { status: "skipped" };
+  }
+
+  const from = process.env.AGENTDASH_EMAIL_FROM?.trim() || DEFAULT_FROM;
+  const replyTo = process.env.AGENTDASH_EMAIL_REPLY_TO?.trim();
+
+  const body: Record<string, unknown> = {
+    from,
+    to: [input.to],
+    subject: input.subject,
+    html: input.html,
+  };
+  if (input.text) body.text = input.text;
+  if (replyTo) body.reply_to = replyTo;
+
+  try {
+    const res = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      logger.warn(
+        { to: input.to, subject: input.subject, status: res.status, detail: detail.slice(0, 240) },
+        "[email] Resend returned non-2xx — email not sent",
+      );
+      return { status: "failed", error: `HTTP ${res.status}` };
+    }
+
+    const json = (await res.json().catch(() => ({}))) as { id?: string };
+    logger.info({ to: input.to, subject: input.subject, messageId: json.id }, "[email] sent");
+    return { status: "sent", messageId: json.id };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn({ to: input.to, subject: input.subject, error: message }, "[email] send threw — email not sent");
+    return { status: "failed", error: message };
+  }
+}
+
+// ---------- email templates ----------
+
+/**
+ * Welcome email sent right after a new user signs up. Plain HTML — no
+ * external assets, no tracking pixels. Renders fine in dark-mode mail
+ * clients (no hardcoded background colors on the body).
+ */
+export function welcomeEmailTemplate(input: { name: string | null; appUrl: string }): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const greet = input.name?.trim() ? `Hi ${input.name},` : "Hi,";
+  const subject = "Welcome to AgentDash";
+  const text = [
+    greet,
+    "",
+    "AgentDash is set up and your account is ready.",
+    "",
+    `Sign in: ${input.appUrl}`,
+    "",
+    "What's next:",
+    "  • Talk to your Chief of Staff — describe what you want to ship.",
+    "  • Hire your first agent — pick a role, give it instructions.",
+    "  • Invite teammates — they share the same workspace and CoS thread.",
+    "",
+    "— The AgentDash team",
+  ].join("\n");
+
+  const html = `
+    <!doctype html>
+    <html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; max-width: 560px; margin: 24px auto; line-height: 1.6;">
+      <h1 style="font-size: 22px; margin: 0 0 16px;">Welcome to AgentDash</h1>
+      <p>${escapeHtml(greet)}</p>
+      <p>AgentDash is set up and your account is ready.</p>
+      <p><a href="${escapeHtml(input.appUrl)}" style="display: inline-block; padding: 10px 16px; background: #1f1e1d; color: #fff; text-decoration: none; border-radius: 6px;">Open AgentDash</a></p>
+      <h3 style="font-size: 15px; margin: 24px 0 8px;">What's next</h3>
+      <ul style="padding-left: 20px;">
+        <li>Talk to your Chief of Staff — describe what you want to ship.</li>
+        <li>Hire your first agent — pick a role, give it instructions.</li>
+        <li>Invite teammates — they share the same workspace and CoS thread.</li>
+      </ul>
+      <p style="margin-top: 32px; color: #666; font-size: 13px;">— The AgentDash team</p>
+    </body></html>
+  `.trim();
+
+  return { subject, html, text };
+}
+
+/**
+ * Password-reset email. Resend's anti-phishing recommendation: include
+ * the URL once in the link AND once as plain text so the user can copy
+ * if their mail client mangles the link.
+ */
+export function resetPasswordEmailTemplate(input: { resetUrl: string }): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const subject = "Reset your AgentDash password";
+  const text = [
+    "Someone (hopefully you) asked to reset your AgentDash password.",
+    "",
+    `Reset link: ${input.resetUrl}`,
+    "",
+    "If you didn't ask for this, you can ignore this email — your password won't change.",
+    "",
+    "The link expires in 1 hour for security.",
+  ].join("\n");
+
+  const html = `
+    <!doctype html>
+    <html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; max-width: 560px; margin: 24px auto; line-height: 1.6;">
+      <h1 style="font-size: 22px; margin: 0 0 16px;">Reset your password</h1>
+      <p>Someone (hopefully you) asked to reset your AgentDash password.</p>
+      <p><a href="${escapeHtml(input.resetUrl)}" style="display: inline-block; padding: 10px 16px; background: #1f1e1d; color: #fff; text-decoration: none; border-radius: 6px;">Reset password</a></p>
+      <p style="font-size: 13px; color: #666;">Or copy this URL: ${escapeHtml(input.resetUrl)}</p>
+      <p style="font-size: 13px; color: #666;">If you didn't ask for this, you can ignore this email — your password won't change. The link expires in 1 hour.</p>
+    </body></html>
+  `.trim();
+
+  return { subject, html, text };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,6 +49,8 @@ import BillingPage from "./pages/BillingPage";
 import { AssessPage } from "./pages/AssessPage";
 import { AssessHistoryPage } from "./pages/AssessHistoryPage";
 import { AuthPage } from "./pages/Auth";
+import { ForgotPasswordPage } from "./pages/ForgotPassword";
+import { ResetPasswordPage } from "./pages/ResetPassword";
 import { BoardClaimPage } from "./pages/BoardClaim";
 import { CliAuthPage } from "./pages/CliAuth";
 import { InviteLandingPage } from "./pages/InviteLanding";
@@ -276,6 +278,8 @@ export function App() {
     <>
       <Routes>
         <Route path="auth" element={<AuthPage />} />
+        <Route path="forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="reset-password" element={<ResetPasswordPage />} />
         <Route path="board-claim/:token" element={<BoardClaimPage />} />
         <Route path="cli-auth/:id" element={<CliAuthPage />} />
         <Route path="invite/:token" element={<InviteLandingPage />} />

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -131,4 +131,18 @@ export const authApi = {
   signOut: async () => {
     await authPost("/sign-out", {});
   },
+
+  // Better Auth's "forget password" endpoint takes the email and a
+  // redirect URL; the server sends a reset link to that email pointing
+  // at /reset-password?token=… on the SPA.
+  forgetPassword: async (input: { email: string; redirectTo: string }) => {
+    await authPost("/forget-password", input);
+  },
+
+  // The reset page POSTs the new password + token from the query string
+  // back to Better Auth, which validates the token and writes the new
+  // hash. After this resolves the user must sign in again.
+  resetPassword: async (input: { newPassword: string; token: string }) => {
+    await authPost("/reset-password", input);
+  },
 };

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useSearchParams } from "@/lib/router";
+import { useNavigate, useSearchParams, Link } from "@/lib/router";
 import { authApi } from "../api/auth";
 import { queryKeys } from "../lib/queryKeys";
 import { getRememberedInvitePath } from "../lib/invite-memory";
@@ -145,7 +145,17 @@ export function AuthPage() {
               />
             </div>
             <div>
-              <label htmlFor="password" className="text-xs text-text-secondary mb-1 block font-medium">Password</label>
+              <div className="flex items-center justify-between mb-1">
+                <label htmlFor="password" className="text-xs text-text-secondary font-medium">Password</label>
+                {mode === "sign_in" && (
+                  <Link
+                    to="/forgot-password"
+                    className="text-xs text-text-secondary underline underline-offset-2 hover:text-accent-500 transition-colors"
+                  >
+                    Forgot password?
+                  </Link>
+                )}
+              </div>
               <input
                 id="password"
                 name="password"

--- a/ui/src/pages/ForgotPassword.tsx
+++ b/ui/src/pages/ForgotPassword.tsx
@@ -1,0 +1,119 @@
+// AgentDash: forgot-password screen. Hands the email off to Better
+// Auth's /api/auth/forget-password; on success we show "check your
+// email" without revealing whether the address actually exists (we
+// trust Better Auth's response not to leak that). The reset link in
+// the email points at /reset-password?token=… (see ResetPassword.tsx).
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Link } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import { Sparkles } from "lucide-react";
+import { authApi } from "../api/auth";
+import { LiveBriefing } from "../marketing/sections/LiveBriefing";
+import "../marketing/sections/LiveBriefing.css";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      authApi.forgetPassword({
+        email: email.trim(),
+        redirectTo: `${window.location.origin}/reset-password`,
+      }),
+    onSuccess: () => {
+      setError(null);
+      setSubmitted(true);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "Couldn't send the reset email.");
+    },
+  });
+
+  const canSubmit = email.trim().length > 0 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+
+  return (
+    <div className="fixed inset-0 flex bg-surface-page">
+      <div className="w-full md:w-1/2 flex flex-col overflow-y-auto">
+        <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
+          <div className="flex items-center gap-2 mb-8">
+            <Sparkles className="h-4 w-4 text-text-tertiary" />
+            <span className="text-sm font-medium text-text-primary">AgentDash</span>
+          </div>
+
+          <h1 className="text-2xl font-semibold text-text-primary">Reset your password</h1>
+          <p className="mt-2 text-sm text-text-secondary">
+            We'll email you a link to choose a new one.
+          </p>
+
+          {submitted ? (
+            <div className="mt-6 rounded-md border border-border-soft bg-surface-raised p-4 text-sm text-text-primary">
+              <p>
+                If an account exists for <span className="font-medium">{email.trim()}</span>, we just
+                sent a reset link. Check your inbox (and spam folder) — the link expires in 1 hour.
+              </p>
+              <p className="mt-3 text-xs text-text-secondary">
+                No email arriving? In dev mode AgentDash skips outbound mail unless{" "}
+                <code className="font-mono text-[11px]">RESEND_API_KEY</code> is set — the reset
+                link is logged to the server console instead.
+              </p>
+            </div>
+          ) : (
+            <form
+              className="mt-6 space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (mutation.isPending || !canSubmit) return;
+                mutation.mutate();
+              }}
+            >
+              <div>
+                <label htmlFor="email" className="text-xs text-text-secondary mb-1 block font-medium">
+                  Email
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  autoFocus
+                  className="w-full rounded-md border border-border-soft bg-surface-raised px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-accent-500 focus:ring-2 focus:ring-accent-200 transition-[color,box-shadow]"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                />
+              </div>
+              {error && <p className="text-xs text-danger-500">{error}</p>}
+              <Button
+                type="submit"
+                disabled={mutation.isPending}
+                aria-disabled={!canSubmit || mutation.isPending}
+                className={`w-full ${!canSubmit && !mutation.isPending ? "opacity-50" : ""}`}
+              >
+                {mutation.isPending ? "Sending…" : "Send reset link"}
+              </Button>
+            </form>
+          )}
+
+          <div className="mt-5 text-sm text-text-secondary">
+            Remembered it?{" "}
+            <Link
+              to="/auth"
+              className="font-medium text-text-primary underline underline-offset-2 hover:text-accent-500 transition-colors"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden md:flex w-1/2 items-center justify-center overflow-hidden bg-surface-page px-12">
+        <div className="mkt-root w-full max-w-xl">
+          <LiveBriefing />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/ResetPassword.tsx
+++ b/ui/src/pages/ResetPassword.tsx
@@ -1,0 +1,140 @@
+// AgentDash: reset-password screen. The user lands here from the link
+// in the password-reset email. We pull the `?token=` from the URL,
+// take a new password, and POST both to /api/auth/reset-password. On
+// success we bounce them back to the sign-in form.
+
+import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate, useSearchParams, Link } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import { Sparkles } from "lucide-react";
+import { authApi } from "../api/auth";
+import { LiveBriefing } from "../marketing/sections/LiveBriefing";
+import "../marketing/sections/LiveBriefing.css";
+
+export function ResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token") ?? "";
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Bounce immediately if there's no token — otherwise the user would
+  // see a confusing "couldn't reset" after typing.
+  useEffect(() => {
+    if (!token) setError("Missing reset token. Request a new email from the forgot-password page.");
+  }, [token]);
+
+  const mutation = useMutation({
+    mutationFn: () => authApi.resetPassword({ newPassword: password, token }),
+    onSuccess: () => {
+      setError(null);
+      setSuccess(true);
+      // Hold the success banner for a beat, then send them to sign in.
+      window.setTimeout(() => navigate("/auth", { replace: true }), 1800);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "Couldn't reset the password.");
+    },
+  });
+
+  const passwordMismatch = password.length > 0 && confirm.length > 0 && password !== confirm;
+  const tooShort = password.length > 0 && password.length < 8;
+  const canSubmit = !!token && password.length >= 8 && password === confirm;
+
+  return (
+    <div className="fixed inset-0 flex bg-surface-page">
+      <div className="w-full md:w-1/2 flex flex-col overflow-y-auto">
+        <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
+          <div className="flex items-center gap-2 mb-8">
+            <Sparkles className="h-4 w-4 text-text-tertiary" />
+            <span className="text-sm font-medium text-text-primary">AgentDash</span>
+          </div>
+
+          <h1 className="text-2xl font-semibold text-text-primary">Choose a new password</h1>
+          <p className="mt-2 text-sm text-text-secondary">
+            At least 8 characters. You'll sign in again with the new password.
+          </p>
+
+          {success ? (
+            <div className="mt-6 rounded-md border border-border-soft bg-surface-raised p-4 text-sm text-text-primary">
+              Password updated. Sending you to the sign-in page…
+            </div>
+          ) : (
+            <form
+              className="mt-6 space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (mutation.isPending || !canSubmit) return;
+                mutation.mutate();
+              }}
+            >
+              <div>
+                <label htmlFor="password" className="text-xs text-text-secondary mb-1 block font-medium">
+                  New password
+                </label>
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="new-password"
+                  autoFocus
+                  className="w-full rounded-md border border-border-soft bg-surface-raised px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-accent-500 focus:ring-2 focus:ring-accent-200 transition-[color,box-shadow]"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                />
+                {tooShort && (
+                  <p className="mt-1 text-xs text-text-tertiary">At least 8 characters.</p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="confirm" className="text-xs text-text-secondary mb-1 block font-medium">
+                  Confirm new password
+                </label>
+                <input
+                  id="confirm"
+                  name="confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  className="w-full rounded-md border border-border-soft bg-surface-raised px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-accent-500 focus:ring-2 focus:ring-accent-200 transition-[color,box-shadow]"
+                  value={confirm}
+                  onChange={(event) => setConfirm(event.target.value)}
+                />
+                {passwordMismatch && (
+                  <p className="mt-1 text-xs text-danger-500">Passwords don't match.</p>
+                )}
+              </div>
+              {error && <p className="text-xs text-danger-500">{error}</p>}
+              <Button
+                type="submit"
+                disabled={mutation.isPending || !canSubmit}
+                aria-disabled={!canSubmit || mutation.isPending}
+                className={`w-full ${!canSubmit && !mutation.isPending ? "opacity-50" : ""}`}
+              >
+                {mutation.isPending ? "Updating…" : "Update password"}
+              </Button>
+            </form>
+          )}
+
+          <div className="mt-5 text-sm text-text-secondary">
+            <Link
+              to="/auth"
+              className="font-medium text-text-primary underline underline-offset-2 hover:text-accent-500 transition-colors"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden md:flex w-1/2 items-center justify-center overflow-hidden bg-surface-page px-12">
+        <div className="mkt-root w-full max-w-xl">
+          <LiveBriefing />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Wires the simplest viable email + password-reset story so users who sign up via the Better Auth flow (#119) get a welcome email and can recover their account if they forget their password.

### Server side
- **New `server/src/auth/email.ts`** — fetch-based Resend wrapper. Reads `RESEND_API_KEY` + `AGENTDASH_EMAIL_FROM`. Skips silently with an info log when the API key is unset (the local-dev case), so an email failure never aborts an auth flow. Two templates: welcome + reset-password.
- **`server/src/auth/better-auth.ts`**:
  - `emailAndPassword.sendResetPassword` hook — Better Auth's built-in forgetPassword flow fires this with a token URL; we rewrite it to `/reset-password` on the SPA, then fire the templated email
  - `databaseHooks.user.create.after` — sends the welcome email when a fresh sign-up lands; wrapped in try/catch so email failure never aborts the user-create txn
- Skipped the `resend` SDK in favor of fetch — the REST API is one endpoint, saves ~200 KB of dep tree

### UI side
- `ui/src/api/auth.ts` — `forgetPassword` and `resetPassword` helpers
- **`ui/src/pages/ForgotPassword.tsx` (new)** — email form, posts to Better Auth, "check your inbox" success state with a dev-mode hint that the reset link is in the server console when `RESEND_API_KEY` is unset
- **`ui/src/pages/ResetPassword.tsx` (new)** — pulls `?token=` from URL, 8+ char password + confirm, validates, posts to Better Auth, bounces to `/auth`
- `ui/src/pages/Auth.tsx` — "Forgot password?" link to the right of the password label (sign-in mode only)
- `ui/src/App.tsx` — registers `/forgot-password` and `/reset-password` routes

Both new pages reuse the LiveBriefing right-column visual from PR #120 for consistency.

### Env vars
| Var | Purpose | Default |
|---|---|---|
| `RESEND_API_KEY` | required to send | unset → no-op |
| `AGENTDASH_EMAIL_FROM` | sender | `AgentDash <onboarding@resend.dev>` |
| `AGENTDASH_EMAIL_REPLY_TO` | optional reply-to | unset |

For local dev: leave unset. For production: set them and ship.

## Test plan
- [x] `pnpm --filter @paperclipai/ui --filter @paperclipai/server typecheck` — green
- [ ] `pnpm -r typecheck` — running
- [ ] User: visit `/?mode=sign_up`, sign up, see welcome email log line in server console (and an email at the address if `RESEND_API_KEY` is set)
- [ ] User: visit `/forgot-password`, request reset, click the reset link, set a new password, sign in successfully