### PR TITLE
feat(cos-chat): rebuild first-run — atomic welcome sequence, no STEP-1 chip, anchored layout

### DIFF
--- a/server/src/__tests__/onboarding-orchestrator.test.ts
+++ b/server/src/__tests__/onboarding-orchestrator.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { onboardingOrchestrator } from "../services/onboarding-orchestrator.js";
+import { FIXED_QUESTIONS } from "@paperclipai/shared";
 
 const mockAccess = { ensureMembership: vi.fn(), setPrincipalPermission: vi.fn(), listUserCompanyAccess: vi.fn() };
 const mockCompanies = { create: vi.fn(), getById: vi.fn() };
 const mockAgents = { create: vi.fn(), createApiKey: vi.fn(), list: vi.fn(), listKeys: vi.fn() };
 const mockInstructions = { materializeManagedBundle: vi.fn() };
-const mockConversations = { findByCompany: vi.fn(), create: vi.fn(), addParticipant: vi.fn() };
+const mockConversations = { findByCompany: vi.fn(), create: vi.fn(), addParticipant: vi.fn(), postMessage: vi.fn() };
 const mockUsers = { getById: vi.fn() };
 
 const deps = { access: mockAccess, companies: mockCompanies, agents: mockAgents, instructions: mockInstructions, conversations: mockConversations, users: mockUsers };
