### PR TITLE
fix(onboarding): make /api/onboarding/bootstrap welcome message idempotent

### DIFF
--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -46,16 +46,28 @@ export function onboardingV2Routes(db: Db) {
       throw unauthorized("Sign-in required");
     }
     const result = await orch.bootstrap(req.actor.userId);
-    // Seed the first CoS message (post the first fixed question to the conversation).
     const firstMessage = `Welcome to AgentDash. Let's get you set up. ${FIXED_QUESTIONS[0]}`;
-    await conversations.postMessage({
-      conversationId: result.conversationId,
-      authorKind: "agent",
-      authorId: result.cosAgentId,
-      body: firstMessage,
-      cardKind: "interview_question_v1",
-      cardPayload: { question: FIXED_QUESTIONS[0], fixedIndex: 0 },
-    });
+
+    // Idempotency on the welcome question. The SPA's `useEffect` in
+    // CoSConversation.tsx triggers this route on every mount; React's
+    // StrictMode double-mounts in dev (and remounts on react-query
+    // refetches) caused 3 duplicate welcome messages on a single
+    // sign-up. Check whether the welcome card is already present
+    // before re-posting.
+    const recent = await conversations.paginate(result.conversationId, { limit: 5 });
+    const alreadySeeded = recent.some(
+      (m: { cardKind?: string | null }) => m.cardKind === "interview_question_v1",
+    );
+    if (!alreadySeeded) {
+      await conversations.postMessage({
+        conversationId: result.conversationId,
+        authorKind: "agent",
+        authorId: result.cosAgentId,
+        body: firstMessage,
+        cardKind: "interview_question_v1",
+        cardPayload: { question: FIXED_QUESTIONS[0], fixedIndex: 0 },
+      });
+    }
     res.json({ ...result, firstMessage });
   });
 


### PR DESCRIPTION
## Summary
User screenshot: same first question rendered twice in CoS chat.

```
Agent · 5:16:05 PM   STEP 1   What's your business and who's it for?
Agent · 5:16:05 PM   STEP 1   What's your business and who's it for?
```

Server log confirmed **three** `onboarding bootstrap complete` lines fired in the same second for one sign-up. Cause: `CoSConversation.tsx` calls `onboardingApi.bootstrap()` from a `useEffect`, which React StrictMode + react-query refetches re-runs on every mount, and the route handler always posted the welcome card no matter how many times it ran.

## Fix
Before posting, paginate the latest 5 messages and skip if a message with `cardKind: "interview_question_v1"` already exists. The orchestrator step (`orch.bootstrap`) is already idempotent on company + membership creation; this brings the route's message-seeding step into line.

Cheaper than rewriting the SPA's bootstrap call to be a singleton — that change would be more invasive and the server-side guard protects against any future caller that triggers `/bootstrap` (mobile client, CLI, etc.).

## Test plan
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` — green
- [ ] Sign up fresh on mini, hit `/cos`, observe single welcome message instead of duplicates