### PR TITLE
fix(auth): bootstrap a workspace + CoS for every new sign-up

### DIFF
--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -92,7 +92,24 @@ export function deriveAuthTrustedOrigins(config: Config, opts?: { listenPort?: n
   return Array.from(trustedOrigins);
 }
 
-export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins: string[]): BetterAuthInstance {
+export interface CreateBetterAuthInstanceOptions {
+  /**
+   * Fires after Better Auth has fully written a new user row. Used to
+   * bootstrap a workspace + CoS agent + conversation for them so the
+   * SPA's CloudAccessGate (which checks for ≥1 company membership)
+   * doesn't block them at "No company access". Errors here are caught
+   * by the caller and logged — sign-up still completes, the user just
+   * has to retry workspace bootstrap manually.
+   */
+  onUserCreated?: (user: { id: string; email: string; name: string | null }) => Promise<void>;
+}
+
+export function createBetterAuthInstance(
+  db: Db,
+  config: Config,
+  trustedOrigins: string[],
+  opts?: CreateBetterAuthInstanceOptions,
+): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET;
   if (!secret) {
@@ -146,7 +163,23 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
     databaseHooks: {
       user: {
         create: {
-          after: async (user: { email: string; name: string | null }) => {
+          after: async (user: { id: string; email: string; name: string | null }) => {
+            // Two independent best-effort steps. Either failing must NOT
+            // abort the user-create transaction — the account is already
+            // committed by the time this runs, so all we'd do is leave a
+            // user without a welcome email or without a workspace.
+            // Bootstrap before email so a slow Resend call doesn't delay
+            // the workspace becoming visible to the SPA.
+            try {
+              if (opts?.onUserCreated) {
+                await opts.onUserCreated(user);
+              }
+            } catch (err) {
+              logger.warn(
+                { userId: user.id, error: err instanceof Error ? err.message : String(err) },
+                "[auth] onUserCreated hook failed — user signed up without a workspace",
+              );
+            }
             try {
               const appUrl = derivePublicAppUrl(publicUrl) ?? "http://localhost:3100";
               const { subject, html, text } = welcomeEmailTemplate({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -512,7 +512,39 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Authenticated mode auth origin configuration",
     );
-    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
+    // Lazy-imported so the auth bootstrap doesn't pull in service deps
+    // (and their plugin SDK pinholes) at module load. The callback runs
+    // once per fresh sign-up and provisions a company + CoS agent +
+    // conversation for the new user — without it the SPA's
+    // CloudAccessGate parks them at "No company access" because they
+    // have zero memberships.
+    const onUserCreated = async (user: { id: string; email: string; name: string | null }) => {
+      const services = await import("./services/index.js");
+      const { authUsers } = await import("@paperclipai/db");
+      const { eq } = await import("drizzle-orm");
+      const orch = services.onboardingOrchestrator({
+        access: services.accessService(db as any),
+        companies: services.companyService(db as any),
+        agents: services.agentService(db as any),
+        instructions: services.agentInstructionsService(),
+        conversations: services.conversationService(db as any),
+        users: {
+          getById: async (id: string) => {
+            const rows = await (db as any)
+              .select()
+              .from(authUsers)
+              .where(eq(authUsers.id, id));
+            return rows[0] ?? null;
+          },
+        },
+      });
+      const result = await orch.bootstrap(user.id);
+      logger.info(
+        { userId: user.id, companyId: result.companyId, cosAgentId: result.cosAgentId },
+        "[auth] bootstrapped workspace for new sign-up",
+      );
+    };
+    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins, { onUserCreated });
     betterAuthHandler = createBetterAuthHandler(auth);
     resolveSession = (req) => resolveBetterAuthSession(auth, req);
     resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);


### PR DESCRIPTION
## Summary
User signed up with a fresh email and hit:

> **No company access** — This account is signed in, but it does not have an active company membership or instance-admin access on this Paperclip instance.

**Cause:** In authenticated mode, Better Auth creates the user row but nothing follows up to provision a workspace. The SPA's `CloudAccessGate` checks `companyIds.length` and parks new users at the no-access page. The orchestrator that *does* the bootstrap (`onboardingOrchestrator(deps).bootstrap(userId)`) was reachable only via `POST /api/onboarding/bootstrap`, which the SPA never calls during fresh sign-up.

In `local_trusted` mode there's no issue because the synthetic `local-board` actor triggers the orchestrator on first SPA load. Authenticated mode just lacked the equivalent hook.

## Fix
Wire the orchestrator into Better Auth's `databaseHooks.user.create.after`:

```
Better Auth writes user row → after-hook fires →
  1. orchestrator.bootstrap(userId)
       → creates company + CoS agent + conversation
       → grants `agents:create` + owner membership
  2. welcome email (existing path from #121)
```

### Implementation
- New `CreateBetterAuthInstanceOptions.onUserCreated` callback so the auth module stays decoupled from service wiring
- The actual orchestrator dispatch lives in `server/src/index.ts` where `db` and services are available; lazy-imported so we don't pull plugin SDK into auth scope
- Both steps (bootstrap + welcome email) independently try/caught — either failing logs a warning but never aborts sign-up. The user row is already committed when the hook fires, so a failure just leaves the user without a workspace (recoverable via `POST /api/onboarding/bootstrap`)

## Test plan
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` — green
- [ ] User: sign up fresh → land in `/cos` with a working workspace, no `No company access` page
- [ ] User: confirm `[auth] bootstrapped workspace for new sign-up` log line appears with their `companyId` + `cosAgentId`