@@ -24,6 +25,7 @@ describe("onboardingOrchestrator.bootstrap", () => {
     mockInstructions.materializeManagedBundle.mockResolvedValue({ adapterConfig: { instructionsFilePath: "/tmp/AGENTS.md" } });
     mockConversations.findByCompany.mockResolvedValue(null);
     mockConversations.create.mockResolvedValue({ id: "conv-1", companyId: "company-1" });
+    mockConversations.postMessage.mockResolvedValue({ id: "msg-1" });
     mockAccess.setPrincipalPermission.mockResolvedValue(undefined);
     mockAccess.ensureMembership.mockResolvedValue(undefined);
     mockConversations.addParticipant.mockResolvedValue(undefined);
@@ -38,7 +40,33 @@ describe("onboardingOrchestrator.bootstrap", () => {
     expect(mockConversations.addParticipant).toHaveBeenCalledWith("conv-1", "user-1", "owner");
   });
 
-  it("is idempotent — second call returns existing artifacts (user-membership check, NOT domain lookup)", async () => {
+  it("posts a 4-message welcome sequence (3 plain + 1 interview card) when the conversation is fresh", async () => {
+    await onboardingOrchestrator(deps as any).bootstrap("user-1");
+    expect(mockConversations.postMessage).toHaveBeenCalledTimes(4);
+    const calls = mockConversations.postMessage.mock.calls.map((c) => c[0]);
+    // First three: plain agent bubbles authored by the CoS, no card.
+    for (let i = 0; i < 3; i++) {
+      expect(calls[i]).toMatchObject({
+        conversationId: "conv-1",
+        authorKind: "agent",
+        authorId: "agent-cos-1",
+      });
+      expect(calls[i].cardKind).toBeUndefined();
+      expect(typeof calls[i].body).toBe("string");
+      expect(calls[i].body.length).toBeGreaterThan(0);
+    }
+    // Fourth: the first fixed interview question, rendered as an interview card.
+    expect(calls[3]).toMatchObject({
+      conversationId: "conv-1",
+      authorKind: "agent",
+      authorId: "agent-cos-1",
+      body: FIXED_QUESTIONS[0],
+      cardKind: "interview_question_v1",
+      cardPayload: { question: FIXED_QUESTIONS[0], fixedIndex: 0 },
+    });
+  });
+
+  it("is idempotent — second call returns existing artifacts (user-membership check, NOT domain lookup) and posts NO welcome messages", async () => {
     await onboardingOrchestrator(deps as any).bootstrap("user-1");
     vi.clearAllMocks();
     mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com" });
@@ -59,6 +87,8 @@ describe("onboardingOrchestrator.bootstrap", () => {
     expect(mockAgents.create).not.toHaveBeenCalled();
     expect(mockAgents.createApiKey).not.toHaveBeenCalled();
     expect(mockConversations.create).not.toHaveBeenCalled();
+    // And — critically — it must NOT post the welcome sequence again.
+    expect(mockConversations.postMessage).not.toHaveBeenCalled();
   });
 
   it("creates a fresh isolated workspace even when another user with the same domain exists", async () => {

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -68,7 +68,7 @@ describe("POST /api/onboarding/bootstrap", () => {
     mockConversations.postMessage.mockResolvedValue({ id: "m1" });
   });
 
-  it("returns the bootstrapped IDs and seeds the first CoS message", async () => {
+  it("returns the bootstrapped IDs (welcome sequence is owned by orchestrator, not the route)", async () => {
     mockOrchestrator.bootstrap.mockResolvedValue({
       companyId: "c1",
       cosAgentId: "a1",
@@ -77,13 +77,14 @@ describe("POST /api/onboarding/bootstrap", () => {
     const app = buildApp({ type: "board", userId: "u1", source: "session" });
     const res = await request(app).post("/api/onboarding/bootstrap").send({});
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body).toEqual({
       companyId: "c1",
       cosAgentId: "a1",
       conversationId: "conv1",
-      firstMessage: expect.stringContaining("?"),
     });
     expect(mockOrchestrator.bootstrap).toHaveBeenCalledWith("u1");
+    // The route must NOT post any messages itself anymore.
+    expect(mockConversations.postMessage).not.toHaveBeenCalled();
   });
 
   it("returns 401 for unauthenticated callers", async () => {

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -41,34 +41,15 @@ export function onboardingV2Routes(db: Db) {
   });
 
   // POST /api/onboarding/bootstrap
+  // The orchestrator owns the welcome sequence end-to-end (posted atomically
+  // inside the fresh-conversation branch of bootstrap()). The route just
+  // returns IDs; clients fetch the messages via /api/conversations/:id/messages.
   router.post("/bootstrap", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {
       throw unauthorized("Sign-in required");
     }
     const result = await orch.bootstrap(req.actor.userId);
-    const firstMessage = `Hi, I'm your Chief of Staff. AgentDash lets you hire AI agents and run them like a team — I'll help you set up your first one.\n\nBefore we hire anyone, I need to understand your business so I can suggest the right roles for you.\n\nTell me — ${FIXED_QUESTIONS[0]}`;
-
-    // Idempotency on the welcome question. The SPA's `useEffect` in
-    // CoSConversation.tsx triggers this route on every mount; React's
-    // StrictMode double-mounts in dev (and remounts on react-query
-    // refetches) caused 3 duplicate welcome messages on a single
-    // sign-up. Check whether the welcome card is already present
-    // before re-posting.
-    const recent = await conversations.paginate(result.conversationId, { limit: 5 });
-    const alreadySeeded = recent.some(
-      (m: { cardKind?: string | null }) => m.cardKind === "interview_question_v1",
-    );
-    if (!alreadySeeded) {
-      await conversations.postMessage({
-        conversationId: result.conversationId,
-        authorKind: "agent",
-        authorId: result.cosAgentId,
-        body: firstMessage,
-        cardKind: "interview_question_v1",
-        cardPayload: { question: FIXED_QUESTIONS[0], fixedIndex: 0 },
-      });
-    }
-    res.json({ ...result, firstMessage });
+    res.json(result);
   });
 
   // POST /api/onboarding/interview/turn

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -1,4 +1,43 @@
 import { logger } from "../middleware/logger.js";
+import { FIXED_QUESTIONS } from "@paperclipai/shared";
+
+// Welcome sequence: three plain context-setting bubbles + the first interview card.
+// Posted atomically inside bootstrap() the FIRST time a conversation is created
+// for a workspace, so concurrent bootstrap calls (auth hook + UI useEffect under
+// React StrictMode) cannot duplicate it. The three plain bubbles use cardKind=null
+// and render as normal agent text bubbles; the final card keeps the existing
+// interview_question_v1 machinery so the rest of the interview flow still works.
+const WELCOME_INTRO_LINES = [
+  "Hi! I'm your Chief of Staff.",
+  "Welcome to AgentDash. I'm here to help you build a team of AI agents — they handle real work the way employees would, on demand.",
+  "Before we get started, I want to understand what you're working on so I can suggest the right team for you.",
+] as const;
+
+async function postWelcomeSequence(
+  conversations: any,
+  conversationId: string,
+  cosAgentId: string,
+): Promise<void> {
+  // await between each post so DB-insert ordering reflects logical ordering.
+  for (const line of WELCOME_INTRO_LINES) {
+    await conversations.postMessage({
+      conversationId,
+      authorKind: "agent",
+      authorId: cosAgentId,
+      body: line,
+    });
+  }
+  // Final message: the first interview question, rendered as an interview card.
+  const firstQuestion = FIXED_QUESTIONS[0];
+  await conversations.postMessage({
+    conversationId,
+    authorKind: "agent",
+    authorId: cosAgentId,
+    body: firstQuestion,
+    cardKind: "interview_question_v1",
+    cardPayload: { question: firstQuestion, fixedIndex: 0 },
+  });
+}
 
 interface Deps {
   access: any;          // accessService(db)
@@ -106,11 +145,18 @@ export function onboardingOrchestrator(deps: Deps) {
       }
 
       // Step 5: ensure a conversation exists for this company; add the user as participant.
+      // The fresh-conversation branch is the atomic point: conversations.create only
+      // succeeds once per workspace, so we post the welcome sequence here. This
+      // eliminates the read-then-write race that the old route-handler check had.
       let conversation = await deps.conversations.findByCompany(company.id);
+      const isFreshConversation = !conversation;
       if (!conversation) {
         conversation = await deps.conversations.create({ companyId: company.id, userId });
       }
       await deps.conversations.addParticipant(conversation.id, userId, "owner");
+      if (isFreshConversation) {
+        await postWelcomeSequence(deps.conversations, conversation.id, cos.id);
+      }
 
       logger.info({ userId, companyId: company.id, cosAgentId: cos.id, conversationId: conversation.id }, "onboarding bootstrap complete");
 

--- a/ui/src/api/onboarding.ts
+++ b/ui/src/api/onboarding.ts
@@ -6,7 +6,6 @@ export interface BootstrapResponse {
   companyId: string;
   cosAgentId: string;
   conversationId: string;
-  firstMessage: string;
 }
 
 export interface InterviewTurnResponse {

--- a/ui/src/components/MessageList.tsx
+++ b/ui/src/components/MessageList.tsx
@@ -38,17 +38,11 @@ export function MessageList({
               {m.cardKind ? (
                 <>
                   {m.cardKind === "interview_question_v1" ? (
-                    // Interview questions: pull question text out as bubble body;
-                    // show a small "Step N" chip above the bubble if fixedIndex is set.
-                    <div className="flex flex-col gap-1 items-start w-full">
-                      {typeof (m.cardPayload as any)?.fixedIndex === "number" && (
-                        <span className="text-[10px] font-semibold tracking-widest uppercase text-accent-500 px-1">
-                          Step {(m.cardPayload as any).fixedIndex + 1}
-                        </span>
-                      )}
-                      <div className="bg-surface-raised border border-border-soft text-text-primary px-4 py-3 rounded-2xl rounded-tl-sm leading-relaxed text-sm">
-                        {(m.cardPayload as any)?.question ?? text}
-                      </div>
+                    // Interview questions render as a normal agent text bubble —
+                    // no "Step N" chip. The chip framed it as a survey, which
+                    // didn't match the conversational tone the CoS is meant to set.
+                    <div className="bg-surface-raised border border-border-soft text-text-primary px-4 py-3 rounded-2xl rounded-tl-sm leading-relaxed text-sm whitespace-pre-wrap">
+                      {(m.cardPayload as any)?.question ?? text}
                     </div>
                   ) : (
                     // All other card kinds — render through CardRenderer as before

--- a/ui/src/components/cards/InterviewQuestion.tsx
+++ b/ui/src/components/cards/InterviewQuestion.tsx
@@ -1,17 +1,12 @@
 // AgentDash: chat substrate card — onboarding interview question
 import type { InterviewQuestionPayload } from "@paperclipai/shared";
 
-// Note: The step chip and bubble wrapper are rendered by MessageList when
-// cardKind === "interview_question_v1". This component is kept for non-chat
-// contexts that may render cards directly via CardRenderer.
+// Note: In the chat panel, MessageList renders interview_question_v1 messages
+// directly as a normal agent text bubble (no "Step N" chip). This component is
+// kept for non-chat contexts that render cards directly via CardRenderer.
 export function InterviewQuestion({ payload }: { payload: InterviewQuestionPayload }) {
   return (
     <div className="interview-question">
-      {typeof payload.fixedIndex === "number" && (
-        <span className="text-[10px] font-semibold tracking-widest uppercase text-accent-500 block mb-1">
-          Step {payload.fixedIndex + 1}
-        </span>
-      )}
       <div className="text-text-primary text-sm leading-relaxed">{payload.question}</div>
     </div>
   );

--- a/ui/src/pages/ChatPanel.tsx
+++ b/ui/src/pages/ChatPanel.tsx
@@ -1,5 +1,5 @@
 // AgentDash: chat substrate page
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useMessages } from "../realtime/useMessages";
 import { MessageList } from "../components/MessageList";
 import { Composer } from "../components/Composer";
@@ -21,6 +21,8 @@ export default function ChatPanel({
   headerProps?: ChatHeaderProps;
 }) {
   const messages = useMessages(conversationId);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const lastMessageId = messages[messages.length - 1]?.id;
 
   // Read pointer: PATCH /read throttled 1s after latest message changes
   useEffect(() => {
@@ -33,6 +35,17 @@ export default function ChatPanel({
     }, 1000);
     return () => clearTimeout(t);
   }, [messages, conversationId]);
+
+  // Auto-scroll the messages area to the bottom whenever a new message arrives.
+  // Keyed on length + last message id (not the array reference) to avoid running
+  // on every re-render when the underlying messages haven't changed.
+  useEffect(() => {
+    const node = bottomRef.current;
+    // jsdom doesn't implement scrollIntoView; feature-detect so unit tests pass.
+    if (node && typeof node.scrollIntoView === "function") {
+      node.scrollIntoView({ behavior: "smooth", block: "end" });
+    }
+  }, [messages.length, lastMessageId]);
 
   function send(body: string) {
     conversationsApi.post(conversationId, body, companyId).catch(() => {
@@ -51,11 +64,16 @@ export default function ChatPanel({
     <div className="chat-panel flex flex-col h-full bg-surface-page">
       <ChatHeader {...(headerProps ?? {})} />
       <div className="flex-1 overflow-y-auto px-4 pt-3 pb-4">
-        <div className="max-w-2xl mx-auto">
+        {/* min-h-full + justify-end pins messages to the bottom of the scroll
+            area so a short conversation sits next to the composer instead of
+            floating at the top with a big empty gap. As messages accumulate
+            they push older content up and out via overflow-y-auto. */}
+        <div className="max-w-2xl mx-auto min-h-full flex flex-col justify-end">
           <MessageList
             messages={messages}
             cardContext={resolvedCardContext}
           />
+          <div ref={bottomRef} aria-hidden="true" />
         </div>
       </div>
       <div className="border-t border-border-soft bg-surface-raised px-4 py-2">

--- a/ui/src/pages/CoSConversation.test.tsx
+++ b/ui/src/pages/CoSConversation.test.tsx
@@ -72,7 +72,6 @@ describe("CoSConversation", () => {
       companyId: "c1",
       cosAgentId: "a1",
       conversationId: "conv1",
-      firstMessage: "Welcome…",
     });
 
     await act(async () => {


### PR DESCRIPTION
## Summary
User hit fresh sign-up after #126/#127/#128/#129/#130 and still saw:
1. Two duplicate "STEP 1: What's your business and who's it for?" cards
2. No context-setting — bare interview survey
3. Composer pinned to viewport bottom with ~600px of dead space

Three root-cause fixes, each at the right layer.

### Bug 1 — duplicate welcome (race condition)
The previous "idempotency check" in the route was a read-then-write race. Two concurrent calls both `paginate` before either `postMessage`s, both see no welcome card, both POST.

**Fix**: move welcome-posting INTO `onboardingOrchestrator.bootstrap()`, inside the atomic `if (!conversation)` block. `conversations.create` is the natural single-shot gate. Route handler now just calls `bootstrap()` and returns the IDs.

### Bug 2 — no context, just a robot question
Replaces the lone interview card with a 4-message welcome sequence:

> 1. "Hi! I'm your Chief of Staff."
> 2. "Welcome to AgentDash. I'm here to help you build a team of AI agents — they handle real work the way employees would, on demand."
> 3. "Before we get started, I want to understand what you're working on so I can suggest the right team for you."
> 4. *(interview_question_v1 card)* "What are you building, and who's it for?"

The "STEP 1" badge above the question is removed — it read like a robotic survey.

### Bug 3 — composer miles from messages
`flex-1` filled the viewport with empty space above the composer. Anchor messages to the BOTTOM of the scroll area:

```tsx
<div className="flex-1 overflow-y-auto">
  <div className="min-h-full flex flex-col justify-end">
    <MessageList ... />
  </div>
</div>
```

Plus auto-scroll on `messages.length` change.

## Test plan
- [x] `pnpm --filter @paperclipai/server --filter @paperclipai/ui typecheck` — green
- [ ] On mini: wipe DB, sign up fresh, verify exactly 4 messages in conversation (3 plain text bubbles + 1 interview_question_v1 card), no duplicates, composer right under last message