### PR TITLE
feat(cos-chat): polished onboarding chat — header, bubbles, send icon, real welcome copy

### DIFF
--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -46,7 +46,7 @@ export function onboardingV2Routes(db: Db) {
       throw unauthorized("Sign-in required");
     }
     const result = await orch.bootstrap(req.actor.userId);
-    const firstMessage = `Welcome to AgentDash. Let's get you set up. ${FIXED_QUESTIONS[0]}`;
+    const firstMessage = `Hi, I'm your Chief of Staff. AgentDash lets you hire AI agents and run them like a team — I'll help you set up your first one.\n\nBefore we hire anyone, I need to understand your business so I can suggest the right roles for you.\n\nTell me — ${FIXED_QUESTIONS[0]}`;
 
     // Idempotency on the welcome question. The SPA's `useEffect` in
     // CoSConversation.tsx triggers this route on every mount; React's

--- a/ui/src/components/ChatHeader.tsx
+++ b/ui/src/components/ChatHeader.tsx
@@ -1,0 +1,57 @@
+// AgentDash: CoS chat header — identity, context, status
+import { Sparkles } from "lucide-react";
+
+export interface ChatHeaderProps {
+  agentName?: string;
+  agentRole?: string;
+  stepCurrent?: number;
+  stepTotal?: number;
+}
+
+export function ChatHeader({
+  agentName = "Chief of Staff",
+  agentRole = "Setting up your AgentDash workspace",
+  stepCurrent,
+  stepTotal,
+}: ChatHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft bg-surface-raised shrink-0">
+      {/* Left: avatar + identity */}
+      <div className="flex items-center gap-3">
+        <div className="relative">
+          <div className="w-9 h-9 rounded-full bg-accent-500 flex items-center justify-center shadow-sm">
+            <Sparkles className="w-4 h-4 text-text-inverse" aria-hidden="true" />
+          </div>
+          {/* Online dot */}
+          <span
+            className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-emerald-500 border-2 border-surface-raised"
+            aria-label="Online"
+          />
+        </div>
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold text-text-primary leading-tight">{agentName}</span>
+          <span className="text-xs text-text-tertiary leading-tight mt-0.5">{agentRole}</span>
+        </div>
+      </div>
+
+      {/* Right: step progress */}
+      {typeof stepCurrent === "number" && typeof stepTotal === "number" && (
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            {Array.from({ length: stepTotal }).map((_, i) => (
+              <span
+                key={i}
+                className={`w-5 h-1 rounded-full transition-colors ${
+                  i < stepCurrent ? "bg-accent-500" : "bg-border-soft"
+                }`}
+              />
+            ))}
+          </div>
+          <span className="text-xs text-text-tertiary tabular-nums">
+            {stepCurrent} / {stepTotal}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/Composer.tsx
+++ b/ui/src/components/Composer.tsx
@@ -1,5 +1,6 @@
 // AgentDash: chat substrate message composer with @mention support
 import { useState } from "react";
+import { SendHorizontal } from "lucide-react";
 
 export function Composer({
   onSend,
@@ -18,33 +19,45 @@ export function Composer({
     setShowMentionMenu(false);
   }
 
+  const isEmpty = !value.trim();
+
   return (
-    <div className="composer relative flex gap-2">
-      <textarea
-        className="border border-border-soft rounded-md px-3 py-2 flex-1 bg-surface-raised text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:border-accent-500 focus-visible:ring-2 focus-visible:ring-accent-200 resize-none transition-[color,box-shadow]"
-        rows={2}
-        value={value}
-        onChange={(e) => {
-          setValue(e.target.value);
-          setShowMentionMenu(/@[A-Za-z][A-Za-z0-9_-]*$/.test(e.target.value));
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey) {
-            e.preventDefault();
-            send();
-          }
-        }}
-        placeholder="Type a message…  Tip: @reese to talk to an agent directly"
-      />
+    <div className="composer relative flex items-center gap-2">
+      <div className="relative flex-1">
+        <input
+          type="text"
+          className="w-full border border-border-soft rounded-xl px-4 py-3 bg-surface-raised text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:border-accent-500 focus-visible:ring-2 focus-visible:ring-accent-200 transition-[color,box-shadow] text-sm"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setShowMentionMenu(
+              agentDirectory.length > 0 && /@[A-Za-z][A-Za-z0-9_-]*$/.test(e.target.value),
+            );
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              send();
+            }
+          }}
+          placeholder="Message your Chief of Staff…"
+          aria-label="Message input"
+        />
+      </div>
+
+      {/* Send icon button */}
       <button
-        className="bg-accent-500 text-text-inverse px-4 rounded-md font-medium hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 disabled:opacity-50"
+        className="w-10 h-10 rounded-full bg-accent-500 flex items-center justify-center shrink-0 hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 disabled:opacity-40 disabled:cursor-not-allowed"
         onClick={send}
+        disabled={isEmpty}
         aria-label="Send message"
       >
-        Send
+        <SendHorizontal className="w-4 h-4 text-text-inverse" />
       </button>
+
+      {/* @mention dropdown */}
       {showMentionMenu && agentDirectory.length > 0 && (
-        <div className="mention-menu absolute bottom-full left-0 bg-surface-raised border border-border-soft rounded-lg shadow-md p-1">
+        <div className="mention-menu absolute bottom-full left-0 mb-2 bg-surface-raised border border-border-soft rounded-lg shadow-md p-1 min-w-[180px]">
           {agentDirectory.map((a) => (
             <button
               key={a.id}

--- a/ui/src/components/MessageList.tsx
+++ b/ui/src/components/MessageList.tsx
@@ -1,4 +1,5 @@
-// AgentDash: chat substrate message list
+// AgentDash: chat substrate message list — bubble layout
+import { Sparkles } from "lucide-react";
 import type { Message } from "../api/conversations";
 import { CardRenderer, type CardContext } from "./cards";
 
@@ -10,21 +11,65 @@ export function MessageList({
   cardContext: CardContext;
 }) {
   return (
-    <div className="message-list space-y-4">
+    <div className="message-list flex flex-col gap-5">
       {messages.map((m) => {
         const author = m.role ?? m.authorKind;
+        const isAgent = author === "agent";
         const text = m.content ?? m.body ?? "";
+        const timeStr = new Date(m.createdAt).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
         return (
-          <div key={m.id} className={`msg msg--${author} space-y-1`}>
-            <div className="text-xs text-text-tertiary">
-              {author === "agent" ? "Agent" : "You"} ·{" "}
-              {new Date(m.createdAt).toLocaleTimeString()}
-            </div>
-            {m.cardKind ? (
-              <CardRenderer cardKind={m.cardKind} payload={m.cardPayload} context={cardContext} />
-            ) : (
-              <div className="msg__body whitespace-pre-wrap text-text-primary leading-relaxed">{text}</div>
+          <div
+            key={m.id}
+            className={`flex items-end gap-3 ${isAgent ? "justify-start" : "justify-end"}`}
+          >
+            {/* Agent avatar — left side only */}
+            {isAgent && (
+              <div className="w-8 h-8 rounded-full bg-accent-500 flex items-center justify-center shrink-0 mb-5">
+                <Sparkles className="w-3.5 h-3.5 text-text-inverse" aria-hidden="true" />
+              </div>
             )}
+
+            {/* Bubble + timestamp column */}
+            <div className={`flex flex-col gap-1 max-w-[80%] ${isAgent ? "items-start" : "items-end"}`}>
+              {m.cardKind ? (
+                <>
+                  {m.cardKind === "interview_question_v1" ? (
+                    // Interview questions: pull question text out as bubble body;
+                    // show a small "Step N" chip above the bubble if fixedIndex is set.
+                    <div className="flex flex-col gap-1 items-start w-full">
+                      {typeof (m.cardPayload as any)?.fixedIndex === "number" && (
+                        <span className="text-[10px] font-semibold tracking-widest uppercase text-accent-500 px-1">
+                          Step {(m.cardPayload as any).fixedIndex + 1}
+                        </span>
+                      )}
+                      <div className="bg-surface-raised border border-border-soft text-text-primary px-4 py-3 rounded-2xl rounded-tl-sm leading-relaxed text-sm">
+                        {(m.cardPayload as any)?.question ?? text}
+                      </div>
+                    </div>
+                  ) : (
+                    // All other card kinds — render through CardRenderer as before
+                    <div className="bg-surface-raised border border-border-soft rounded-2xl rounded-tl-sm px-4 py-3 w-full">
+                      <CardRenderer cardKind={m.cardKind} payload={m.cardPayload} context={cardContext} />
+                    </div>
+                  )}
+                </>
+              ) : isAgent ? (
+                <div className="bg-surface-raised border border-border-soft text-text-primary px-4 py-3 rounded-2xl rounded-tl-sm leading-relaxed text-sm whitespace-pre-wrap">
+                  {text}
+                </div>
+              ) : (
+                <div className="bg-accent-500 text-text-inverse px-4 py-3 rounded-2xl rounded-br-sm leading-relaxed text-sm whitespace-pre-wrap">
+                  {text}
+                </div>
+              )}
+
+              {/* Timestamp below bubble */}
+              <span className="text-[11px] text-text-tertiary px-1">{timeStr}</span>
+            </div>
           </div>
         );
       })}

--- a/ui/src/components/cards/InterviewQuestion.tsx
+++ b/ui/src/components/cards/InterviewQuestion.tsx
@@ -1,15 +1,18 @@
 // AgentDash: chat substrate card — onboarding interview question
 import type { InterviewQuestionPayload } from "@paperclipai/shared";
 
+// Note: The step chip and bubble wrapper are rendered by MessageList when
+// cardKind === "interview_question_v1". This component is kept for non-chat
+// contexts that may render cards directly via CardRenderer.
 export function InterviewQuestion({ payload }: { payload: InterviewQuestionPayload }) {
   return (
     <div className="interview-question">
       {typeof payload.fixedIndex === "number" && (
-        <div className="text-xs text-text-tertiary mb-1 font-medium tracking-wide uppercase">
+        <span className="text-[10px] font-semibold tracking-widest uppercase text-accent-500 block mb-1">
           Step {payload.fixedIndex + 1}
-        </div>
+        </span>
       )}
-      <div className="text-text-primary">{payload.question}</div>
+      <div className="text-text-primary text-sm leading-relaxed">{payload.question}</div>
     </div>
   );
 }

--- a/ui/src/pages/ChatPanel.tsx
+++ b/ui/src/pages/ChatPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useMessages } from "../realtime/useMessages";
 import { MessageList } from "../components/MessageList";
 import { Composer } from "../components/Composer";
+import { ChatHeader, type ChatHeaderProps } from "../components/ChatHeader";
 import { conversationsApi } from "../api/conversations";
 import type { CardContext } from "../components/cards";
 
@@ -11,11 +12,13 @@ export default function ChatPanel({
   companyId,
   agentDirectory = [],
   cardContext,
+  headerProps,
 }: {
   conversationId: string;
   companyId: string;
   agentDirectory?: Array<{ id: string; name: string; role: string }>;
   cardContext?: CardContext;
+  headerProps?: ChatHeaderProps;
 }) {
   const messages = useMessages(conversationId);
 
@@ -46,6 +49,7 @@ export default function ChatPanel({
 
   return (
     <div className="chat-panel flex flex-col h-full bg-surface-page">
+      <ChatHeader {...(headerProps ?? {})} />
       <div className="flex-1 overflow-y-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           <MessageList


### PR DESCRIPTION
## Summary

- **ChatHeader** (`ui/src/components/ChatHeader.tsx`, new): Identifies the Chief of Staff agent with name, role tagline, online status dot (green), and optional step progress bar (pill indicators + N/total count). Uses the existing `Sparkles` lucide icon inside an accent-colored avatar circle — consistent with the Auth page.
- **MessageList** (`ui/src/components/MessageList.tsx`): Rebuilt as real chat bubbles. Agent messages left-align with a Sparkles avatar; user messages right-align in accent-500. Timestamps live below each bubble. Interview question cards render with a small "Step N" accent chip above the bubble instead of inline uppercase text. All other card kinds still flow through `CardRenderer` wrapped in a surface-raised bubble shell.
- **Composer** (`ui/src/components/Composer.tsx`): Single-line rounded-xl input replaces the two-row textarea. Send button is a `SendHorizontal` icon in an accent-colored circle (disabled + greyed when empty). Placeholder changed to "Message your Chief of Staff…". `@`-mention menu logic is preserved.
- **ChatPanel** (`ui/src/pages/ChatPanel.tsx`): Mounts `ChatHeader` at the top; accepts optional `headerProps` to let callers pass agent name, role, and step progress.
- **onboarding-v2.ts** (`server/src/routes/onboarding-v2.ts`): First message is now a warm CoS intro — sets context, explains what AgentDash does, then leads into the first interview question naturally.
- **InterviewQuestion** (`ui/src/components/cards/InterviewQuestion.tsx`): Step chip refined (accent color, consistent size) for non-chat card render contexts.

## Test plan

- [ ] Open `http://localhost:3100/cos` — verify ChatHeader shows "Chief of Staff" with green dot
- [ ] Check that the first message is the new CoS intro copy (warm, multi-paragraph)
- [ ] Send a message — verify user bubble appears right-aligned in teal, agent replies left-aligned with avatar
- [ ] Verify send button is disabled (dimmed) when input is empty, active when text is present
- [ ] Confirm "Step 1" chip appears above the first interview question bubble
- [ ] Resize to mobile width — bubbles max at 80%, no overflow
- [ ] `pnpm --filter @paperclipai/ui --filter @paperclipai/server typecheck` — both pass ✓
- [ ] Pre-existing failures: 8 tests in `workspace-runtime.test.ts` fail with ENOENT on `.paperclip/config.json` — unrelated to this change, pre-existing on `main`

## Design choices you may want to tweak

- **Avatar shape**: currently a filled circle (`rounded-full`). Could be a rounded square if you prefer a more "agent card" feel.
- **Bubble corner radius**: `rounded-2xl` with a directional nub (`rounded-tl-sm` for agent, `rounded-br-sm` for user). Let me know if you want fully symmetric corners instead.
- **Step progress bar**: only appears when `stepCurrent`/`stepTotal` are passed from `CoSConversation`. Currently not wired — the header shows with no progress bar until that data is plumbed through. Easy follow-up.
- **Online dot color**: `bg-emerald-500` (Tailwind built-in). Could switch to a design-token green if one is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)