### PR TITLE
feat(cos): Phase A — collapse welcome to one rich Phase 0 greeting

### DIFF
--- a/server/src/__tests__/onboarding-orchestrator.test.ts
+++ b/server/src/__tests__/onboarding-orchestrator.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { onboardingOrchestrator } from "../services/onboarding-orchestrator.js";
-import { FIXED_QUESTIONS } from "@paperclipai/shared";
 
 const mockAccess = { ensureMembership: vi.fn(), setPrincipalPermission: vi.fn(), listUserCompanyAccess: vi.fn() };
 const mockCompanies = { create: vi.fn(), getById: vi.fn(), findByEmailDomain: vi.fn() };
@@ -14,7 +13,7 @@ const deps = { access: mockAccess, companies: mockCompanies, agents: mockAgents,
 describe("onboardingOrchestrator.bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com" });
+    mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com", name: "Alice Anderson" });
     mockAccess.listUserCompanyAccess.mockResolvedValue([]);
     mockCompanies.create.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
     mockCompanies.getById.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
@@ -41,36 +40,45 @@ describe("onboardingOrchestrator.bootstrap", () => {
     expect(mockConversations.addParticipant).toHaveBeenCalledWith("conv-1", "user-1", "owner");
   });
 
-  it("posts a 4-message welcome sequence (3 plain + 1 interview card) when the conversation is fresh", async () => {
+  it("posts ONE Phase 0 greeting (greeting + role + first goal question) when the conversation is fresh", async () => {
+    // Phase 0 of the spec at
+    // docs/superpowers/specs/2026-05-04-cos-onboarding-conversation-design.md.
+    // The opening turn collapses greeting + context + first question into one
+    // message — anything more reads like a robot survey, per the user's
+    // feedback after the previous 4-bubble version.
     await onboardingOrchestrator(deps as any).bootstrap("user-1");
-    expect(mockConversations.postMessage).toHaveBeenCalledTimes(4);
-    const calls = mockConversations.postMessage.mock.calls.map((c) => c[0]);
-    // First three: plain agent bubbles authored by the CoS, no card.
-    for (let i = 0; i < 3; i++) {
-      expect(calls[i]).toMatchObject({
-        conversationId: "conv-1",
-        authorKind: "agent",
-        authorId: "agent-cos-1",
-      });
-      expect(calls[i].cardKind).toBeUndefined();
-      expect(typeof calls[i].body).toBe("string");
-      expect(calls[i].body.length).toBeGreaterThan(0);
-    }
-    // Fourth: the first fixed interview question, rendered as an interview card.
-    expect(calls[3]).toMatchObject({
+    expect(mockConversations.postMessage).toHaveBeenCalledTimes(1);
+    const call = mockConversations.postMessage.mock.calls[0][0];
+    expect(call).toMatchObject({
       conversationId: "conv-1",
       authorKind: "agent",
       authorId: "agent-cos-1",
-      body: FIXED_QUESTIONS[0],
-      cardKind: "interview_question_v1",
-      cardPayload: { question: FIXED_QUESTIONS[0], fixedIndex: 0 },
     });
+    expect(call.cardKind).toBeUndefined();
+    // Personalized salutation uses the user's first name.
+    expect(call.body).toContain("Alice");
+    // Identifies the agent role.
+    expect(call.body).toMatch(/chief of staff/i);
+    // Sets context for what AgentDash is and why this conversation exists.
+    expect(call.body).toMatch(/agentdash/i);
+    // Asks the first goal question (short-term + long-term framing).
+    expect(call.body).toMatch(/short-term/i);
+    expect(call.body).toMatch(/6.?12 months|long-?term/i);
+  });
+
+  it("falls back to a generic salutation when the user has no name", async () => {
+    mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com", name: null });
+    await onboardingOrchestrator(deps as any).bootstrap("user-1");
+    const call = mockConversations.postMessage.mock.calls[0][0];
+    // No name → "Hi there!" rather than "Hi {firstName}!".
+    expect(call.body).toMatch(/^Hi there!/);
+    expect(call.body).not.toMatch(/^Hi null/);
   });
 
   it("is idempotent — second call returns existing artifacts (user-membership check, NOT domain lookup) and posts NO welcome messages", async () => {
     await onboardingOrchestrator(deps as any).bootstrap("user-1");
     vi.clearAllMocks();
-    mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com" });
+    mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com", name: "Alice Anderson" });
     // Second call: user already has an active membership — reuse that company.
     mockAccess.listUserCompanyAccess.mockResolvedValue([{ companyId: "company-1", status: "active", principalId: "user-1" }]);
     mockCompanies.getById.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -1,41 +1,40 @@
 import { logger } from "../middleware/logger.js";
-import { FIXED_QUESTIONS, deriveCompanyEmailDomain } from "@paperclipai/shared";
+import { deriveCompanyEmailDomain } from "@paperclipai/shared";
 
-// Welcome sequence: three plain context-setting bubbles + the first interview card.
-// Posted atomically inside bootstrap() the FIRST time a conversation is created
-// for a workspace, so concurrent bootstrap calls (auth hook + UI useEffect under
-// React StrictMode) cannot duplicate it. The three plain bubbles use cardKind=null
-// and render as normal agent text bubbles; the final card keeps the existing
-// interview_question_v1 machinery so the rest of the interview flow still works.
-const WELCOME_INTRO_LINES = [
-  "Hi! I'm your Chief of Staff.",
-  "Welcome to AgentDash. I'm here to help you build a team of AI agents — they handle real work the way employees would, on demand.",
-  "Before we get started, I want to understand what you're working on so I can suggest the right team for you.",
-] as const;
+// Phase 0 of the CoS-led onboarding flow (see
+// docs/superpowers/specs/2026-05-04-cos-onboarding-conversation-design.md).
+// One rich opening message — greeting + role + first goal question, in that
+// order — posted atomically inside bootstrap() the FIRST time a conversation
+// is created for a workspace. The atomicity is crucial: concurrent bootstrap
+// calls (auth-hook + UI `useEffect` under React StrictMode) all converge on
+// the existing conversation and skip the welcome.
+//
+// Why ONE message instead of four: the user's feedback was the previous
+// 4-bubble sequence read like a robot survey, not a conversation. A real
+// Chief of Staff introduces themselves and asks one substantive question.
+// Subsequent turns are LLM-driven (Phase 1+).
+
+function buildPhase0Greeting(userName: string | null | undefined): string {
+  const firstName = (userName ?? "").trim().split(/\s+/)[0] || null;
+  const salutation = firstName ? `Hi ${firstName}!` : "Hi there!";
+  return [
+    `${salutation} I'm your Chief of Staff at AgentDash.`,
+    `You're about to build out an AI workforce — agents that take on roles you'd normally hire employees for. My job is to figure out what kind of team you need and get them set up.`,
+    `To start, tell me what you're trying to accomplish. What's your top short-term goal, and where do you want this to be in 6–12 months?`,
+  ].join("\n\n");
+}
 
 async function postWelcomeSequence(
   conversations: any,
   conversationId: string,
   cosAgentId: string,
+  userName: string | null | undefined,
 ): Promise<void> {
-  // await between each post so DB-insert ordering reflects logical ordering.
-  for (const line of WELCOME_INTRO_LINES) {
-    await conversations.postMessage({
-      conversationId,
-      authorKind: "agent",
-      authorId: cosAgentId,
-      body: line,
-    });
-  }
-  // Final message: the first interview question, rendered as an interview card.
-  const firstQuestion = FIXED_QUESTIONS[0];
   await conversations.postMessage({
     conversationId,
     authorKind: "agent",
     authorId: cosAgentId,
-    body: firstQuestion,
-    cardKind: "interview_question_v1",
-    cardPayload: { question: firstQuestion, fixedIndex: 0 },
+    body: buildPhase0Greeting(userName),
   });
 }
 
@@ -197,7 +196,7 @@ export function onboardingOrchestrator(deps: Deps) {
       }
       await deps.conversations.addParticipant(conversation.id, userId, "owner");
       if (isFreshConversation) {
-        await postWelcomeSequence(deps.conversations, conversation.id, cos.id);
+        await postWelcomeSequence(deps.conversations, conversation.id, cos.id, user.name);
       }
 
       logger.info({ userId, companyId: company.id, cosAgentId: cos.id, conversationId: conversation.id }, "onboarding bootstrap complete");


### PR DESCRIPTION
## Summary
Implements **Phase A** from the [CoS onboarding conversation design spec](../blob/docs/cos-onboarding-conversation-spec/docs/superpowers/specs/2026-05-04-cos-onboarding-conversation-design.md).

The previous 4-bubble welcome (greet + welcome + context + interview card) read like a robot survey. The user asked for a real conversation opener instead: greeting + role + first goal question, all in one substantive message.

> Hi {firstName}! I'm your Chief of Staff at AgentDash.
>
> You're about to build out an AI workforce — agents that take on roles you'd normally hire employees for. My job is to figure out what kind of team you need and get them set up.
>
> To start, tell me what you're trying to accomplish. What's your top short-term goal, and where do you want this to be in 6–12 months?

- Personalized salutation uses the user's first name from `auth_users.name`; falls back to "Hi there!" when name is null
- Subsequent turns are LLM-driven via `dispatch-llm` — Phases 1+ in the spec land in a follow-up PR
- Atomicity preserved (posted inside `if (!conversation)` so concurrent bootstrap calls don't duplicate)
- `interview_question_v1` card kind no longer used by Phase 0 (just plain text); renderer stays in place for future code

## Test plan
- [x] `pnpm --filter @paperclipai/server exec vitest run onboarding-orchestrator` — 6/6 passing
- [x] `pnpm --filter @paperclipai/server exec vitest run onboarding-v2-routes` — 4/4 passing
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` — clean
- [ ] User: sign up on the mini, see one rich opening message instead of 4 bubbles

## Note on PR #135
That e2e test asserts the 4-message welcome that this PR removes. It needs rebasing or superseding by Phase E's persona-driven test before it can merge. Holding #135.