### PR TITLE
fix(onboarding): per-user workspace isolation — drop domain-based auto-attach

### DIFF
--- a/server/src/__tests__/onboarding-orchestrator.test.ts
+++ b/server/src/__tests__/onboarding-orchestrator.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { onboardingOrchestrator } from "../services/onboarding-orchestrator.js";
 
-const mockAccess = { ensureMembership: vi.fn(), setPrincipalPermission: vi.fn() };
-const mockCompanies = { create: vi.fn(), findByEmailDomain: vi.fn() };
+const mockAccess = { ensureMembership: vi.fn(), setPrincipalPermission: vi.fn(), listUserCompanyAccess: vi.fn() };
+const mockCompanies = { create: vi.fn(), getById: vi.fn() };
 const mockAgents = { create: vi.fn(), createApiKey: vi.fn(), list: vi.fn(), listKeys: vi.fn() };
 const mockInstructions = { materializeManagedBundle: vi.fn() };
 const mockConversations = { findByCompany: vi.fn(), create: vi.fn(), addParticipant: vi.fn() };
@@ -14,8 +14,9 @@ describe("onboardingOrchestrator.bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com" });
-    mockCompanies.findByEmailDomain.mockResolvedValue(null);
+    mockAccess.listUserCompanyAccess.mockResolvedValue([]);
     mockCompanies.create.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
+    mockCompanies.getById.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
     mockAgents.list.mockResolvedValue([]);
     mockAgents.listKeys.mockResolvedValue([]);
     mockAgents.create.mockResolvedValue({ id: "agent-cos-1", companyId: "company-1", role: "chief_of_staff", adapterType: "claude_api", adapterConfig: {} });
@@ -37,11 +38,13 @@ describe("onboardingOrchestrator.bootstrap", () => {
     expect(mockConversations.addParticipant).toHaveBeenCalledWith("conv-1", "user-1", "owner");
   });
 
