### PR TITLE
feat(cos-chat): tighten chat layout — trim header height, footer padding, top gap

### DIFF
--- a/ui/src/components/ChatHeader.tsx
+++ b/ui/src/components/ChatHeader.tsx
@@ -15,7 +15,7 @@ export function ChatHeader({
   stepTotal,
 }: ChatHeaderProps) {
   return (
-    <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft bg-surface-raised shrink-0">
+    <div className="flex items-center justify-between px-6 py-2.5 border-b border-border-soft bg-surface-raised shrink-0">
       {/* Left: avatar + identity */}
       <div className="flex items-center gap-3">
         <div className="relative">

--- a/ui/src/components/Composer.tsx
+++ b/ui/src/components/Composer.tsx
@@ -26,7 +26,7 @@ export function Composer({
       <div className="relative flex-1">
         <input
           type="text"
-          className="w-full border border-border-soft rounded-xl px-4 py-3 bg-surface-raised text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:border-accent-500 focus-visible:ring-2 focus-visible:ring-accent-200 transition-[color,box-shadow] text-sm"
+          className="w-full border border-border-soft rounded-xl px-4 py-2 bg-surface-raised text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:border-accent-500 focus-visible:ring-2 focus-visible:ring-accent-200 transition-[color,box-shadow] text-sm"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);
@@ -47,7 +47,7 @@ export function Composer({
 
       {/* Send icon button */}
       <button
-        className="w-10 h-10 rounded-full bg-accent-500 flex items-center justify-center shrink-0 hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 disabled:opacity-40 disabled:cursor-not-allowed"
+        className="w-9 h-9 rounded-full bg-accent-500 flex items-center justify-center shrink-0 hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 disabled:opacity-40 disabled:cursor-not-allowed"
         onClick={send}
         disabled={isEmpty}
         aria-label="Send message"

--- a/ui/src/pages/ChatPanel.tsx
+++ b/ui/src/pages/ChatPanel.tsx
@@ -50,7 +50,7 @@ export default function ChatPanel({
   return (
     <div className="chat-panel flex flex-col h-full bg-surface-page">
       <ChatHeader {...(headerProps ?? {})} />
-      <div className="flex-1 overflow-y-auto px-4 py-8">
+      <div className="flex-1 overflow-y-auto px-4 pt-3 pb-4">
         <div className="max-w-2xl mx-auto">
           <MessageList
             messages={messages}
@@ -58,7 +58,7 @@ export default function ChatPanel({
           />
         </div>
       </div>
-      <div className="border-t border-border-soft bg-surface-raised px-4 py-4">
+      <div className="border-t border-border-soft bg-surface-raised px-4 py-2">
         <div className="max-w-2xl mx-auto">
           <Composer onSend={send} agentDirectory={agentDirectory} />
         </div>


### PR DESCRIPTION
## Summary

- **Header** (`ChatHeader.tsx`): `py-4` → `py-2.5` — shaves ~12px off total header height (before: ~68px, after: ~56px)
- **Scroll area** (`ChatPanel.tsx`): `py-8` → `pt-3 pb-4` — eliminates the 32px dead space above the first message, messages now start close to the header
- **Footer wrapper** (`ChatPanel.tsx`): `py-4` → `py-2` — saves ~16px on the composer bar (before: ~72px, after: ~56px)
- **Composer input** (`Composer.tsx`): `py-3` → `py-2` — tighter input field
- **Send button** (`Composer.tsx`): `w-10 h-10` → `w-9 h-9` — stays optically centered with the slimmer input

No bubble design changes (rounded-2xl, left/right alignment, avatar, accent color all untouched). @mention menu logic untouched. Tailwind 4 tokens only — no new colors or fonts.

## Test plan

- [ ] `pnpm --filter @paperclipai/ui typecheck` passes clean (verified before PR)
- [ ] Open `/cos` — header shows Sparkles avatar, "Chief of Staff", role tagline, online dot, all compact
- [ ] Scroll area: first message appears near top, no large whitespace gap
- [ ] Composer: input and send button are vertically centered and tighter
- [ ] Type `@` with agents present — mention dropdown still appears above input
- [ ] Resize to mobile (<640px) — no horizontal scroll, layout holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)