### PR TITLE
feat(cos-onboarding): Phase C — deep-interview engine

### DIFF
--- a/server/src/__tests__/deep-interview-engine.test.ts
+++ b/server/src/__tests__/deep-interview-engine.test.ts
@@ -1,0 +1,681 @@
+// AgentDash (Phase C): unit tests for the deep-interview engine state machine.
+//
+// We mock the Drizzle DB at the call-site level (select/insert/update returning
+// predictable shapes) and inject a stub dispatchLLM that returns canned
+// responses with valid JSON trailers. This keeps the test scope to engine
+// logic without standing up an embedded postgres.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  AMBIGUITY_THRESHOLD,
+  HARD_ROUND_CAP,
+  computeWeightedAmbiguity,
+  pickChallengeMode,
+  targetWeakestDimension,
+  allDimensionsDone,
+  nextOntologySnapshot,
+  deepInterviewEngine,
+  type EngineLLMDispatch,
+} from "../services/deep-interview-engine.js";
+import type {
+  DimensionScores,
+  OntologySnapshot,
+  TranscriptTurn,
+} from "@paperclipai/shared/deep-interview";
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Pure-helper tests
+// ---------------------------------------------------------------------------
+
+describe("computeWeightedAmbiguity", () => {
+  it("brownfield uses 35/25/25/15 weights", () => {
+    const dims: DimensionScores = {
+      goal: 1,
+      constraints: 1,
+      criteria: 1,
+      context: 1,
+    };
+    expect(computeWeightedAmbiguity(dims, true)).toBeCloseTo(0, 5);
+  });
+
+  it("brownfield with all-zeros yields ambiguity 1.0", () => {
+    const dims: DimensionScores = {
+      goal: 0,
+      constraints: 0,
+      criteria: 0,
+      context: 0,
+    };
+    expect(computeWeightedAmbiguity(dims, true)).toBeCloseTo(1, 5);
+  });
+
+  it("greenfield uses 40/30/30 weights and ignores context", () => {
+    const dims: DimensionScores = {
+      goal: 1,
+      constraints: 1,
+      criteria: 1,
+      context: 0,
+    };
+    // 1 - (1*0.4 + 1*0.3 + 1*0.3) = 0
+    expect(computeWeightedAmbiguity(dims, false)).toBeCloseTo(0, 5);
+  });
+
+  it("clamps non-finite or out-of-range inputs", () => {
+    const dims: DimensionScores = {
+      goal: Number.POSITIVE_INFINITY,
+      constraints: -10,
+      criteria: 2,
+      context: NaN,
+    };
+    const v = computeWeightedAmbiguity(dims, true);
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("targetWeakestDimension", () => {
+  it("returns 'goal' when all are equal (stable tiebreak)", () => {
+    const dims: DimensionScores = {
+      goal: 0.5,
+      constraints: 0.5,
+      criteria: 0.5,
+      context: 0.5,
+    };
+    expect(targetWeakestDimension(dims, true)).toBe("goal");
+  });
+
+  it("returns the lowest-scoring dim", () => {
+    const dims: DimensionScores = {
+      goal: 0.9,
+      constraints: 0.3,
+      criteria: 0.6,
+      context: 0.7,
+    };
+    expect(targetWeakestDimension(dims, true)).toBe("constraints");
+  });
+
+  it("ignores 'context' on greenfield", () => {
+    const dims: DimensionScores = {
+      goal: 0.9,
+      constraints: 0.5,
+      criteria: 0.4,
+      context: 0.0,
+    };
+    expect(targetWeakestDimension(dims, false)).toBe("criteria");
+  });
+
+  it("falls back to 'goal' when dims are null", () => {
+    expect(targetWeakestDimension(null, true)).toBe("goal");
+  });
+});
+
+describe("pickChallengeMode", () => {
+  it("returns 'contrarian' on round 4 if not used", () => {
+    expect(pickChallengeMode(4, [], 0.6)).toBe("contrarian");
+  });
+
+  it("does not re-fire a mode that's already in challengeModesUsed", () => {
+    expect(pickChallengeMode(4, ["contrarian"], 0.6)).toBeNull();
+  });
+
+  it("returns 'simplifier' on round 6", () => {
+    expect(pickChallengeMode(6, ["contrarian"], 0.6)).toBe("simplifier");
+  });
+
+  it("returns 'ontologist' on round 8 only when ambiguity > 0.3", () => {
+    expect(pickChallengeMode(8, [], 0.5)).toBe("ontologist");
+    expect(pickChallengeMode(8, [], 0.2)).toBeNull();
+  });
+
+  it("returns null on rounds without a configured challenge", () => {
+    expect(pickChallengeMode(1, [], 0.5)).toBeNull();
+    expect(pickChallengeMode(7, [], 0.5)).toBeNull();
+    expect(pickChallengeMode(20, [], 0.5)).toBeNull();
+  });
+});
+
+describe("allDimensionsDone", () => {
+  it("requires all four dims ≥ 0.9 on brownfield", () => {
+    expect(
+      allDimensionsDone(
+        { goal: 0.95, constraints: 0.95, criteria: 0.95, context: 0.95 },
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      allDimensionsDone(
+        { goal: 0.95, constraints: 0.95, criteria: 0.95, context: 0.5 },
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores 'context' on greenfield", () => {
+    expect(
+      allDimensionsDone(
+        { goal: 0.95, constraints: 0.95, criteria: 0.95, context: 0 },
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when dims is null", () => {
+    expect(allDimensionsDone(null, true)).toBe(false);
+  });
+});
+
+describe("nextOntologySnapshot", () => {
+  it("returns null stabilityRatio for the first snapshot", () => {
+    const snap = nextOntologySnapshot(
+      [],
+      [{ name: "Customer", type: "core_domain" }],
+      1,
+    );
+    expect(snap.round).toBe(1);
+    expect(snap.entities).toHaveLength(1);
+    expect(snap.newCount).toBe(1);
+    expect(snap.stabilityRatio).toBeNull();
+  });
+
+  it("computes stabilityRatio against prior snapshot", () => {
+    const prev: OntologySnapshot[] = [
+      {
+        round: 1,
+        entities: [
+          { name: "Customer", type: "core_domain" },
+          { name: "Order", type: "core_domain" },
+        ],
+        newCount: 2,
+        changedCount: 0,
+        stableCount: 0,
+        stabilityRatio: null,
+      },
+    ];
+    // Add a third entity, keep the other two unchanged.
+    const next = nextOntologySnapshot(
+      prev,
+      [{ name: "Product", type: "core_domain" }],
+      2,
+    );
+    // 2 stable / 3 total = 0.666...
+    expect(next.entities).toHaveLength(3);
+    expect(next.newCount).toBe(1);
+    expect(next.stableCount).toBe(2);
+    expect(next.stabilityRatio).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("counts changed entities (same name, different fields) correctly", () => {
+    const prev: OntologySnapshot[] = [
+      {
+        round: 1,
+        entities: [{ name: "Customer", type: "core_domain", fields: ["id"] }],
+        newCount: 1,
+        changedCount: 0,
+        stableCount: 0,
+        stabilityRatio: null,
+      },
+    ];
+    const next = nextOntologySnapshot(
+      prev,
+      [{ name: "Customer", type: "core_domain", fields: ["id", "email"] }],
+      2,
+    );
+    expect(next.changedCount).toBe(1);
+    expect(next.newCount).toBe(0);
+    expect(next.stableCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine integration with mocked DB + stub LLM
+// ---------------------------------------------------------------------------
+
+interface FakeStateRow {
+  id: string;
+  scope: string;
+  scopeRefId: string;
+  status: string;
+  currentRound: number;
+  ambiguityScore: number | null;
+  dimensionScores: DimensionScores | null;
+  ontologySnapshots: OntologySnapshot[];
+  challengeModesUsed: string[];
+  transcript: TranscriptTurn[];
+}
+
+function makeStateRow(overrides?: Partial<FakeStateRow>): FakeStateRow {
+  return {
+    id: "state-aaaa-bbbb",
+    scope: "cos_onboarding",
+    scopeRefId: "ref-1234",
+    status: "in_progress",
+    currentRound: 0,
+    ambiguityScore: null,
+    dimensionScores: null,
+    ontologySnapshots: [],
+    challengeModesUsed: [],
+    transcript: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Build a Drizzle-shaped fake DB. The engine calls:
+ *   - db.select().from(...).where(...).limit(1)
+ *   - db.insert(...).values(...).returning()
+ *   - db.update(...).set(...).where(...)
+ *
+ * We intercept by chaining thenable objects.
+ */
+function makeFakeDb(stateRow: FakeStateRow | null) {
+  let current: FakeStateRow | null = stateRow;
+  let lastInsertedSpec: { id: string; stateId: string } | null = null;
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+
+  const selectChain = () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => (current ? [current] : []),
+      }),
+    }),
+  });
+
+  const insertChain = (_table: unknown) => {
+    return {
+      values: (val: Record<string, unknown>) => ({
+        returning: async () => {
+          // Discriminate by shape: specs always carry stateId + finalAmbiguity;
+          // states carry scope + scopeRefId.
+          const isSpec = "stateId" in val && "finalAmbiguity" in val;
+          const tableName = isSpec ? "deep_interview_specs" : "deep_interview_states";
+          insertCalls.push({ table: tableName, ...val });
+          if (isSpec) {
+            lastInsertedSpec = {
+              id: "spec-xxxx-yyyy",
+              stateId: (val.stateId as string) ?? "",
+            };
+            return [{ id: lastInsertedSpec.id, ...val }];
+          }
+          current = {
+            id: "state-aaaa-bbbb",
+            scope: (val.scope as string) ?? "cos_onboarding",
+            scopeRefId: (val.scopeRefId as string) ?? "ref-1234",
+            status: "in_progress",
+            currentRound: 0,
+            ambiguityScore: null,
+            dimensionScores: null,
+            ontologySnapshots: [],
+            challengeModesUsed: [],
+            transcript: [],
+          };
+          return [{ ...current }];
+        },
+      }),
+    };
+  };
+
+  const updateChain = () => ({
+    set: (patch: Record<string, unknown>) => {
+      updateCalls.push(patch);
+      // Apply patch in-place so subsequent select() reads see it.
+      if (current) {
+        const dropUpdatedAt = { ...patch };
+        delete dropUpdatedAt.updatedAt;
+        Object.assign(current, dropUpdatedAt);
+      }
+      return {
+        where: async () => undefined,
+      };
+    },
+  });
+
+  return {
+    db: {
+      select: selectChain,
+      insert: insertChain,
+      update: updateChain,
+    } as unknown as Parameters<typeof deepInterviewEngine>[0]["db"],
+    // Probes for assertions:
+    getCurrent: () => current,
+    getLastSpec: () => lastInsertedSpec,
+    getUpdateCalls: () => updateCalls,
+    getInsertCalls: () => insertCalls,
+  };
+}
+
+function trailerJson(payload: {
+  ambiguity_score: number;
+  dimensions: DimensionScores;
+  ontology_delta?: Array<Record<string, unknown>>;
+  next_phase?: string;
+  action?: string;
+}): string {
+  return [
+    "Here is my next question. What outcomes matter most?",
+    "",
+    "```json",
+    JSON.stringify({
+      ambiguity_score: payload.ambiguity_score,
+      dimensions: payload.dimensions,
+      ontology_delta: payload.ontology_delta ?? [],
+      next_phase: payload.next_phase ?? "continue",
+      action: payload.action ?? "ask_next",
+    }),
+    "```",
+  ].join("\n");
+}
+
+describe("deepInterviewEngine.nextTurn — happy path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("first turn creates the row, increments to round 1, persists dim scores", async () => {
+    const fake = makeFakeDb(null);
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(
+      trailerJson({
+        ambiguity_score: 0.85,
+        dimensions: { goal: 0.3, constraints: 0.1, criteria: 0.1, context: 0.1 },
+        ontology_delta: [{ name: "Customer", type: "core_domain" }],
+      }),
+    );
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn({
+      scope: "cos_onboarding",
+      scopeRefId: "ref-1234",
+      userId: "user-1",
+      companyId: "company-1",
+      initialIdea: "Build a CRM",
+      adapter: "claude_api",
+    });
+
+    expect(result.kind).toBe("question");
+    expect(result.round).toBe(0); // No userAnswer ⇒ round stays at 0; engine asks the seed question.
+    expect(llm).toHaveBeenCalledTimes(1);
+    const updates = fake.getUpdateCalls();
+    expect(updates.length).toBeGreaterThan(0);
+    expect(updates[0]!.dimensionScores).toEqual({
+      goal: 0.3,
+      constraints: 0.1,
+      criteria: 0.1,
+      context: 0.1,
+    });
+  });
+
+  it("subsequent turn with userAnswer increments currentRound", async () => {
+    const fake = makeFakeDb(
+      makeStateRow({
+        currentRound: 1,
+        ambiguityScore: 0.8,
+        dimensionScores: { goal: 0.3, constraints: 0.1, criteria: 0.1, context: 0.1 },
+        transcript: [
+          {
+            round: 1,
+            question: "What outcomes matter most?",
+            targetDimension: "goal",
+            answer: "",
+            ambiguityAfter: 0.8,
+          },
+        ],
+      }),
+    );
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(
+      trailerJson({
+        ambiguity_score: 0.6,
+        dimensions: { goal: 0.6, constraints: 0.4, criteria: 0.3, context: 0.2 },
+      }),
+    );
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn({
+      scope: "cos_onboarding",
+      scopeRefId: "ref-1234",
+      userId: "user-1",
+      companyId: "company-1",
+      initialIdea: "Build a CRM",
+      adapter: "claude_api",
+      userAnswer: "Top of funnel growth.",
+    });
+
+    expect(result.kind).toBe("question");
+    expect(result.round).toBe(2);
+    expect(result.ambiguityScore).toBeCloseTo(0.6);
+  });
+});
+
+describe("deepInterviewEngine.nextTurn — termination conditions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flips to ready_to_crystallize when ambiguity drops to threshold", async () => {
+    const fake = makeFakeDb(
+      makeStateRow({
+        currentRound: 5,
+        ambiguityScore: 0.4,
+        dimensionScores: { goal: 0.6, constraints: 0.5, criteria: 0.5, context: 0.4 },
+        transcript: [
+          {
+            round: 5,
+            question: "Last Q?",
+            targetDimension: "goal",
+            answer: "",
+            ambiguityAfter: 0.4,
+          },
+        ],
+      }),
+    );
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(
+      trailerJson({
+        ambiguity_score: AMBIGUITY_THRESHOLD - 0.05,
+        dimensions: { goal: 0.95, constraints: 0.9, criteria: 0.9, context: 0.85 },
+      }),
+    );
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn({
+      scope: "cos_onboarding",
+      scopeRefId: "ref-1234",
+      userId: "user-1",
+      companyId: "company-1",
+      initialIdea: "X",
+      adapter: "claude_api",
+      userAnswer: "Final answer",
+    });
+
+    expect(result.kind).toBe("ready_to_crystallize");
+    expect(result.ambiguityScore).toBeLessThanOrEqual(AMBIGUITY_THRESHOLD);
+    const updates = fake.getUpdateCalls();
+    expect(updates[updates.length - 1]!.status).toBe("ready_to_crystallize");
+  });
+
+  it("flips to ready_to_crystallize at round HARD_ROUND_CAP", async () => {
+    const fake = makeFakeDb(
+      makeStateRow({
+        currentRound: HARD_ROUND_CAP - 1,
+        ambiguityScore: 0.7,
+        dimensionScores: { goal: 0.5, constraints: 0.5, criteria: 0.5, context: 0.5 },
+        transcript: [
+          {
+            round: HARD_ROUND_CAP - 1,
+            question: "Q19?",
+            targetDimension: "goal",
+            answer: "",
+            ambiguityAfter: 0.7,
+          },
+        ],
+      }),
+    );
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(
+      trailerJson({
+        ambiguity_score: 0.7,
+        dimensions: { goal: 0.5, constraints: 0.5, criteria: 0.5, context: 0.5 },
+      }),
+    );
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn({
+      scope: "cos_onboarding",
+      scopeRefId: "ref-1234",
+      userId: "user-1",
+      companyId: "company-1",
+      initialIdea: "X",
+      adapter: "claude_api",
+      userAnswer: "Last allowed answer",
+    });
+
+    expect(result.kind).toBe("ready_to_crystallize");
+    expect(result.round).toBe(HARD_ROUND_CAP);
+  });
+});
+
+describe("deepInterviewEngine.nextTurn — malformed trailer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not crash when LLM omits the JSON trailer", async () => {
+    const fake = makeFakeDb(makeStateRow());
+    const llm: EngineLLMDispatch = vi
+      .fn()
+      .mockResolvedValue("Just prose. No JSON trailer at all.");
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    await expect(
+      engine.nextTurn({
+        scope: "cos_onboarding",
+        scopeRefId: "ref-1234",
+        userId: "user-1",
+        companyId: "company-1",
+        initialIdea: "X",
+        adapter: "claude_api",
+      }),
+    ).resolves.toMatchObject({ kind: "question" });
+    // It should still persist a turn, falling back to derived ambiguity from
+    // existing dims (zeros yield 1.0).
+    const updates = fake.getUpdateCalls();
+    expect(updates.length).toBeGreaterThan(0);
+    const lastAmbiguity = updates[updates.length - 1]!.ambiguityScore;
+    expect(typeof lastAmbiguity).toBe("number");
+  });
+
+  it("does not crash on garbled JSON trailer", async () => {
+    const fake = makeFakeDb(makeStateRow());
+    const llm: EngineLLMDispatch = vi
+      .fn()
+      .mockResolvedValue('Body\n\n```json\n{"ambiguity_score": "not a number"}\n```');
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    await expect(
+      engine.nextTurn({
+        scope: "cos_onboarding",
+        scopeRefId: "ref-1234",
+        userId: "user-1",
+        companyId: "company-1",
+        initialIdea: "X",
+        adapter: "claude_api",
+      }),
+    ).resolves.toMatchObject({ kind: "question" });
+  });
+});
+
+describe("deepInterviewEngine.crystallize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inserts a deep_interview_specs row and flips status='crystallized'", async () => {
+    const fake = makeFakeDb(
+      makeStateRow({
+        status: "ready_to_crystallize",
+        currentRound: 5,
+        ambiguityScore: 0.15,
+        dimensionScores: { goal: 0.95, constraints: 0.9, criteria: 0.9, context: 0.85 },
+        ontologySnapshots: [
+          {
+            round: 5,
+            entities: [{ name: "Customer", type: "core_domain" }],
+            newCount: 1,
+            changedCount: 0,
+            stableCount: 0,
+            stabilityRatio: null,
+          },
+        ],
+        transcript: [
+          {
+            round: 1,
+            question: "Goal?",
+            targetDimension: "goal",
+            answer: "Grow ARR",
+            ambiguityAfter: 0.6,
+          },
+          {
+            round: 2,
+            question: "Constraints?",
+            targetDimension: "constraints",
+            answer: "No PII storage",
+            ambiguityAfter: 0.4,
+          },
+          {
+            round: 3,
+            question: "Criteria?",
+            targetDimension: "criteria",
+            answer: "10x faster than baseline",
+            ambiguityAfter: 0.2,
+          },
+        ],
+      }),
+    );
+    // crystallize() does not call the LLM.
+    const llm: EngineLLMDispatch = vi.fn();
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const out = await engine.crystallize("state-aaaa-bbbb");
+    expect(out.specId).toBe("spec-xxxx-yyyy");
+    expect(out.stateId).toBe("state-aaaa-bbbb");
+    expect(llm).not.toHaveBeenCalled();
+
+    const inserts = fake.getInsertCalls();
+    const specInsert = inserts.find((i) => i.table === "deep_interview_specs");
+    expect(specInsert).toBeDefined();
+    expect(specInsert!.goal).toBe("Grow ARR");
+    expect(specInsert!.constraints).toEqual(["No PII storage"]);
+    expect(specInsert!.criteria).toEqual(["10x faster than baseline"]);
+    // status update emitted with crystallized.
+    const updates = fake.getUpdateCalls();
+    expect(updates[updates.length - 1]!.status).toBe("crystallized");
+  });
+
+  it("throws when state row does not exist", async () => {
+    const fake = makeFakeDb(null);
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: vi.fn() });
+    await expect(engine.crystallize("nope")).rejects.toThrow(/not found/);
+  });
+});
+
+describe("deepInterviewEngine.getInProgress", () => {
+  it("returns the row for matching (scope, scopeRefId)", async () => {
+    const fake = makeFakeDb(makeStateRow({ currentRound: 3 }));
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: vi.fn() });
+    const row = await engine.getInProgress("cos_onboarding", "ref-1234");
+    expect(row).not.toBeNull();
+    expect(row!.currentRound).toBe(3);
+  });
+
+  it("returns null when no row exists", async () => {
+    const fake = makeFakeDb(null);
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: vi.fn() });
+    const row = await engine.getInProgress("cos_onboarding", "ref-9999");
+    expect(row).toBeNull();
+  });
+});

