### PR TITLE
fix(cos): wire replier to honor the user's adapter pick (hermes/claude_local/...)

### DIFF
--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -9,7 +9,7 @@ import {
   cosReplier,
   agentSummoner,
 } from "../services/index.js";
-import { anthropicLLM } from "../services/anthropic-llm.js";
+import { dispatchLLM } from "../services/dispatch-llm.js";
 
 export function conversationRoutes(db: Db) {
   const router = Router();
@@ -36,10 +36,10 @@ export function conversationRoutes(db: Db) {
         execute: async () => ({ output: "Stub agent reply" }),
       }),
     }),
-    // anthropicLLM auto-falls back to a stub when ANTHROPIC_API_KEY is unset
-    // (so dev without keys still works); when set, it calls Claude with prompt
-    // caching on the system prompt.
-    replier: cosReplier({ conversations: svc, llm: anthropicLLM } as any),
+    // dispatchLLM routes to whichever adapter the user picked via `agentdash setup`
+    // (AGENTDASH_DEFAULT_ADAPTER). Defaults to claude_api; also supports hermes_local
+    // and claude_local. Falls back to anthropicLLM stub when keys are unset.
+    replier: cosReplier({ conversations: svc, llm: dispatchLLM } as any),
     cosResolver,
   });
 

--- a/server/src/services/dispatch-llm.ts
+++ b/server/src/services/dispatch-llm.ts
@@ -1,0 +1,148 @@
+import { spawn } from "node:child_process";
+import { anthropicLLM } from "./anthropic-llm.js";
+import { logger } from "../middleware/logger.js";
+
+// Default hermes binary path — matches the mini's installation.
+// Overridden by AGENTDASH_HERMES_COMMAND env var if set.
+const DEFAULT_HERMES_COMMAND = "/Users/maxiaoer/.local/bin/hermes";
+
+/** Timeout for local adapter spawns in milliseconds. */
+const ADAPTER_TIMEOUT_MS = 45_000;
+
+interface LLMInput {
+  system: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+}
+
+/**
+ * Run a child process with a timeout, collecting stdout.
+ * Rejects if the process exits non-zero or the timeout fires.
+ */
+function spawnWithTimeout(
+  command: string,
+  args: string[],
+  stdinData?: string,
+  timeoutMs = ADAPTER_TIMEOUT_MS,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGKILL");
+        reject(new Error(`[dispatch-llm] ${command} timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      }
+    });
+
+    child.on("close", (code) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(`[dispatch-llm] ${command} exited ${code}: ${stderr.trim()}`));
+        } else {
+          resolve(stdout.trim());
+        }
+      }
+    });
+
+    if (stdinData !== undefined) {
+      child.stdin.end(stdinData);
+    }
+  });
+}
+
+/**
+ * Build a single-turn prompt string for local adapters that don't accept
+ * structured message arrays. Concatenates the system prompt and the full
+ * conversation history.
+ */
+function buildFlatPrompt(input: LLMInput): string {
+  const parts: string[] = [];
+  if (input.system) {
+    parts.push(`[System]\n${input.system}`);
+  }
+  for (const msg of input.messages) {
+    const role = msg.role === "assistant" ? "Assistant" : "User";
+    parts.push(`[${role}]\n${msg.content}`);
+  }
+  parts.push("[Assistant]");
+  return parts.join("\n\n");
+}
+
+/**
+ * LLM dispatch for CoS replies.
+ *
+ * Reads AGENTDASH_DEFAULT_ADAPTER at call time (not module load) so
+ * env changes after startup are respected.
+ *
+ * Supported adapters:
+ *  - "claude_api" (default): calls Anthropic API via anthropicLLM
+ *  - "hermes_local": spawns `hermes chat -q "<prompt>" -Q`
+ *  - "claude_local": spawns `claude --print -` with prompt on stdin
+ *  - everything else: falls back to claude_api with a TODO log
+ */
+export async function dispatchLLM(input: LLMInput): Promise<string> {
+  const adapter = (process.env.AGENTDASH_DEFAULT_ADAPTER ?? "claude_api").trim();
+
+  if (adapter === "claude_api" || adapter === "") {
+    return anthropicLLM(input);
+  }
+
+  if (adapter === "hermes_local") {
+    const hermesCmd =
+      (process.env.AGENTDASH_HERMES_COMMAND ?? "").trim() || DEFAULT_HERMES_COMMAND;
+    const prompt = buildFlatPrompt(input);
+    logger.info({ adapter, hermesCmd }, "[dispatch-llm] routing CoS reply through hermes_local");
+    try {
+      const reply = await spawnWithTimeout(hermesCmd, ["chat", "-q", prompt, "-Q"]);
+      if (!reply) {
+        logger.warn({ adapter }, "[dispatch-llm] hermes_local returned empty reply, using fallback");
+        return anthropicLLM(input);
+      }
+      return reply;
+    } catch (err) {
+      logger.error({ err, adapter }, "[dispatch-llm] hermes_local failed, falling back to claude_api");
+      return anthropicLLM(input);
+    }
+  }
+
+  if (adapter === "claude_local") {
+    const prompt = buildFlatPrompt(input);
+    logger.info({ adapter }, "[dispatch-llm] routing CoS reply through claude_local");
+    try {
+      const reply = await spawnWithTimeout("claude", ["--print", "-"], prompt);
+      if (!reply) {
+        logger.warn({ adapter }, "[dispatch-llm] claude_local returned empty reply, using fallback");
+        return anthropicLLM(input);
+      }
+      return reply;
+    } catch (err) {
+      logger.error({ err, adapter }, "[dispatch-llm] claude_local failed, falling back to claude_api");
+      return anthropicLLM(input);
+    }
+  }
+
+  // TODO: add dispatch for gemini_local, codex_local, etc.
+  logger.warn(
+    { adapter },
+    "[dispatch-llm] adapter not yet supported for CoS chat — falling back to claude_api",
+  );
+  return anthropicLLM(input);
+}

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -65,7 +65,7 @@ export function onboardingOrchestrator(deps: Deps) {
         const created = await deps.agents.create(company.id, {
           name: "Chief of Staff",
           role: "chief_of_staff",
-          adapterType: "claude_api",
+          adapterType: (process.env.AGENTDASH_DEFAULT_ADAPTER ?? "claude_api").trim() || "claude_api",
           adapterConfig: {},
           status: "idle",
           spentMonthlyCents: 0,


### PR DESCRIPTION
## Summary

- **Root cause**: `cosReplier` was hardwired to `anthropicLLM`, ignoring the adapter the user picked in `agentdash setup`. Without `ANTHROPIC_API_KEY` every reply returned `"Got it. (stub reply…)"`.
- **Fix**: new `server/src/services/dispatch-llm.ts` reads `AGENTDASH_DEFAULT_ADAPTER` at call time and routes to the right backend:
  - `claude_api` (default) → existing `anthropicLLM` path, no behaviour change
  - `hermes_local` → spawns `hermes chat -q "<prompt>" -Q` (45 s timeout; falls back to `anthropicLLM` on error). Binary path defaults to `/Users/maxiaoer/.local/bin/hermes`, overridden by `AGENTDASH_HERMES_COMMAND`.
  - `claude_local` → spawns `claude --print -` with the prompt on stdin (45 s timeout; same fallback pattern).
  - anything else → falls back to `claude_api` with a `[dispatch-llm] adapter not yet supported` warning log.
- `conversations.ts`: swap hardcoded `anthropicLLM` for `dispatchLLM`.
- `onboarding-orchestrator.ts`: CoS agent `adapterType` now reads `AGENTDASH_DEFAULT_ADAPTER` instead of hardcoding `"claude_api"`.

## Hermes CLI invocation settled on

```
hermes chat -q "<flat prompt>" -Q
```

Discovered from `hermes-paperclip-adapter@0.2.0` dist source (`execute.js` line 261). The `-Q` flag suppresses streaming; `-q` passes the prompt inline.

## Limitations

- `gemini_local`, `codex_local`, `opencode_local`, `pi_local`, `cursor`, `openclaw_gateway` are not yet dispatched — they fall back to `claude_api` with a TODO log. Adding them is a follow-up.
- `hermes_local` uses a flat concatenated prompt (system + history) rather than Hermes's native session/turn API, which is fine for the CoS single-reply pattern but won't carry tool calls.
- `AGENTDASH_HERMES_COMMAND` env var lets you override the binary path without code changes.

## Test plan

- [ ] `pnpm -r typecheck` — passes (verified locally)
- [ ] `pnpm --filter @paperclipai/server build` — passes (verified locally)
- [ ] On Mac mini (`maxiaoer@192.168.86.45`): `git pull --ff-only && pnpm install --silent && pnpm dev --restart`; set `AGENTDASH_DEFAULT_ADAPTER=hermes_local` in `.env`, POST a message to CoS, confirm log shows `[dispatch-llm] routing CoS reply through hermes_local` and reply is not the stub string.
- [ ] With `AGENTDASH_DEFAULT_ADAPTER` unset: reply still works via `anthropicLLM` (or stub if no key — same behaviour as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)