### PR TITLE
fix(test): allow companies.create's trailing flag arg in free-mail tests

### DIFF
--- a/server/src/__tests__/signup-pro-free-mail-block.test.ts
+++ b/server/src/__tests__/signup-pro-free-mail-block.test.ts
@@ -151,9 +151,12 @@ describe("POST /api/companies — Pro free-mail block (AGE-60 + AGE-104)", () =>
       const res = await request(app).post("/api/companies").send({ name: "Personal" });
 
       expect(res.status).toBe(201);
-      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
-        emailDomain: `alice@${domain}`,
-      }));
+      // companies.create is invoked with (input, allowProSeed) — match by
+      // the first arg only via expect.anything() for the trailing flag.
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({ emailDomain: `alice@${domain}` }),
+        expect.anything(),
+      );
     },
   );
 


### PR DESCRIPTION
## Summary
The 5 AGE-104 \"ALLOWS the FIRST workspace from {gmail/yahoo/outlook/hotmail/icloud}.com\" tests have been failing on main for several PRs. Confirmed pre-existing — failures show up as red across multiple unrelated PRs (#125, #126, #127, …).

**Diagnosis**: the route's `companies.create(input, allowProSeed)` is invoked with a trailing boolean flag the tests didn't account for. `toHaveBeenCalledWith(expect.objectContaining({...}))` enforces an exact-args match including arity.

**Fix**: pass `expect.anything()` for the trailing flag. Intent of the assertion (input-shape verification) is preserved.

## Test plan
- [x] `pnpm --filter @paperclipai/server exec vitest run signup-pro-free-mail-block` — was 8/13 passing, now **13/13**