--- a/server/src/__tests__/deep-interview-parser.test.ts
+++ b/server/src/__tests__/deep-interview-parser.test.ts
@@ -1,0 +1,172 @@
+// AgentDash (Phase C): unit tests for the JSON-trailer parser.
+//
+// Round-trip: a fake LLM response with a valid trailer parses + strips body.
+// Malformed inputs return null trailer, never crash.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseJsonTrailer, type TrailerPayload } from "../services/deep-interview-parser.js";
+
+// Silence the parser's own warn logs during tests so the output is readable.
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const VALID_TRAILER: TrailerPayload = {
+  ambiguity_score: 0.42,
+  dimensions: { goal: 0.7, constraints: 0.5, criteria: 0.4, context: 0.6 },
+  ontology_delta: [
+    {
+      name: "Customer",
+      type: "core_domain",
+      fields: ["id", "email"],
+      relationships: ["Order"],
+    },
+  ],
+  next_phase: "continue",
+  action: "ask_next",
+};
+
+function buildResponse(body: string, trailer: TrailerPayload): string {
+  return `${body}\n\n\`\`\`json\n${JSON.stringify(trailer, null, 2)}\n\`\`\``;
+}
+
+describe("parseJsonTrailer — valid trailers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("round-trips a well-formed trailer and strips the fenced block", () => {
+    const raw = buildResponse(
+      "Here is my next question. Do you support multi-tenant?",
+      VALID_TRAILER,
+    );
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).not.toBeNull();
+    expect(result.trailer!.ambiguity_score).toBeCloseTo(0.42);
+    expect(result.trailer!.dimensions.goal).toBeCloseTo(0.7);
+    expect(result.trailer!.ontology_delta).toHaveLength(1);
+    expect(result.trailer!.ontology_delta[0]!.name).toBe("Customer");
+    // visibleBody must NOT contain the fenced block.
+    expect(result.visibleBody).not.toContain("```json");
+    expect(result.visibleBody).toContain("Do you support multi-tenant?");
+  });
+
+  it("accepts trailer without optional 'action' field", () => {
+    const trailer: TrailerPayload = { ...VALID_TRAILER };
+    delete (trailer as Partial<TrailerPayload>).action;
+    const raw = buildResponse("Question?", trailer);
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).not.toBeNull();
+    expect(result.trailer!.action).toBeUndefined();
+  });
+
+  it("accepts all four next_phase challenge values", () => {
+    for (const phase of [
+      "continue",
+      "crystallize",
+      "challenge:contrarian",
+      "challenge:simplifier",
+      "challenge:ontologist",
+    ] as const) {
+      const trailer: TrailerPayload = { ...VALID_TRAILER, next_phase: phase };
+      const raw = buildResponse("Q?", trailer);
+      const result = parseJsonTrailer(raw);
+      expect(result.trailer, `phase ${phase}`).not.toBeNull();
+      expect(result.trailer!.next_phase).toBe(phase);
+    }
+  });
+});
+
+describe("parseJsonTrailer — malformed inputs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null trailer when fence is missing", () => {
+    const result = parseJsonTrailer("Just prose, no fence at all.");
+    expect(result.trailer).toBeNull();
+    expect(result.visibleBody).toBe("Just prose, no fence at all.");
+  });
+
+  it("returns null trailer when JSON is unterminated", () => {
+    const raw = 'Body\n\n```json\n{"ambiguity_score": 0.5, "dim';
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).toBeNull();
+  });
+
+  it("returns null trailer when trailer payload is non-object", () => {
+    const raw = "Body\n\n```json\n42\n```";
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).toBeNull();
+  });
+
+  it("returns null trailer when ambiguity_score is missing", () => {
+    const raw = `Body\n\n\`\`\`json\n${JSON.stringify({
+      dimensions: VALID_TRAILER.dimensions,
+      ontology_delta: [],
+      next_phase: "continue",
+    })}\n\`\`\``;
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).toBeNull();
+  });
+
+  it("returns null trailer when next_phase is unknown", () => {
+    const raw = buildResponse("Q?", {
+      ...VALID_TRAILER,
+      // @ts-expect-error testing rejection of unknown phase
+      next_phase: "nonsense",
+    });
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).toBeNull();
+  });
+
+  it("returns null trailer when ontology entity has wrong type", () => {
+    const raw = buildResponse("Q?", {
+      ...VALID_TRAILER,
+      // @ts-expect-error testing rejection of unknown ontology type
+      ontology_delta: [{ name: "X", type: "garbage" }],
+    });
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).toBeNull();
+  });
+
+  it("returns null trailer when dimensions are non-numeric", () => {
+    const raw = buildResponse("Q?", {
+      ...VALID_TRAILER,
+      // @ts-expect-error testing rejection of non-numeric dim
+      dimensions: { goal: "high", constraints: 0.5, criteria: 0.4, context: 0.6 },
+    });
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).toBeNull();
+  });
+
+  it("never throws on completely empty input", () => {
+    expect(() => parseJsonTrailer("")).not.toThrow();
+    const result = parseJsonTrailer("");
+    expect(result.trailer).toBeNull();
+    expect(result.visibleBody).toBe("");
+  });
+});
+
+describe("parseJsonTrailer — body extraction edge cases", () => {
+  it("strips trailing whitespace from visibleBody", () => {
+    const raw = `Body line   \n\n\`\`\`json\n${JSON.stringify(VALID_TRAILER)}\n\`\`\`   `;
+    const result = parseJsonTrailer(raw);
+    expect(result.visibleBody.endsWith(" ")).toBe(false);
+    expect(result.visibleBody).toBe("Body line");
+  });
+
+  it("matches only the LAST fenced json block when multiple appear", () => {
+    const raw = `Pre block\n\`\`\`json\n{"foo":1}\n\`\`\`\nMid\n\`\`\`json\n${JSON.stringify(
+      VALID_TRAILER,
+    )}\n\`\`\``;
+    const result = parseJsonTrailer(raw);
+    expect(result.trailer).not.toBeNull();
+    expect(result.trailer!.ambiguity_score).toBeCloseTo(0.42);
+  });
+});

