### PR TITLE
feat(auth): drop corp-email requirement for Free + Pro by default

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -617,9 +617,15 @@ export async function startServer(): Promise<StartedServer> {
     betterAuthHandler,
     resolveSession,
     pluginWorkerManager,
-    // AgentDash (AGE-60): Pro deployments enforce corp-email signup; Free
-    // (local_trusted) does not.
-    requireCorpEmail: config.deploymentMode === "authenticated",
+    // AgentDash: corp-email requirement removed at user request
+    // (2026-05-03) — applies to both Free and Pro tiers, so gmail/yahoo/
+    // outlook etc. can sign up freely. Originally introduced in AGE-60
+    // to gate Pro deployments behind a "work email" check.
+    //
+    // The toggle is preserved as an env-var escape hatch for self-hosters
+    // who want the old behavior back without a code change. Set
+    // AGENTDASH_REQUIRE_CORP_EMAIL=true on the server to re-enforce.
+    requireCorpEmail: process.env.AGENTDASH_REQUIRE_CORP_EMAIL === "true",
   });
   const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
 

--- a/server/src/middleware/corp-email-signup-guard.ts
+++ b/server/src/middleware/corp-email-signup-guard.ts
@@ -1,15 +1,20 @@
-// AgentDash (AGE-104 follow-up): corp-email signup guard.
+// AgentDash: corp-email signup guard.
 //
-// Pro deployments (deploymentMode === "authenticated") reject signups from
-// free-mail providers (gmail, yahoo, outlook, ...). Until now this only
-// fired at company-creation time (AGE-60), which surfaced the error AFTER
-// the user had already created an account — too late to act on the
-// "use your work email" hint. This middleware moves the same rule to the
-// signup endpoint so the friendly inline error renders BEFORE the user
-// commits to an account.
+// **Disabled by default as of 2026-05-03.** Both Free and Pro users may
+// sign up with any email domain. The middleware is still wired so a
+// self-hoster who wants to require work emails can flip
+// `AGENTDASH_REQUIRE_CORP_EMAIL=true` (see server/src/index.ts) to
+// re-enforce without a code change.
 //
-// The Auth.tsx form already maps the `pro_requires_corp_email` code to a
-// dedicated inline message (see ui/src/pages/Auth.tsx).
+// Original rationale (AGE-60 / AGE-104): Pro deployments rejected
+// gmail/yahoo/outlook signups at the company-creation step, which
+// surfaced the error AFTER the user already had an account. This
+// middleware moved the rule to the signup endpoint so the friendly
+// inline error rendered BEFORE the user committed. With the rule now
+// off, both code paths short-circuit on `enabled: false`.
+//
+// Auth.tsx still maps the `pro_requires_corp_email` code to a dedicated
+// inline message in case a self-hoster turns the rule back on.
 
 import type { RequestHandler } from "express";
 import { FREE_MAIL_DOMAINS } from "@paperclipai/shared";


### PR DESCRIPTION
## Summary
User asked: don't require corp email for free users and pro users.

Originally (AGE-60 / AGE-104) Pro deployments rejected gmail / yahoo / outlook / hotmail / icloud sign-ups at both the sign-up endpoint AND additional-workspace creation. In practice this blocked legitimate solo founders signing up with personal email.

This flips the default off for both tiers. The middleware is still wired so a self-hoster who wants the old "require work email" behavior can re-enforce via `AGENTDASH_REQUIRE_CORP_EMAIL=true` env var — no code change needed.

```diff
-    // AGE-60: Pro deployments enforce corp-email signup; Free does not.
-    requireCorpEmail: config.deploymentMode === "authenticated",
+    // Removed at user request (2026-05-03) — applies to both Free and Pro.
+    // Toggle preserved as env var for self-hosters who want it back.
+    requireCorpEmail: process.env.AGENTDASH_REQUIRE_CORP_EMAIL === "true",
```

## Test plan
- [x] `pnpm --filter @paperclipai/server typecheck` — green
- [x] Confirmed pre-existing failures in `signup-pro-free-mail-block.test.ts` are unrelated (same 5 failures on main; they test the `requireCorpEmail: true` rejection path, which is unaffected)
- [ ] User: sign up on the mini with gmail.com — succeeds, lands in CoS chat, welcome email logs / sends

## Deployment note
After merge: the running server on the mini also needs a restart to pick up the new default. I'll handle that in the same SSH session.