### PR TITLE
fix(orchestrator): use deriveCompanyEmailDomain so gmail users get isolated workspaces

### DIFF
--- a/server/src/__tests__/onboarding-orchestrator.test.ts
+++ b/server/src/__tests__/onboarding-orchestrator.test.ts
@@ -3,7 +3,7 @@ import { onboardingOrchestrator } from "../services/onboarding-orchestrator.js";
 import { FIXED_QUESTIONS } from "@paperclipai/shared";
 
 const mockAccess = { ensureMembership: vi.fn(), setPrincipalPermission: vi.fn(), listUserCompanyAccess: vi.fn() };
-const mockCompanies = { create: vi.fn(), getById: vi.fn() };
+const mockCompanies = { create: vi.fn(), getById: vi.fn(), findByEmailDomain: vi.fn() };
 const mockAgents = { create: vi.fn(), createApiKey: vi.fn(), list: vi.fn(), listKeys: vi.fn() };
 const mockInstructions = { materializeManagedBundle: vi.fn() };
 const mockConversations = { findByCompany: vi.fn(), create: vi.fn(), addParticipant: vi.fn(), postMessage: vi.fn() };
@@ -18,6 +18,7 @@ describe("onboardingOrchestrator.bootstrap", () => {
     mockAccess.listUserCompanyAccess.mockResolvedValue([]);
     mockCompanies.create.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
     mockCompanies.getById.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
+    mockCompanies.findByEmailDomain.mockResolvedValue(null);
     mockAgents.list.mockResolvedValue([]);
     mockAgents.listKeys.mockResolvedValue([]);
     mockAgents.create.mockResolvedValue({ id: "agent-cos-1", companyId: "company-1", role: "chief_of_staff", adapterType: "claude_api", adapterConfig: {} });
@@ -91,18 +92,40 @@ describe("onboardingOrchestrator.bootstrap", () => {
     expect(mockConversations.postMessage).not.toHaveBeenCalled();
   });
 
-  it("creates a fresh isolated workspace even when another user with the same domain exists", async () => {
+  it("creates a fresh isolated workspace for a free-mail user even when another same-domain user exists", async () => {
     // gmail.com user-2 signs up; user-1 (also gmail.com) already has a company.
-    // The orchestrator must NOT attach user-2 to user-1's company.
+    // For free-mail providers, deriveCompanyEmailDomain returns "<local>@<domain>"
+    // so each personal account has its own workspace key — the unique constraint
+    // doesn't collide with another gmail user, and findByEmailDomain isn't even
+    // consulted for free-mail keys (they contain "@", which the orchestrator
+    // uses as the discriminator).
     mockUsers.getById.mockResolvedValue({ id: "user-2", email: "bob@gmail.com" });
     mockAccess.listUserCompanyAccess.mockResolvedValue([]); // user-2 has NO memberships yet
-    mockCompanies.create.mockResolvedValue({ id: "company-2", name: "Gmail", emailDomain: "gmail.com" });
+    mockCompanies.create.mockResolvedValue({ id: "company-2", name: "Gmail", emailDomain: "bob@gmail.com" });
     mockAgents.create.mockResolvedValue({ id: "agent-cos-2", companyId: "company-2", role: "chief_of_staff", adapterType: "claude_api", adapterConfig: {} });
     mockConversations.create.mockResolvedValue({ id: "conv-2", companyId: "company-2" });
 
     const result = await onboardingOrchestrator(deps as any).bootstrap("user-2");
     expect(result.companyId).toBe("company-2");
-    // A brand-new company was created — not looked up by domain.
-    expect(mockCompanies.create).toHaveBeenCalledWith(expect.objectContaining({ emailDomain: "gmail.com" }));
+    // Free-mail keys are per-user; corp-domain lookup is skipped for them.
+    expect(mockCompanies.findByEmailDomain).not.toHaveBeenCalled();
+    expect(mockCompanies.create).toHaveBeenCalledWith(expect.objectContaining({ emailDomain: "bob@gmail.com" }));
+  });
+
+  it("attaches a corp-domain user to an existing same-domain company (team pattern)", async () => {
+    // alice@acme.com signs up; an "acme.com" workspace already exists from
+    // another teammate. We expect the orchestrator to attach alice to it
+    // (no fresh workspace created), since deriveCompanyEmailDomain returns
+    // bare "acme.com" for non-free-mail domains and findByEmailDomain wins.
+    mockUsers.getById.mockResolvedValue({ id: "user-3", email: "alice@acme.com" });
+    mockAccess.listUserCompanyAccess.mockResolvedValue([]);
+    mockCompanies.findByEmailDomain.mockResolvedValue({ id: "company-acme", name: "Acme", emailDomain: "acme.com" });
+    mockAgents.list.mockResolvedValue([{ id: "agent-cos-acme", role: "chief_of_staff" }]);
+    mockConversations.findByCompany.mockResolvedValue({ id: "conv-acme", companyId: "company-acme" });
+
+    const result = await onboardingOrchestrator(deps as any).bootstrap("user-3");
+    expect(result.companyId).toBe("company-acme");
+    expect(mockCompanies.findByEmailDomain).toHaveBeenCalledWith("acme.com");
+    expect(mockCompanies.create).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -1,5 +1,5 @@
 import { logger } from "../middleware/logger.js";
-import { FIXED_QUESTIONS } from "@paperclipai/shared";
+import { FIXED_QUESTIONS, deriveCompanyEmailDomain } from "@paperclipai/shared";
 
 // Welcome sequence: three plain context-setting bubbles + the first interview card.
 // Posted atomically inside bootstrap() the FIRST time a conversation is created
@@ -82,24 +82,66 @@ export function onboardingOrchestrator(deps: Deps) {
       // second workspace. We intentionally do NOT look up by email domain —
       // domain matching caused all gmail.com users to land in the same workspace,
       // which is a critical isolation bug.
-      const emailDomain = deriveEmailDomain(user.email);
+      //
+      // Use `deriveCompanyEmailDomain` from @paperclipai/shared rather than the
+      // local `deriveEmailDomain` helper. For free-mail providers (gmail/yahoo/
+      // outlook/...) the shared helper returns `local@domain` — a per-user
+      // workspace key — so the unique constraint on companies.emailDomain
+      // doesn't collide between unrelated personal accounts that happen to
+      // share a domain. The local helper returns just `gmail.com`, which makes
+      // any second gmail.com user's bootstrap throw "domain already claimed".
+      let emailDomain: string | null = null;
+      if (user.email) {
+        try {
+          emailDomain = deriveCompanyEmailDomain(user.email);
+        } catch {
+          // Falls through with emailDomain = null. The DB column allows null;
+          // workspace creation still succeeds for emails the helper can't
+          // parse (e.g. the synthetic local-board actor in local_trusted mode).
+        }
+      }
       const existingMemberships = await deps.access.listUserCompanyAccess(userId);
       const activeMembership = existingMemberships.find(
         (m: any) => m.status === "active",
       );
       let company: { id: string; name?: string; emailDomain?: string | null };
       if (activeMembership) {
+        // Returning user — reuse the workspace they already belong to.
         const found = await deps.companies.getById(activeMembership.companyId);
         if (!found) throw new Error(`Company ${activeMembership.companyId} not found for existing membership`);
         company = found;
       } else {
-        // Every sign-up gets its own fresh, isolated workspace.
-        // Cross-team membership happens via invites, not domain matching.
-        company = await deps.companies.create({
-          name: companyNameFromEmail(user.email),
-          emailDomain,
-          budgetMonthlyCents: 0,
-        });
+        // First sign-up for this user. Decide whether to attach to an
+        // existing same-domain company (corp pattern) or create a fresh
+        // workspace (free-mail pattern).
+        //
+        // The discriminator is the shape of `emailDomain` after
+        // `deriveCompanyEmailDomain`:
+        //   - free-mail (gmail/yahoo/outlook/…): "<local>@<domain>" —
+        //     unique per user, so even if a same-provider user already
+        //     exists their key won't collide. We always create fresh.
+        //   - corp (acme.com / yourstartup.io / …): "<domain>" —
+        //     shared across all users at that domain, so we attach to
+        //     the existing workspace if any. Coworkers join their team
+        //     by signing up with their work email.
+        //
+        // The free-mail key contains "@", corp keys don't — that's the
+        // detection. Falls back to fresh workspace if `emailDomain` is
+        // unset (synthetic local-board actor / unparseable email).
+        const isCorpDomain =
+          typeof emailDomain === "string" && emailDomain.length > 0 && !emailDomain.includes("@");
+        const corpExisting = isCorpDomain && deps.companies.findByEmailDomain
+          ? await deps.companies.findByEmailDomain(emailDomain)
+          : null;
+        if (corpExisting) {
+          company = corpExisting;
+        } else {
+          company = await deps.companies.create({
+            name: companyNameFromEmail(user.email),
+            emailDomain,
+            budgetMonthlyCents: 0,
+          });
+        }
       }
 
       // Step 2: grant agents:create FIRST (before owner promotion — see GH #72).


### PR DESCRIPTION
## Summary
User signed up with `thetangstr003@gmail.com` after `thetangstr@gmail.com` already existed. Got dumped at **"No company access"**. Server log:

```
[auth] onUserCreated hook failed — user signed up without a workspace
  error: "Email domain gmail.com is already claimed by company cea12eee-bf8f-…"
```

The orchestrator was using a local `deriveEmailDomain` helper that returned bare `"gmail.com"` for both users → unique-constraint violation on `companies.emailDomain` → workspace creation threw → user stranded.

## Fix
Switch to `deriveCompanyEmailDomain` from `@paperclipai/shared`, which already encodes the right product semantics:

| Domain class | Key | Behavior |
|---|---|---|
| free-mail (`gmail`/`yahoo`/`outlook`/`hotmail`/`icloud`) | `"<local>@<domain>"` | Per-user workspace key. Two gmails → two isolated workspaces. |
| corp (`acme.com`/`yourstartup.io`) | `"<domain>"` | Shared. Coworkers join their team's workspace. |

Detection: free-mail keys contain `@`, corp keys don't. Skip `findByEmailDomain` entirely for free-mail (would always miss); call it for corp so coworkers auto-attach.

## Test plan
- [x] `pnpm --filter @paperclipai/server exec vitest run onboarding-orchestrator` — 5/5 passed
- [x] Updated free-mail isolation test to expect `emailDomain: "bob@gmail.com"` and verify `findByEmailDomain` is NOT called
- [x] NEW corp-domain test: `alice@acme.com` sign-up finds existing acme.com workspace, joins it, no fresh workspace created
- [ ] User: nuke mini DB, sign up with two gmail addresses, verify both land in their own workspaces (not "No company access")