-  it("is idempotent — second call returns existing artifacts", async () => {
+  it("is idempotent — second call returns existing artifacts (user-membership check, NOT domain lookup)", async () => {
     await onboardingOrchestrator(deps as any).bootstrap("user-1");
     vi.clearAllMocks();
     mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com" });
-    mockCompanies.findByEmailDomain.mockResolvedValue({ id: "company-1", emailDomain: "acme.com" });
+    // Second call: user already has an active membership — reuse that company.
+    mockAccess.listUserCompanyAccess.mockResolvedValue([{ companyId: "company-1", status: "active", principalId: "user-1" }]);
+    mockCompanies.getById.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
     mockAgents.list.mockResolvedValue([{ id: "agent-cos-1", role: "chief_of_staff", adapterType: "claude_api", adapterConfig: {} }]);
     mockAgents.listKeys.mockResolvedValue([{ id: "key-1" }]);
     mockConversations.findByCompany.mockResolvedValue({ id: "conv-1", companyId: "company-1" });
@@ -51,9 +54,25 @@ describe("onboardingOrchestrator.bootstrap", () => {
 
     const result = await onboardingOrchestrator(deps as any).bootstrap("user-1");
     expect(result).toEqual({ companyId: "company-1", cosAgentId: "agent-cos-1", conversationId: "conv-1" });
+    // Must NOT create a new company on the second bootstrap call.
     expect(mockCompanies.create).not.toHaveBeenCalled();
     expect(mockAgents.create).not.toHaveBeenCalled();
     expect(mockAgents.createApiKey).not.toHaveBeenCalled();
     expect(mockConversations.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a fresh isolated workspace even when another user with the same domain exists", async () => {
+    // gmail.com user-2 signs up; user-1 (also gmail.com) already has a company.
+    // The orchestrator must NOT attach user-2 to user-1's company.
+    mockUsers.getById.mockResolvedValue({ id: "user-2", email: "bob@gmail.com" });
+    mockAccess.listUserCompanyAccess.mockResolvedValue([]); // user-2 has NO memberships yet
+    mockCompanies.create.mockResolvedValue({ id: "company-2", name: "Gmail", emailDomain: "gmail.com" });
+    mockAgents.create.mockResolvedValue({ id: "agent-cos-2", companyId: "company-2", role: "chief_of_staff", adapterType: "claude_api", adapterConfig: {} });
+    mockConversations.create.mockResolvedValue({ id: "conv-2", companyId: "company-2" });
+
+    const result = await onboardingOrchestrator(deps as any).bootstrap("user-2");
+    expect(result.companyId).toBe("company-2");
+    // A brand-new company was created — not looked up by domain.
+    expect(mockCompanies.create).toHaveBeenCalledWith(expect.objectContaining({ emailDomain: "gmail.com" }));
   });
 });

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -36,10 +36,26 @@ export function onboardingOrchestrator(deps: Deps) {
       const user = (await deps.users.getById(userId)) ?? resolveLocalUser(userId);
       if (!user) throw new Error(`User ${userId} not found`);
 
-      // Step 1: ensure a company. Use email-domain lookup first (idempotency).
+      // Step 1: ensure a company.
+      // Idempotency is per-user, not per-domain: if this user already belongs to
+      // a company (e.g. bootstrap() fired twice from auth hook + CoSConversation
+      // useEffect), reuse their first active membership rather than creating a
+      // second workspace. We intentionally do NOT look up by email domain —
+      // domain matching caused all gmail.com users to land in the same workspace,
+      // which is a critical isolation bug.
       const emailDomain = deriveEmailDomain(user.email);
-      let company = emailDomain ? await deps.companies.findByEmailDomain(emailDomain) : null;
-      if (!company) {
+      const existingMemberships = await deps.access.listUserCompanyAccess(userId);
+      const activeMembership = existingMemberships.find(
+        (m: any) => m.status === "active",
+      );
+      let company: { id: string; name?: string; emailDomain?: string | null };
+      if (activeMembership) {
+        const found = await deps.companies.getById(activeMembership.companyId);
+        if (!found) throw new Error(`Company ${activeMembership.companyId} not found for existing membership`);
+        company = found;
+      } else {
+        // Every sign-up gets its own fresh, isolated workspace.
+        // Cross-team membership happens via invites, not domain matching.
         company = await deps.companies.create({
           name: companyNameFromEmail(user.email),
           emailDomain,


### PR DESCRIPTION
## Summary

- **Critical isolation bug**: users signing up with the same email domain (e.g. `gmail.com`) were being auto-attached to the first existing workspace with that domain, exposing other users' conversation history
- **Root cause**: `onboarding-orchestrator.ts` called `findByEmailDomain` and attached the new user to any matching company — every gmail.com user landed in the same workspace
- **Fix**: Drop `findByEmailDomain` entirely. Every sign-up creates its own fresh, isolated workspace. Cross-team membership now requires an explicit invite
- **Idempotency preserved on the user side**: if `bootstrap()` fires twice for the same user (auth hook + CoS `useEffect` double-fire), the orchestrator checks `listUserCompanyAccess(userId)` first — if the user already has an active membership, it reuses that company instead of creating a second one

## Files changed

- `server/src/services/onboarding-orchestrator.ts`: replace domain lookup with user-membership check for idempotency; always create a new company for a truly new user
- `server/src/__tests__/onboarding-orchestrator.test.ts`: update idempotency test to use user-membership mock (`listUserCompanyAccess`), add new isolation test asserting two same-domain users get separate companies

## Test results

```
✓ src/__tests__/onboarding-orchestrator.test.ts (3 tests)
  ✓ creates company, CoS agent, API key, and conversation for a fresh user
  ✓ is idempotent — second call returns existing artifacts (user-membership check, NOT domain lookup)
  ✓ creates a fresh isolated workspace even when another user with the same domain exists
```

`pnpm --filter @paperclipai/server typecheck` — clean (0 errors)

The 5 pre-existing failures in `signup-pro-free-mail-block.test.ts` are unrelated to this change (test assertions pass a full email as `emailDomain` but the route stores the domain-only string — present on `main` before this PR).

## DB cleanup on mini

After merging, the polluted shared workspace on `maxiaoer@192.168.86.45` needs to be cleaned. Connect to embedded Postgres (`PGPASSWORD=paperclip psql -h 127.0.0.1 -p 54329 -U paperclip -d paperclipai`) and DELETE the shared gmail/example.com workspaces. Users' `auth_users` rows stay intact — their next `bootstrap()` call (triggered by CoSConversation useEffect on next page load) will create fresh isolated workspaces via the new code path.

DO NOT MERGE — leave for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)