--- a/server/src/__tests__/deep-interview-prompts.test.ts
+++ b/server/src/__tests__/deep-interview-prompts.test.ts
@@ -1,0 +1,253 @@
+// AgentDash (Phase C): unit tests for deep-interview prompt composition.
+//
+// HARD acceptance gates (Phase C #7):
+//   - composePrompt({ adapter: "claude_api" }).system contains SKILL_MD_FULL
+//   - composePrompt({ adapter: "hermes_local" }).system contains SKILL_MD_SUMMARY
+// Both checks are string-equality assertions — comments / "should" hand-waves
+// are not acceptable.
+
+import { describe, it, expect } from "vitest";
+import {
+  SKILL_MD_FULL,
+  SKILL_MD_SUMMARY,
+} from "@paperclipai/shared/deep-interview-skill";
+import {
+  composePrompt,
+  selectPromptDepth,
+  type DeepInterviewStateRow,
+} from "../services/deep-interview-prompts.js";
+
+function makeState(
+  overrides?: Partial<DeepInterviewStateRow>,
+): DeepInterviewStateRow {
+  return {
+    scope: "cos_onboarding",
+    scopeRefId: "11111111-1111-1111-1111-111111111111",
+    currentRound: 1,
+    ambiguityScore: null,
+    dimensionScores: null,
+    ontologySnapshots: [],
+    challengeModesUsed: [],
+    transcript: [],
+    brownfield: false,
+    initialIdea: "Build a CRM for dentists.",
+    ...overrides,
+  };
+}
+
+describe("selectPromptDepth", () => {
+  it("returns 'full' only for claude_api", () => {
+    expect(selectPromptDepth("claude_api")).toBe("full");
+  });
+
+  it("returns 'summary' for hermes_local", () => {
+    expect(selectPromptDepth("hermes_local")).toBe("summary");
+  });
+
+  it("returns 'summary' for claude_local", () => {
+    expect(selectPromptDepth("claude_local")).toBe("summary");
+  });
+
+  it("returns 'summary' for codex_local / gemini_local / cursor", () => {
+    expect(selectPromptDepth("codex_local")).toBe("summary");
+    expect(selectPromptDepth("gemini_local")).toBe("summary");
+    expect(selectPromptDepth("cursor")).toBe("summary");
+  });
+
+  it("returns 'summary' for an unknown adapter (default-safe)", () => {
+    expect(selectPromptDepth("nonexistent_adapter_xyz")).toBe("summary");
+  });
+});
+
+describe("composePrompt — Phase C acceptance #7 (HARD)", () => {
+  it("claude_api ships SKILL_MD_FULL verbatim", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState(),
+    });
+    expect(composed.system.includes(SKILL_MD_FULL)).toBe(true);
+    // And does NOT regress to the summary.
+    expect(composed.system.startsWith(SKILL_MD_FULL)).toBe(true);
+  });
+
+  it("hermes_local ships SKILL_MD_SUMMARY verbatim", () => {
+    const composed = composePrompt({
+      adapter: "hermes_local",
+      phase: "ask_question",
+      state: makeState(),
+    });
+    expect(composed.system.includes(SKILL_MD_SUMMARY)).toBe(true);
+    expect(composed.system.startsWith(SKILL_MD_SUMMARY)).toBe(true);
+    // And the system prompt must NOT contain the full SKILL.md (the
+    // distinguishing token-budget invariant — Pre-mortem #4).
+    // Use the fingerprint of SKILL_MD_FULL that does NOT also appear in the
+    // summary: the bracketed "next-skill-args" front-matter line is unique
+    // to the full corpus.
+    expect(composed.system).not.toContain("next-skill-args: --consensus --direct");
+  });
+
+  it("claude_local ships SKILL_MD_SUMMARY (also a spawn adapter)", () => {
+    const composed = composePrompt({
+      adapter: "claude_local",
+      phase: "ask_question",
+      state: makeState(),
+    });
+    expect(composed.system.includes(SKILL_MD_SUMMARY)).toBe(true);
+  });
+});
+
+describe("composePrompt — challenge modes", () => {
+  it("does not inject any challenge fragment when challengeMode is omitted", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({ currentRound: 4, challengeModesUsed: [] }),
+    });
+    expect(composed.system).not.toContain("[CHALLENGE — Contrarian]");
+    expect(composed.system).not.toContain("[CHALLENGE — Simplifier]");
+    expect(composed.system).not.toContain("[CHALLENGE — Ontologist]");
+  });
+
+  it("injects the contrarian fragment when challengeMode='contrarian'", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({ currentRound: 4, challengeModesUsed: [] }),
+      challengeMode: "contrarian",
+    });
+    expect(composed.system).toContain("[CHALLENGE — Contrarian]");
+  });
+
+  it("injects the simplifier fragment when challengeMode='simplifier'", () => {
+    const composed = composePrompt({
+      adapter: "hermes_local",
+      phase: "ask_question",
+      state: makeState({ currentRound: 6, challengeModesUsed: ["contrarian"] }),
+      challengeMode: "simplifier",
+    });
+    expect(composed.system).toContain("[CHALLENGE — Simplifier]");
+  });
+
+  it("injects the ontologist fragment when challengeMode='ontologist'", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({
+        currentRound: 8,
+        ambiguityScore: 0.45,
+        challengeModesUsed: ["contrarian", "simplifier"],
+      }),
+      challengeMode: "ontologist",
+    });
+    expect(composed.system).toContain("[CHALLENGE — Ontologist]");
+  });
+});
+
+describe("composePrompt — scope framing", () => {
+  it("brownfield mode states the 35/25/25/15 weighting", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({ brownfield: true }),
+    });
+    const modeLine = composed.system
+      .split("\n")
+      .find((line) => line.startsWith("[Mode]"));
+    expect(modeLine).toBeDefined();
+    expect(modeLine).toContain("Brownfield");
+    expect(modeLine).toContain("0.35");
+    expect(modeLine).toContain("0.25");
+    expect(modeLine).toContain("0.15");
+  });
+
+  it("greenfield mode states the 40/30/30 weighting and drops context", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({ brownfield: false }),
+    });
+    // Pull out only the [Mode] line; SKILL.md itself mentions various
+    // numbers (including 0.15) so we have to scope the assertion to the
+    // engine's own scope-framing fragment.
+    const modeLine = composed.system
+      .split("\n")
+      .find((line) => line.startsWith("[Mode]"));
+    expect(modeLine).toBeDefined();
+    expect(modeLine).toContain("Greenfield");
+    expect(modeLine).toContain("0.40");
+    expect(modeLine).toContain("0.30");
+    expect(modeLine).not.toContain("0.15");
+  });
+});
+
+describe("composePrompt — messages", () => {
+  it("seeds the conversation with the user's initial idea", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({ initialIdea: "I want to build X" }),
+    });
+    expect(composed.messages.length).toBe(1);
+    expect(composed.messages[0]!.role).toBe("user");
+    expect(composed.messages[0]!.content).toBe("I want to build X");
+  });
+
+  it("rebuilds prior turns as alternating assistant/user messages", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState({
+        currentRound: 2,
+        transcript: [
+          {
+            round: 1,
+            question: "Q1?",
+            targetDimension: "goal",
+            answer: "A1",
+            ambiguityAfter: 0.7,
+          },
+        ],
+      }),
+    });
+    // [user: idea, assistant: Q1, user: A1]
+    expect(composed.messages.length).toBe(3);
+    expect(composed.messages[1]!.role).toBe("assistant");
+    expect(composed.messages[1]!.content).toBe("Q1?");
+    expect(composed.messages[2]!.role).toBe("user");
+    expect(composed.messages[2]!.content).toBe("A1");
+  });
+});
+
+describe("composePrompt — phase-specific tasks", () => {
+  it("ask_question phase appends the response trailer contract", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "ask_question",
+      state: makeState(),
+    });
+    expect(composed.system).toContain("[Response contract]");
+    expect(composed.system).toContain("ambiguity_score");
+    expect(composed.system).toContain("ontology_delta");
+  });
+
+  it("score phase asks for trailer-only output", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "score",
+      state: makeState(),
+    });
+    expect(composed.system).toContain("Score the user's most recent answer");
+    expect(composed.system).toContain("[Response contract]");
+  });
+
+  it("crystallize phase asks for the final spec", () => {
+    const composed = composePrompt({
+      adapter: "claude_api",
+      phase: "crystallize",
+      state: makeState(),
+    });
+    expect(composed.system).toContain("converged");
+    expect(composed.system).toContain("non_goals");
+  });
+});

--- a/server/src/services/deep-interview-engine.ts
+++ b/server/src/services/deep-interview-engine.ts
@@ -1,0 +1,613 @@
+// AgentDash (Phase C): deep-interview engine — the Socratic loop orchestrator.
+//
+// One service entrypoint:
+//   nextTurn(input) → { question, ambiguityScore, dimensions, round, status, ... }
+//
+// Per-turn responsibilities:
+//   1. getOrCreate the deep_interview_states row keyed by (scope, scopeRefId).
+//   2. If a userAnswer is present, append it to the cached transcript and
+//      advance currentRound.
+//   3. Compose a prompt via composePrompt(); dispatch via the injected LLM.
+//   4. Parse the JSON trailer; update dimensionScores, ambiguityScore,
+//      ontologySnapshots, challengeModesUsed.
+//   5. Decide hard-stop (ambiguity ≤ threshold OR round ≥ 20 OR all dims ≥ 0.9):
+//      flip status to 'ready_to_crystallize' and return a marker.
+//   6. Otherwise return the next question for the UI to render.
+//
+// Cross-state-machine wiring (cos_onboarding_states.deep_interview_spec_id +
+// CoS phase advance) is Phase F's `crystallizeAndAdvanceCos` helper. Phase C
+// `crystallize()` only writes deep_interview_specs and flips
+// deep_interview_states.status — it does NOT touch cos_onboarding_states.
+//
+// See docs/superpowers/plans/2026-05-04-onboarding-redesign-deep-interview-plan.md
+// (Phase C) for the full design rationale.
+
+import { and, eq, sql } from "drizzle-orm";
+import {
+  deepInterviewSpecs,
+  deepInterviewStates,
+  type Db,
+} from "@paperclipai/db";
+import type { AgentAdapterType } from "@paperclipai/shared";
+import type {
+  ChallengeMode,
+  DeepInterviewScope,
+  DimensionScores,
+  OntologyEntity,
+  OntologySnapshot,
+  TranscriptTurn,
+} from "@paperclipai/shared/deep-interview";
+import { logger } from "../middleware/logger.js";
+import {
+  composePrompt,
+  type DeepInterviewStateRow as PromptStateRow,
+} from "./deep-interview-prompts.js";
+import {
+  parseJsonTrailer,
+  type TrailerPayload,
+} from "./deep-interview-parser.js";
+
+// ---------------------------------------------------------------------------
+// Tunables (kept explicit so they appear in tests + observability)
+// ---------------------------------------------------------------------------
+
+/** Crystallize when ambiguity drops to or below this. */
+export const AMBIGUITY_THRESHOLD = 0.2;
+
+/** Crystallize regardless of ambiguity once we hit this many rounds. */
+export const HARD_ROUND_CAP = 20;
+
+/** Crystallize when ALL dimension scores meet this. */
+export const ALL_DIMS_DONE_AT = 0.9;
+
+/** Round at which each challenge mode fires (used-once each). */
+const CHALLENGE_ROUNDS: Record<number, ChallengeMode> = {
+  4: "contrarian",
+  6: "simplifier",
+  8: "ontologist",
+};
+
+/** Brownfield weights — must sum to 1.0. */
+const BROWNFIELD_WEIGHTS = {
+  goal: 0.35,
+  constraints: 0.25,
+  criteria: 0.25,
+  context: 0.15,
+} as const;
+
+/** Greenfield weights — must sum to 1.0 across the three present dims. */
+const GREENFIELD_WEIGHTS = {
+  goal: 0.4,
+  constraints: 0.3,
+  criteria: 0.3,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type EngineLLMDispatch = (input: {
+  system: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+}) => Promise<string>;
+
+export interface NextTurnInput {
+  scope: DeepInterviewScope;
+  scopeRefId: string;
+  userId: string;
+  companyId: string;
+  initialIdea: string;
+  adapter: AgentAdapterType;
+  /** Set true on a brownfield idea (prior codebase context exists). */
+  brownfield?: boolean;
+  /** The user's answer to the previous turn. Omit on the very first call. */
+  userAnswer?: string;
+}
+
+export type NextTurnResult =
+  | {
+      kind: "question";
+      stateId: string;
+      round: number;
+      question: string;
+      ambiguityScore: number;
+      dimensions: DimensionScores;
+      challengeMode: ChallengeMode | null;
+      ontologyStability: number | null;
+    }
+  | {
+      kind: "ready_to_crystallize";
+      stateId: string;
+      round: number;
+      ambiguityScore: number;
+      dimensions: DimensionScores;
+    };
+
+export interface CrystallizeResult {
+  specId: string;
+  stateId: string;
+}
+
+export interface DeepInterviewEngine {
+  nextTurn(input: NextTurnInput): Promise<NextTurnResult>;
+  crystallize(stateId: string): Promise<CrystallizeResult>;
+  getInProgress(
+    scope: DeepInterviewScope,
+    scopeRefId: string,
+  ): Promise<DeepInterviewStateRow | null>;
+}
+
+export interface EngineDeps {
+  db: Db;
+  /**
+   * LLM dispatcher. Production wiring uses dispatchLLM from
+   * server/src/services/dispatch-llm.ts; tests inject a stub.
+   */
+  dispatchLLM: EngineLLMDispatch;
+}
+
+// Internal row shape — narrower than the Drizzle row type so the engine and
+// prompt builder share a structural contract.
+interface DeepInterviewStateRow {
+  id: string;
+  scope: DeepInterviewScope;
+  scopeRefId: string;
+  status: "in_progress" | "ready_to_crystallize" | "crystallized" | "abandoned";
+  currentRound: number;
+  ambiguityScore: number | null;
+  dimensionScores: DimensionScores | null;
+  ontologySnapshots: OntologySnapshot[];
+  challengeModesUsed: ChallengeMode[];
+  transcript: TranscriptTurn[];
+  initialIdea: string;
+  brownfield: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function computeWeightedAmbiguity(
+  dims: DimensionScores,
+  brownfield: boolean,
+): number {
+  const g = clamp01(dims.goal);
+  const c = clamp01(dims.constraints);
+  const cr = clamp01(dims.criteria);
+  if (brownfield) {
+    const ctx = clamp01(dims.context);
+    const clarity =
+      g * BROWNFIELD_WEIGHTS.goal +
+      c * BROWNFIELD_WEIGHTS.constraints +
+      cr * BROWNFIELD_WEIGHTS.criteria +
+      ctx * BROWNFIELD_WEIGHTS.context;
+    return clamp01(1 - clarity);
+  }
+  const clarity =
+    g * GREENFIELD_WEIGHTS.goal +
+    c * GREENFIELD_WEIGHTS.constraints +
+    cr * GREENFIELD_WEIGHTS.criteria;
+  return clamp01(1 - clarity);
+}
+
+function targetWeakestDimension(
+  dims: DimensionScores | null,
+  brownfield: boolean,
+): keyof DimensionScores {
+  if (!dims) return "goal";
+  const candidates: Array<[keyof DimensionScores, number]> = [
+    ["goal", dims.goal],
+    ["constraints", dims.constraints],
+    ["criteria", dims.criteria],
+  ];
+  if (brownfield) candidates.push(["context", dims.context]);
+  candidates.sort((a, b) => a[1] - b[1]);
+  return candidates[0]![0];
+}
+
+function allDimensionsDone(
+  dims: DimensionScores | null,
+  brownfield: boolean,
+): boolean {
+  if (!dims) return false;
+  if (
+    dims.goal < ALL_DIMS_DONE_AT ||
+    dims.constraints < ALL_DIMS_DONE_AT ||
+    dims.criteria < ALL_DIMS_DONE_AT
+  ) {
+    return false;
+  }
+  if (brownfield && dims.context < ALL_DIMS_DONE_AT) return false;
+  return true;
+}
+
+function pickChallengeMode(
+  round: number,
+  used: ChallengeMode[],
+  ambiguity: number | null,
+): ChallengeMode | null {
+  const candidate = CHALLENGE_ROUNDS[round];
+  if (!candidate) return null;
+  if (used.includes(candidate)) return null;
+  // Ontologist only fires when ambiguity is still meaningfully above threshold.
+  if (candidate === "ontologist" && (ambiguity ?? 1) <= 0.3) return null;
+  return candidate;
+}
+
+function mergeOntology(
+  prev: OntologyEntity[],
+  delta: OntologyEntity[],
+): { merged: OntologyEntity[]; newCount: number; changedCount: number; stableCount: number } {
+  const byName = new Map<string, OntologyEntity>();
+  for (const e of prev) byName.set(e.name, e);
+  let newCount = 0;
+  let changedCount = 0;
+  for (const e of delta) {
+    const existing = byName.get(e.name);
+    if (!existing) {
+      newCount += 1;
+      byName.set(e.name, e);
+      continue;
+    }
+    if (JSON.stringify(existing) !== JSON.stringify(e)) {
+      changedCount += 1;
+    }
+    byName.set(e.name, e);
+  }
+  const merged = Array.from(byName.values());
+  const stableCount = merged.length - newCount - changedCount;
+  return { merged, newCount, changedCount, stableCount: Math.max(0, stableCount) };
+}
+
+function nextOntologySnapshot(
+  prev: OntologySnapshot[],
+  delta: OntologyEntity[],
+  round: number,
+): OntologySnapshot {
+  const lastEntities = prev.length > 0 ? prev[prev.length - 1]!.entities : [];
+  const { merged, newCount, changedCount, stableCount } = mergeOntology(
+    lastEntities,
+    delta,
+  );
+  // Stability ratio: stable / total. Null on first snapshot (no prior round).
+  const total = merged.length;
+  const stabilityRatio = prev.length === 0 || total === 0 ? null : stableCount / total;
+  return {
+    round,
+    entities: merged,
+    newCount,
+    changedCount,
+    stableCount,
+    stabilityRatio,
+  };
+}
+
+function rowToInternal(row: typeof deepInterviewStates.$inferSelect, fallbackInitialIdea: string, brownfield: boolean): DeepInterviewStateRow {
+  return {
+    id: row.id,
+    scope: row.scope as DeepInterviewScope,
+    scopeRefId: row.scopeRefId,
+    status: (row.status as DeepInterviewStateRow["status"]) ?? "in_progress",
+    currentRound: row.currentRound,
+    ambiguityScore: row.ambiguityScore,
+    dimensionScores: (row.dimensionScores as DimensionScores | null) ?? null,
+    ontologySnapshots: (row.ontologySnapshots as OntologySnapshot[]) ?? [],
+    challengeModesUsed: (row.challengeModesUsed as ChallengeMode[]) ?? [],
+    transcript: (row.transcript as TranscriptTurn[]) ?? [],
+    initialIdea: fallbackInitialIdea,
+    brownfield,
+  };
+}
+
+function toPromptRow(row: DeepInterviewStateRow): PromptStateRow {
+  return {
+    scope: row.scope,
+    scopeRefId: row.scopeRefId,
+    currentRound: row.currentRound,
+    ambiguityScore: row.ambiguityScore,
+    dimensionScores: row.dimensionScores,
+    ontologySnapshots: row.ontologySnapshots,
+    challengeModesUsed: row.challengeModesUsed,
+    transcript: row.transcript,
+    brownfield: row.brownfield,
+    initialIdea: row.initialIdea,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service factory
+// ---------------------------------------------------------------------------
+
+export function deepInterviewEngine(deps: EngineDeps): DeepInterviewEngine {
+  const { db, dispatchLLM } = deps;
+
+  async function getOrCreateRow(
+    input: NextTurnInput,
+  ): Promise<DeepInterviewStateRow> {
+    const existing = await db
+      .select()
+      .from(deepInterviewStates)
+      .where(
+        and(
+          eq(deepInterviewStates.scope, input.scope),
+          eq(deepInterviewStates.scopeRefId, input.scopeRefId),
+        ),
+      )
+      .limit(1);
+
+    if (existing.length > 0) {
+      return rowToInternal(existing[0]!, input.initialIdea, input.brownfield ?? false);
+    }
+
+    const inserted = await db
+      .insert(deepInterviewStates)
+      .values({
+        scope: input.scope,
+        scopeRefId: input.scopeRefId,
+        status: "in_progress",
+        currentRound: 0,
+        ambiguityScore: null,
+        dimensionScores: null,
+        ontologySnapshots: [],
+        challengeModesUsed: [],
+        transcript: [],
+      })
+      .returning();
+
+    return rowToInternal(inserted[0]!, input.initialIdea, input.brownfield ?? false);
+  }
+
+  async function persistTurn(
+    stateId: string,
+    patch: Partial<typeof deepInterviewStates.$inferInsert>,
+  ): Promise<void> {
+    await db
+      .update(deepInterviewStates)
+      .set({ ...patch, updatedAt: sql`now()` })
+      .where(eq(deepInterviewStates.id, stateId));
+  }
+
+  async function nextTurn(input: NextTurnInput): Promise<NextTurnResult> {
+    const row = await getOrCreateRow(input);
+
+    if (row.status !== "in_progress") {
+      // Idempotent on already-finished interviews.
+      logger.info(
+        { stateId: row.id, status: row.status },
+        "[deep-interview-engine] nextTurn called on non-in_progress row",
+      );
+      return {
+        kind: "ready_to_crystallize",
+        stateId: row.id,
+        round: row.currentRound,
+        ambiguityScore: row.ambiguityScore ?? 0,
+        dimensions:
+          row.dimensionScores ?? { goal: 1, constraints: 1, criteria: 1, context: 1 },
+      };
+    }
+
+    // 1. If we have an answer, append to transcript so the next prompt sees it.
+    let transcript = row.transcript;
+    let nextRound = row.currentRound;
+    if (typeof input.userAnswer === "string" && input.userAnswer.length > 0) {
+      const lastQuestion =
+        transcript.length > 0 ? transcript[transcript.length - 1]!.question : "";
+      const targetDimension = targetWeakestDimension(row.dimensionScores, row.brownfield);
+      // The most recent transcript turn was created with question only; we now
+      // append the answer + a fresh ambiguityAfter (tentative until the LLM
+      // re-scores below).
+      const tentativeTurn: TranscriptTurn = {
+        round: nextRound,
+        question: lastQuestion,
+        targetDimension,
+        answer: input.userAnswer,
+        ambiguityAfter: row.ambiguityScore ?? 1,
+      };
+      transcript = [...transcript.slice(0, -1), tentativeTurn];
+      nextRound = row.currentRound + 1;
+    }
+
+    // 2. Compose + dispatch.
+    const challengeMode = pickChallengeMode(
+      nextRound,
+      row.challengeModesUsed,
+      row.ambiguityScore,
+    );
+    const promptInput = toPromptRow({
+      ...row,
+      currentRound: nextRound,
+      transcript,
+    });
+    const composed = composePrompt({
+      adapter: input.adapter,
+      phase: "ask_question",
+      state: promptInput,
+      challengeMode: challengeMode ?? undefined,
+    });
+
+    const raw = await dispatchLLM({
+      system: composed.system,
+      messages: composed.messages,
+    });
+
+    const { visibleBody, trailer } = parseJsonTrailer(raw);
+
+    // 3. Update state from trailer (or fall through with previous values).
+    const dims: DimensionScores =
+      trailer?.dimensions ??
+      row.dimensionScores ?? { goal: 0, constraints: 0, criteria: 0, context: 0 };
+    const ambiguity =
+      trailer?.ambiguity_score !== undefined
+        ? clamp01(trailer.ambiguity_score)
+        : computeWeightedAmbiguity(dims, row.brownfield);
+
+    const ontologySnapshot = nextOntologySnapshot(
+      row.ontologySnapshots,
+      trailer?.ontology_delta ?? [],
+      nextRound,
+    );
+    const ontologySnapshots = [...row.ontologySnapshots, ontologySnapshot];
+
+    const modesUsed = challengeMode
+      ? [...row.challengeModesUsed, challengeMode]
+      : row.challengeModesUsed;
+
+    // The LLM's visible body becomes the next turn's question.
+    const newTurn: TranscriptTurn = {
+      round: nextRound,
+      question: visibleBody,
+      targetDimension: targetWeakestDimension(dims, row.brownfield),
+      answer: "",
+      ambiguityAfter: ambiguity,
+      ...(challengeMode ? { challengeMode } : {}),
+    };
+    const nextTranscript = [...transcript, newTurn];
+
+    // 4. Decide hard-stop.
+    const reachedCap = nextRound >= HARD_ROUND_CAP;
+    const reachedAmbiguity = ambiguity <= AMBIGUITY_THRESHOLD;
+    const reachedDims = allDimensionsDone(dims, row.brownfield);
+    const stop = reachedCap || reachedAmbiguity || reachedDims;
+    const newStatus: DeepInterviewStateRow["status"] = stop
+      ? "ready_to_crystallize"
+      : "in_progress";
+
+    await persistTurn(row.id, {
+      currentRound: nextRound,
+      ambiguityScore: ambiguity,
+      dimensionScores: dims,
+      ontologySnapshots,
+      challengeModesUsed: modesUsed,
+      transcript: nextTranscript,
+      status: newStatus,
+    });
+
+    logger.info(
+      {
+        stateId: row.id,
+        round: nextRound,
+        scope: row.scope,
+        adapter: input.adapter,
+        ambiguity,
+        dims,
+        challengeMode,
+        stop,
+        reason: reachedCap ? "round_cap" : reachedAmbiguity ? "ambiguity" : reachedDims ? "dims" : null,
+      },
+      "[deep-interview-engine] turn dispatched",
+    );
+
+    if (stop) {
+      return {
+        kind: "ready_to_crystallize",
+        stateId: row.id,
+        round: nextRound,
+        ambiguityScore: ambiguity,
+        dimensions: dims,
+      };
+    }
+
+    return {
+      kind: "question",
+      stateId: row.id,
+      round: nextRound,
+      question: visibleBody,
+      ambiguityScore: ambiguity,
+      dimensions: dims,
+      challengeMode: challengeMode ?? null,
+      ontologyStability: ontologySnapshot.stabilityRatio,
+    };
+  }
+
+  async function crystallize(stateId: string): Promise<CrystallizeResult> {
+    const rows = await db
+      .select()
+      .from(deepInterviewStates)
+      .where(eq(deepInterviewStates.id, stateId))
+      .limit(1);
+    if (rows.length === 0) {
+      throw new Error(`[deep-interview-engine] state ${stateId} not found`);
+    }
+    const row = rows[0]!;
+
+    const dims = (row.dimensionScores as DimensionScores | null) ?? {
+      goal: 0,
+      constraints: 0,
+      criteria: 0,
+      context: 0,
+    };
+    const transcript = (row.transcript as TranscriptTurn[]) ?? [];
+    const ontologySnapshots = (row.ontologySnapshots as OntologySnapshot[]) ?? [];
+    const lastOntology =
+      ontologySnapshots.length > 0
+        ? ontologySnapshots[ontologySnapshots.length - 1]!.entities
+        : [];
+
+    const goalText = transcript.find((t) => t.targetDimension === "goal")?.answer ?? "";
+    const constraints = transcript
+      .filter((t) => t.targetDimension === "constraints")
+      .map((t) => t.answer)
+      .filter((s) => s.length > 0);
+    const criteria = transcript
+      .filter((t) => t.targetDimension === "criteria")
+      .map((t) => t.answer)
+      .filter((s) => s.length > 0);
+
+    const inserted = await db
+      .insert(deepInterviewSpecs)
+      .values({
+        stateId: row.id,
+        goal: goalText,
+        constraints,
+        criteria,
+        nonGoals: [],
+        ontology: lastOntology,
+        transcript,
+        finalAmbiguity: row.ambiguityScore ?? 0,
+        dimensionScores: dims,
+      })
+      .returning();
+
+    await db
+      .update(deepInterviewStates)
+      .set({ status: "crystallized", updatedAt: sql`now()` })
+      .where(eq(deepInterviewStates.id, row.id));
+
+    logger.info(
+      { stateId: row.id, specId: inserted[0]!.id, finalAmbiguity: row.ambiguityScore },
+      "[deep-interview-engine] crystallized",
+    );
+
+    return { specId: inserted[0]!.id, stateId: row.id };
+  }
+
+  async function getInProgress(
+    scope: DeepInterviewScope,
+    scopeRefId: string,
+  ): Promise<DeepInterviewStateRow | null> {
+    const rows = await db
+      .select()
+      .from(deepInterviewStates)
+      .where(
+        and(
+          eq(deepInterviewStates.scope, scope),
+          eq(deepInterviewStates.scopeRefId, scopeRefId),
+        ),
+      )
+      .limit(1);
+    if (rows.length === 0) return null;
+    return rowToInternal(rows[0]!, "", false);
+  }
+
+  return { nextTurn, crystallize, getInProgress };
+}
+
+// Re-export for convenience.
+export { computeWeightedAmbiguity, pickChallengeMode, targetWeakestDimension, allDimensionsDone, nextOntologySnapshot };

--- a/server/src/services/deep-interview-parser.ts
+++ b/server/src/services/deep-interview-parser.ts
@@ -1,0 +1,173 @@
+// AgentDash (Phase C): JSON-trailer parser for deep-interview LLM responses.
+//
+// LLM output contract (see deep-interview-prompts.ts TRAILER_CONTRACT):
+//   <visible body in plain English>
+//   ```json
+//   { "ambiguity_score": ..., "dimensions": {...}, ... }
+//   ```
+//
+// Tolerant by design: missing fence, unterminated string, or non-object payload
+// all return { visibleBody: <raw>, trailer: null } and log a warning. The
+// engine treats a null trailer as "no signal this turn" and falls back to
+// previous round scores rather than crashing.
+//
+// See docs/superpowers/plans/2026-05-04-onboarding-redesign-deep-interview-plan.md
+// (Phase C, Pre-mortem #1) for the design rationale.
+
+import { logger } from "../middleware/logger.js";
+import type {
+  DimensionScores,
+  OntologyEntity,
+} from "@paperclipai/shared/deep-interview";
+
+export interface TrailerPayload {
+  ambiguity_score: number;
+  dimensions: DimensionScores;
+  ontology_delta: OntologyEntity[];
+  next_phase:
+    | "continue"
+    | "crystallize"
+    | "challenge:contrarian"
+    | "challenge:simplifier"
+    | "challenge:ontologist";
+  action?: "ask_next" | "force_crystallize";
+}
+
+export interface ParseResult {
+  /** The LLM's prose, stripped of the fenced JSON block. */
+  visibleBody: string;
+  /** Parsed + validated trailer, or null on any failure. */
+  trailer: TrailerPayload | null;
+}
+
+// Match all fenced JSON blocks; we always pick the LAST one. The trailer
+// contract says the JSON block is the final element of the response, but the
+// prose body may contain other fenced blocks (rare).
+const FENCED_JSON_RE = /```json\s*([\s\S]*?)```/gi;
+
+function isDimensionScores(value: unknown): value is DimensionScores {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.goal === "number" &&
+    typeof v.constraints === "number" &&
+    typeof v.criteria === "number" &&
+    typeof v.context === "number"
+  );
+}
+
+function isOntologyEntity(value: unknown): value is OntologyEntity {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.name !== "string") return false;
+  if (
+    v.type !== "core_domain" &&
+    v.type !== "supporting" &&
+    v.type !== "external_system"
+  ) {
+    return false;
+  }
+  if (
+    v.fields !== undefined &&
+    !(Array.isArray(v.fields) && v.fields.every((f) => typeof f === "string"))
+  ) {
+    return false;
+  }
+  if (
+    v.relationships !== undefined &&
+    !(
+      Array.isArray(v.relationships) &&
+      v.relationships.every((r) => typeof r === "string")
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+const ALLOWED_PHASES = new Set([
+  "continue",
+  "crystallize",
+  "challenge:contrarian",
+  "challenge:simplifier",
+  "challenge:ontologist",
+]);
+
+function isTrailerPayload(value: unknown): value is TrailerPayload {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.ambiguity_score !== "number") return false;
+  if (!Number.isFinite(v.ambiguity_score)) return false;
+  if (!isDimensionScores(v.dimensions)) return false;
+  if (!Array.isArray(v.ontology_delta)) return false;
+  if (!v.ontology_delta.every(isOntologyEntity)) return false;
+  if (typeof v.next_phase !== "string" || !ALLOWED_PHASES.has(v.next_phase)) {
+    return false;
+  }
+  if (
+    v.action !== undefined &&
+    v.action !== "ask_next" &&
+    v.action !== "force_crystallize"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Parse an LLM response into { visibleBody, trailer }.
+ *
+ * Tolerant of malformed input:
+ *   - missing fence       → { visibleBody: text.trimEnd(), trailer: null }
+ *   - JSON.parse failure  → { visibleBody: text.trimEnd(), trailer: null }
+ *   - shape mismatch      → { visibleBody: text-with-fence-stripped, trailer: null }
+ *
+ * Logs a warning on every failure so adapter-quality dashboards can spot
+ * regressions.
+ */
+export function parseJsonTrailer(text: string): ParseResult {
+  const matches = Array.from(text.matchAll(FENCED_JSON_RE));
+  if (matches.length === 0) {
+    logger.warn(
+      { rawFirst200: text.slice(0, 200) },
+      "[deep-interview-parser] no fenced JSON trailer found",
+    );
+    return { visibleBody: text.trimEnd(), trailer: null };
+  }
+
+  const match = matches[matches.length - 1]!;
+  // Reject if there is non-whitespace content after the last fenced block —
+  // the contract says the trailer is the final element of the response.
+  const tail = text.slice((match.index ?? 0) + match[0].length);
+  if (tail.trim().length > 0) {
+    logger.warn(
+      { tailFirst200: tail.slice(0, 200) },
+      "[deep-interview-parser] content after trailer; treating as malformed",
+    );
+    return { visibleBody: text.trimEnd(), trailer: null };
+  }
+
+  const body = text.slice(0, match.index).trimEnd();
+  const jsonRaw = match[1] ?? "";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonRaw.trim());
+  } catch (err) {
+    logger.warn(
+      { err, rawFirst200: jsonRaw.slice(0, 200) },
+      "[deep-interview-parser] JSON.parse failed",
+    );
+    return { visibleBody: body, trailer: null };
+  }
+
+  if (!isTrailerPayload(parsed)) {
+    logger.warn(
+      { rawFirst200: jsonRaw.slice(0, 200) },
+      "[deep-interview-parser] trailer shape mismatch",
+    );
+    return { visibleBody: body, trailer: null };
+  }
+
+  return { visibleBody: body, trailer: parsed };
+}

--- a/server/src/services/deep-interview-prompts.ts
+++ b/server/src/services/deep-interview-prompts.ts
@@ -1,0 +1,215 @@
+// AgentDash (Phase C): pure prompt-composition helpers for the deep-interview
+// engine. Two responsibilities:
+//
+//   1. selectPromptDepth(adapter): picks "full" (claude_api only) vs "summary"
+//      (everything else). Hard requirement — Phase C acceptance #7. Spawn-based
+//      adapters have no prompt caching at the API level (verified at
+//      dispatch-llm.ts:108-140), so shipping the 16.7k-token full SKILL.md
+//      across 8+ rounds would burn ~133k uncached tokens per interview.
+//
+//   2. composePrompt(): concatenates the appropriate SKILL corpus + scope
+//      framing + per-round challenge fragment + JSON-trailer schema contract
+//      into a system prompt + messages array suitable for dispatchLLM.
+//
+// Pure functions only — no I/O. The engine (deep-interview-engine.ts) owns
+// all DB writes and dispatch wiring.
+//
+// See docs/superpowers/plans/2026-05-04-onboarding-redesign-deep-interview-plan.md
+// (Phase C) for the full design rationale.
+
+import type { AgentAdapterType } from "@paperclipai/shared";
+import {
+  SKILL_MD_FULL,
+  SKILL_MD_SUMMARY,
+} from "@paperclipai/shared/deep-interview-skill";
+import type {
+  ChallengeMode,
+  DimensionScores,
+  OntologyEntity,
+  OntologySnapshot,
+  TranscriptTurn,
+} from "@paperclipai/shared/deep-interview";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PromptPhase = "ask_question" | "score" | "crystallize";
+
+/**
+ * Subset of `deepInterviewStates` columns the prompt builder needs. We define
+ * a structural type rather than importing the Drizzle row type to keep this
+ * module pure / testable without a DB.
+ */
+export interface DeepInterviewStateRow {
+  scope: string;
+  scopeRefId: string;
+  currentRound: number;
+  ambiguityScore: number | null;
+  dimensionScores: DimensionScores | null;
+  ontologySnapshots: OntologySnapshot[];
+  challengeModesUsed: string[];
+  transcript: TranscriptTurn[];
+  /**
+   * Set true when prior-codebase context exists (brownfield). Drives the
+   * 4-dimension weighting (35/25/25/15) vs greenfield (40/30/30, no context).
+   */
+  brownfield: boolean;
+  /** Initial idea / seed prompt provided by the user. */
+  initialIdea: string;
+}
+
+export interface ComposeInput {
+  adapter: AgentAdapterType;
+  phase: PromptPhase;
+  state: DeepInterviewStateRow;
+  /** When set, inject the matching challenge-mode fragment. */
+  challengeMode?: ChallengeMode;
+}
+
+export interface ComposedPrompt {
+  system: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-depth selection (Phase C acceptance #7)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick which SKILL corpus to ship for a given adapter.
+ *
+ * Hard contract:
+ *   - "claude_api" → "full" (cached via cache_control: ephemeral in
+ *      anthropic-llm.ts; the 16.7k tokens are paid once per cache window).
+ *   - everything else → "summary" (~150-line distillation, ~3-4k tokens,
+ *      bounded for argv-flattened spawn adapters).
+ *
+ * Unknown adapter strings default to "summary" — safer to ship less context.
+ */
+export function selectPromptDepth(
+  adapter: AgentAdapterType,
+): "full" | "summary" {
+  return adapter === "claude_api" ? "full" : "summary";
+}
+
+// ---------------------------------------------------------------------------
+// Challenge-mode fragments
+// ---------------------------------------------------------------------------
+
+const CHALLENGE_FRAGMENTS: Record<ChallengeMode, string> = {
+  contrarian: `\n\n[CHALLENGE — Contrarian]\nYour next question MUST adopt a contrarian stance. Pick the user's strongest stated assumption and ask why it might be wrong, or propose the literal opposite of their goal as a candidate framing. The point is to expose hidden premises, not to be hostile. One sharp question only.`,
+  simplifier: `\n\n[CHALLENGE — Simplifier]\nYour next question MUST aggressively simplify. Identify the single most load-bearing requirement; ask whether the entire problem could be reframed without it. Propose the smallest possible MVP that still solves the user's core pain. One sharp question only.`,
+  ontologist: `\n\n[CHALLENGE — Ontologist]\nYour next question MUST stress-test the ontology. Pick the most ambiguous entity in the user's model and ask for explicit fields, relationships, and lifecycle. If two entities have overlapping responsibilities, ask which one is canonical. One sharp question only.`,
+};
+
+// ---------------------------------------------------------------------------
+// Trailer-contract fragment
+// ---------------------------------------------------------------------------
+
+const TRAILER_CONTRACT = `
+
+[Response contract]
+Reply in plain English to the user. Then, on a new line, emit a fenced JSON block carrying structured data the engine consumes. The block MUST be the LAST thing in your response, and MUST parse as JSON.
+
+\`\`\`json
+{
+  "ambiguity_score": 0.42,
+  "dimensions": { "goal": 0.7, "constraints": 0.5, "criteria": 0.4, "context": 0.6 },
+  "ontology_delta": [
+    { "name": "Customer", "type": "core_domain", "fields": ["id","email"], "relationships": ["Order"] }
+  ],
+  "next_phase": "continue",
+  "action": "ask_next"
+}
+\`\`\`
+
+Allowed values:
+- ambiguity_score: 0.0 (fully clear) .. 1.0 (entirely unclear).
+- dimensions: numbers 0..1 for { goal, constraints, criteria, context }.
+- ontology_delta: array of OntologyEntity ({ name, type: "core_domain"|"supporting"|"external_system", fields?, relationships? }).
+- next_phase: "continue" | "crystallize" | "challenge:contrarian" | "challenge:simplifier" | "challenge:ontologist".
+- action: "ask_next" | "force_crystallize" (optional; default ask_next).`;
+
+// ---------------------------------------------------------------------------
+// Scope framing
+// ---------------------------------------------------------------------------
+
+function scopeFraming(state: DeepInterviewStateRow): string {
+  const parts: string[] = [];
+  parts.push(`\n\n[Scope]\n${state.scope}`);
+  if (state.brownfield) {
+    parts.push(
+      `\n[Mode] Brownfield — weight ambiguity as goal*0.35 + constraints*0.25 + criteria*0.25 + context*0.15.`,
+    );
+  } else {
+    parts.push(
+      `\n[Mode] Greenfield — weight ambiguity as goal*0.40 + constraints*0.30 + criteria*0.30. No prior-codebase context dimension.`,
+    );
+  }
+  parts.push(`\n[Round] ${state.currentRound}`);
+  if (state.ambiguityScore !== null) {
+    parts.push(`\n[Last ambiguity] ${state.ambiguityScore.toFixed(3)}`);
+  }
+  if (state.challengeModesUsed.length > 0) {
+    parts.push(`\n[Modes already used] ${state.challengeModesUsed.join(", ")}`);
+  }
+  return parts.join("");
+}
+
+function transcriptToMessages(
+  state: DeepInterviewStateRow,
+): Array<{ role: "user" | "assistant"; content: string }> {
+  const out: Array<{ role: "user" | "assistant"; content: string }> = [];
+  // Seed: the user's initial idea is the first user message.
+  out.push({ role: "user", content: state.initialIdea });
+  for (const turn of state.transcript) {
+    out.push({ role: "assistant", content: turn.question });
+    out.push({ role: "user", content: turn.answer });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// composePrompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the system prompt + messages array for a given engine phase.
+ *
+ * - claude_api ships SKILL_MD_FULL; every other adapter ships SKILL_MD_SUMMARY.
+ * - Challenge-mode fragments are appended in `ask_question` phase only.
+ * - JSON-trailer contract is appended in `ask_question` and `score` phases
+ *   (the LLM emits the trailer; the engine parses it).
+ */
+export function composePrompt(input: ComposeInput): ComposedPrompt {
+  const depth = selectPromptDepth(input.adapter);
+  const skill = depth === "full" ? SKILL_MD_FULL : SKILL_MD_SUMMARY;
+
+  const parts: string[] = [skill];
+  parts.push(scopeFraming(input.state));
+
+  if (input.phase === "ask_question") {
+    parts.push(
+      `\n\n[Task]\nAsk ONE question that targets the weakest dimension. Be specific. Reference the user's prior answers when useful. Do not ask compound questions.`,
+    );
+    if (input.challengeMode) {
+      parts.push(CHALLENGE_FRAGMENTS[input.challengeMode]);
+    }
+    parts.push(TRAILER_CONTRACT);
+  } else if (input.phase === "score") {
+    parts.push(
+      `\n\n[Task]\nScore the user's most recent answer against the four dimensions. Update ambiguity. Do not ask another question — just emit the trailer.`,
+    );
+    parts.push(TRAILER_CONTRACT);
+  } else {
+    parts.push(
+      `\n\n[Task]\nThe interview has converged. Emit the final crystallized spec as a JSON object with keys: goal (string), constraints (string[]), criteria (string[]), non_goals (string[]), ontology (OntologyEntity[]). No prose.`,
+    );
+  }
+
+  return {
+    system: parts.join(""),
+    messages: transcriptToMessages(input.state),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the deep-interview Socratic loop engine (`server/src/services/deep-interview-engine.ts`) with `nextTurn`, `crystallize`, and `getInProgress`. Per-turn the engine composes a prompt, dispatches via the injected LLM, parses the JSON trailer, updates dimension scores / ambiguity / ontology snapshots / challenge modes, and stops on ambiguity ≤ 0.20, round ≥ 20, or all dims ≥ 0.9.
- Adds `server/src/services/deep-interview-prompts.ts` with `selectPromptDepth(adapter)` (claude_api → SKILL_MD_FULL; everything else → SKILL_MD_SUMMARY) and `composePrompt()` covering ask_question / score / crystallize phases, brownfield/greenfield weighting, and round 4/6/8 challenge fragments (contrarian/simplifier/ontologist).
- Adds `server/src/services/deep-interview-parser.ts` for tolerant JSON-trailer extraction. Missing fence, unterminated JSON, shape mismatch, or content past the trailer all return `{ visibleBody, trailer: null }` with a warn log — never throws.
- Phase C HARD acceptance #7 covered by string-equality unit tests: `composePrompt({ adapter: "claude_api" }).system` starts with `SKILL_MD_FULL`; `composePrompt({ adapter: "hermes_local" }).system` starts with `SKILL_MD_SUMMARY` (and does not regress to the full corpus).

## Test plan
- [x] `pnpm --filter @paperclipai/server typecheck` — passes
- [x] `pnpm --filter @paperclipai/server exec vitest run deep-interview` — 61 passed (3 test files, 0 failures)
- [ ] No route wiring this PR — Phase D wires the engine into `/assess`. The engine writes only to `deep_interview_states` and `deep_interview_specs` per the source-of-truth contract.

## Context
Phase A (`SKILL_MD_FULL` / `SKILL_MD_SUMMARY`) and Phase B (schema + types) shipped previously. This PR is Phase C of `docs/superpowers/plans/2026-05-04-onboarding-redesign-deep-interview-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)