### PR TITLE
feat(cos-onboarding): Phase D — wire deep-interview engine into /assess (flag-gated)

### DIFF
--- a/server/src/__tests__/assess-routes.test.ts
+++ b/server/src/__tests__/assess-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockAssess = vi.hoisted(() => ({
   research: vi.fn(async () => ({
@@ -9,7 +9,16 @@ const mockAssess = vi.hoisted(() => ({
     allIndustries: ["Healthcare", "Tech/SaaS"],
   })),
   runAssessment: vi.fn(async () => ({
-    stream: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("# Report")); c.close(); } }),
+    stream: new ReadableStream({
+      start(c) {
+        // The legacy /assess route parses SSE-style `data: { ... }` lines
+        // for content_block_delta.text — emit one matching frame.
+        const frame =
+          'data: {"type":"content_block_delta","delta":{"text":"# Report"}}\n\n';
+        c.enqueue(new TextEncoder().encode(frame));
+        c.close();
+      },
+    }),
     onComplete: vi.fn(),
   })),
   getAssessment: vi.fn(async () => ({
@@ -19,8 +28,54 @@ const mockAssess = vi.hoisted(() => ({
   })),
 }));
 
+const mockProjectAssess = vi.hoisted(() => ({
+  generateClarifyQuestions: vi.fn(async () => ({
+    rephrased: "rephrased",
+    questions: [{ id: "q1", question: "Legacy q?", hint: "", options: [] }],
+  })),
+  generateFollowUp: vi.fn(async () => ({
+    rephrased: "",
+    questions: [{ id: "f1", question: "Legacy followup?", hint: "", options: [] }],
+  })),
+  runProjectAssessment: vi.fn(async () => ({
+    stream: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("# Project Report")); c.close(); } }),
+    slug: "project",
+    onComplete: vi.fn(),
+  })),
+  listProjectAssessments: vi.fn(async () => []),
+  getProjectAssessment: vi.fn(async () => null),
+}));
+
+// AgentDash (Phase D): engine + dispatchLLM mocks for the flag-on path.
+const mockEngine = vi.hoisted(() => ({
+  nextTurn: vi.fn(async () => ({
+    kind: "question" as const,
+    stateId: "state-test",
+    round: 1,
+    question: "What outcomes matter most to you?",
+    ambiguityScore: 0.7,
+    dimensions: { goal: 0.3, constraints: 0.1, criteria: 0.1, context: 0.1 },
+    challengeMode: null,
+    ontologyStability: null,
+  })),
+  crystallize: vi.fn(),
+  getInProgress: vi.fn(async () => null),
+}));
+
 vi.mock("../services/assess.js", () => ({
   assessService: () => mockAssess,
+}));
+
+vi.mock("../services/assess-project.js", () => ({
+  assessProjectService: () => mockProjectAssess,
+}));
+
+vi.mock("../services/deep-interview-engine.js", () => ({
+  deepInterviewEngine: () => mockEngine,
+}));
+
+vi.mock("../services/dispatch-llm.js", () => ({
+  dispatchLLM: vi.fn(async () => "stub"),
 }));
 
 import express from "express";
@@ -96,6 +151,200 @@ describe("Assess routes", () => {
         isInstanceAdmin: false,
       });
       await request(app).get("/api/companies/company-1/assess").expect(403);
+    });
+  });
+
+  // AgentDash (Phase D): flag-OFF behavior — legacy path, unchanged.
+  describe("flag OFF — legacy assess path", () => {
+    beforeEach(() => {
+      delete process.env.AGENTDASH_DEEP_INTERVIEW_ASSESS;
+    });
+
+    it("POST /companies/:cid/assess streams legacy assessService output", async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post("/api/companies/company-1/assess")
+        .send({ description: "Build a CRM" })
+        .expect(200);
+
+      expect(res.text).toBe("# Report");
+      expect(mockAssess.runAssessment).toHaveBeenCalled();
+      expect(mockEngine.nextTurn).not.toHaveBeenCalled();
+    });
+
+    it("POST /assess/project/clarify returns legacy questions", async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post("/api/companies/company-1/assess/project/clarify")
+        .send({ intake: { projectName: "X", description: "Y", oneLineGoal: "Z", sponsor: "S" } })
+        .expect(200);
+
+      expect(res.body.rephrased).toBe("rephrased");
+      expect(res.body.questions[0].question).toBe("Legacy q?");
+      expect(mockProjectAssess.generateClarifyQuestions).toHaveBeenCalled();
+      expect(mockEngine.nextTurn).not.toHaveBeenCalled();
+    });
+  });
+
+  // AgentDash (Phase D): flag-ON behavior — engine path.
+  describe("flag ON — deep-interview engine path", () => {
+    beforeEach(() => {
+      process.env.AGENTDASH_DEEP_INTERVIEW_ASSESS = "true";
+    });
+
+    afterEach(() => {
+      delete process.env.AGENTDASH_DEEP_INTERVIEW_ASSESS;
+    });
+
+    it("POST /companies/:cid/assess routes through engine.nextTurn", async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post("/api/companies/company-1/assess")
+        .send({ description: "Build a CRM", userAnswer: "Top of funnel growth" })
+        .expect(200);
+
+      expect(res.text).toBe("What outcomes matter most to you?");
+      expect(mockEngine.nextTurn).toHaveBeenCalledTimes(1);
+      const callArg = mockEngine.nextTurn.mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArg.scope).toBe("cos_onboarding");
+      expect(callArg.scopeRefId).toBe("company-1");
+      expect(callArg.companyId).toBe("company-1");
+      expect(callArg.userAnswer).toBe("Top of funnel growth");
+      // Legacy MUST NOT have been invoked.
+      expect(mockAssess.runAssessment).not.toHaveBeenCalled();
+    });
+
+    it("POST /assess/project/clarify routes through engine.nextTurn with assess_project scope", async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post("/api/companies/company-1/assess/project/clarify")
+        .send({ intake: { projectName: "Robotics", description: "Stuff", oneLineGoal: "Build", sponsor: "Chris" } })
+        .expect(200);
+
+      expect(res.body.questions).toHaveLength(1);
+      expect(res.body.questions[0].question).toBe("What outcomes matter most to you?");
+      expect(mockEngine.nextTurn).toHaveBeenCalledTimes(1);
+      const callArg = mockEngine.nextTurn.mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArg.scope).toBe("assess_project");
+      expect(String(callArg.scopeRefId)).toContain("company-1:");
+      expect(mockProjectAssess.generateClarifyQuestions).not.toHaveBeenCalled();
+    });
+
+    it("POST /assess/project/followup forwards the most recent answer", async () => {
+      const app = createApp();
+      await request(app)
+        .post("/api/companies/company-1/assess/project/followup")
+        .send({
+          intake: { projectName: "Robotics", description: "X", oneLineGoal: "Y", sponsor: "Z" },
+          answers: [
+            { questionId: "r1", text: "First answer" },
+            { questionId: "r2", text: "Latest answer" },
+          ],
+          rephrased: "rephrased text",
+        })
+        .expect(200);
+
+      const callArg = mockEngine.nextTurn.mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArg.userAnswer).toBe("Latest answer");
+    });
+
+    it("ready_to_crystallize result is streamed as a marker (graceful)", async () => {
+      mockEngine.nextTurn.mockResolvedValueOnce({
+        kind: "ready_to_crystallize",
+        stateId: "state-test",
+        round: 12,
+        ambiguityScore: 0.18,
+        dimensions: { goal: 0.95, constraints: 0.9, criteria: 0.9, context: 0.85 },
+      });
+      const app = createApp();
+      const res = await request(app)
+        .post("/api/companies/company-1/assess")
+        .send({ description: "Build a CRM" })
+        .expect(200);
+      expect(res.text).toContain("[deep-interview] Ready to crystallize");
+      expect(res.text).toContain("0.180");
+    });
+  });
+
+  // AgentDash (Phase D): GET /onboarding/in-progress — resume support.
+  describe("GET /onboarding/in-progress", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("returns 200 with the row when an in-progress state exists", async () => {
+      mockEngine.getInProgress.mockResolvedValueOnce({
+        id: "state-aaaa",
+        scope: "cos_onboarding",
+        scopeRefId: "company-1",
+        status: "in_progress",
+        currentRound: 3,
+        ambiguityScore: 0.6,
+        dimensionScores: { goal: 0.5, constraints: 0.4, criteria: 0.4, context: 0.3 },
+        ontologySnapshots: [],
+        challengeModesUsed: [],
+        transcript: [],
+        initialIdea: "",
+        brownfield: false,
+      } as any);
+
+      const app = createApp();
+      const res = await request(app)
+        .get("/api/onboarding/in-progress")
+        .query({ scope: "cos_onboarding", scopeRefId: "company-1" })
+        .expect(200);
+
+      expect(res.body.state).not.toBeNull();
+      expect(res.body.state.currentRound).toBe(3);
+      expect(res.body.resumeUrl).toBe("/assess?onboarding=1");
+    });
+
+    it("returns 200 with state=null when nothing in progress", async () => {
+      mockEngine.getInProgress.mockResolvedValueOnce(null);
+      const app = createApp();
+      const res = await request(app)
+        .get("/api/onboarding/in-progress")
+        .query({ scope: "cos_onboarding", scopeRefId: "company-1" })
+        .expect(200);
+      expect(res.body.state).toBeNull();
+      expect(res.body.resumeUrl).toBeNull();
+    });
+
+    it("returns 400 on bad scope", async () => {
+      const app = createApp();
+      await request(app)
+        .get("/api/onboarding/in-progress")
+        .query({ scope: "bogus", scopeRefId: "company-1" })
+        .expect(400);
+    });
+
+    it("returns 400 when scopeRefId missing", async () => {
+      const app = createApp();
+      await request(app)
+        .get("/api/onboarding/in-progress")
+        .query({ scope: "cos_onboarding" })
+        .expect(400);
+    });
+
+    it("rejects when caller lacks company access", async () => {
+      const app = createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: ["other-company"],
+        source: "jwt",
+        isInstanceAdmin: false,
+      });
+      await request(app)
+        .get("/api/onboarding/in-progress")
+        .query({ scope: "cos_onboarding", scopeRefId: "company-1" })
+        .expect(403);
+    });
+
+    it("extracts companyId from synthetic assess_project scopeRefId for authz", async () => {
+      mockEngine.getInProgress.mockResolvedValueOnce(null);
+      const app = createApp();
+      await request(app)
+        .get("/api/onboarding/in-progress")
+        .query({ scope: "assess_project", scopeRefId: "company-1:robotics" })
+        .expect(200);
     });
   });
 });

--- a/server/src/routes/assess.ts
+++ b/server/src/routes/assess.ts
@@ -5,10 +5,28 @@ import { assessService } from "../services/assess.js";
 import { assessProjectService } from "../services/assess-project.js";
 import { buildProjectDocx } from "../services/assess-project-docx.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
+// AgentDash (Phase D): deep-interview engine wiring (flag-gated, default OFF)
+import { deepInterviewEngine, type EngineLLMDispatch } from "../services/deep-interview-engine.js";
+import { dispatchLLM } from "../services/dispatch-llm.js";
+import type { AgentAdapterType } from "@paperclipai/shared";
+import type { DeepInterviewScope } from "@paperclipai/shared/deep-interview";
 
 function httpStatus(err: unknown): number {
   const e = err as { statusCode?: number; status?: number };
   return e.statusCode ?? e.status ?? 500;
+}
+
+/**
+ * AgentDash (Phase D): read the deep-interview flag at request-handling time
+ * (NOT module load) so a flag flip takes effect without a restart.
+ */
+function deepInterviewEnabled(): boolean {
+  return process.env.AGENTDASH_DEEP_INTERVIEW_ASSESS === "true";
+}
+
+function defaultAdapter(): AgentAdapterType {
+  return ((process.env.AGENTDASH_DEFAULT_ADAPTER ?? "claude_api").trim() ||
+    "claude_api") as AgentAdapterType;
 }
 
 export function assessRoutes(db: Db) {
@@ -16,6 +34,12 @@ export function assessRoutes(db: Db) {
   const svc = assessService(db);
   // AgentDash: project-mode service
   const projectSvc = assessProjectService(db);
+  // AgentDash (Phase D): production wiring uses the dispatchLLM service. Tests
+  // can override by mocking the module at import time.
+  const engine = deepInterviewEngine({
+    db,
+    dispatchLLM: dispatchLLM as EngineLLMDispatch,
+  });
 
   // POST /companies/:companyId/assess/research — lightweight URL research
   router.post("/companies/:companyId/assess/research", async (req, res) => {
@@ -33,11 +57,50 @@ export function assessRoutes(db: Db) {
   });
 
   // POST /companies/:companyId/assess — run full assessment (streaming)
+  // AgentDash (Phase D): when AGENTDASH_DEEP_INTERVIEW_ASSESS=true, drive a
+  // deep-interview turn instead of the legacy MiniMax streaming markdown call.
+  // The engine emits a single question per turn; we stream that as plain text
+  // so the existing UI (which appends streamed chunks) renders the question.
   router.post("/companies/:companyId/assess", async (req, res) => {
     try {
       assertBoard(req);
       const companyId = req.params.companyId as string;
       assertCompanyAccess(req, companyId);
+
+      if (deepInterviewEnabled()) {
+        const initialIdea = typeof req.body?.description === "string"
+          ? req.body.description
+          : typeof req.body?.oneLineGoal === "string"
+            ? req.body.oneLineGoal
+            : "";
+        const userAnswer = typeof req.body?.userAnswer === "string"
+          ? req.body.userAnswer
+          : undefined;
+
+        const turn = await engine.nextTurn({
+          scope: "cos_onboarding" as DeepInterviewScope,
+          scopeRefId: companyId,
+          userId: req.actor.userId ?? "board",
+          companyId,
+          initialIdea,
+          adapter: defaultAdapter(),
+          userAnswer,
+        });
+
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        // Stream the engine output as plain text. Existing UI appends chunks.
+        if (turn.kind === "question") {
+          res.write(turn.question);
+        } else {
+          res.write(
+            `[deep-interview] Ready to crystallize at round ${turn.round} (ambiguity ${turn.ambiguityScore.toFixed(3)}).`,
+          );
+        }
+        res.end();
+        return;
+      }
 
       const { stream, onComplete } = await svc.runAssessment(companyId, req.body, req.body.companyWebContent);
 
@@ -114,6 +177,39 @@ export function assessRoutes(db: Db) {
         res.status(400).json({ error: "Missing intake object" });
         return;
       }
+
+      if (deepInterviewEnabled()) {
+        // AgentDash (Phase D): engine path — one engine turn produces one
+        // question, which we surface as the SOLE clarify question in the UI's
+        // existing { rephrased, questions } envelope. Subsequent turns flow
+        // through /followup so we don't need to re-emit the rephrase.
+        const projectId = typeof (intake as { projectId?: string }).projectId === "string"
+          ? (intake as { projectId: string }).projectId
+          : `${companyId}:${((intake as { projectName?: string }).projectName ?? "project").slice(0, 64)}`;
+        const initialIdea = [
+          (intake as { projectName?: string }).projectName ?? "",
+          (intake as { oneLineGoal?: string }).oneLineGoal ?? "",
+          (intake as { description?: string }).description ?? "",
+        ].filter(Boolean).join("\n\n");
+
+        const turn = await engine.nextTurn({
+          scope: "assess_project" as DeepInterviewScope,
+          scopeRefId: projectId,
+          userId: req.actor.userId ?? "board",
+          companyId,
+          initialIdea,
+          adapter: defaultAdapter(),
+        });
+
+        res.json({
+          rephrased: (intake as { oneLineGoal?: string }).oneLineGoal ?? initialIdea.slice(0, 160),
+          questions: turn.kind === "question"
+            ? [{ id: `r${turn.round}`, question: turn.question, hint: "", options: [] }]
+            : [],
+        });
+        return;
+      }
+
       const result = await projectSvc.generateClarifyQuestions(companyId, intake);
       res.json(result);
     } catch (err: unknown) {
@@ -133,6 +229,41 @@ export function assessRoutes(db: Db) {
         res.status(400).json({ error: "Missing intake or answers" });
         return;
       }
+
+      if (deepInterviewEnabled()) {
+        const projectId = typeof (intake as { projectId?: string }).projectId === "string"
+          ? (intake as { projectId: string }).projectId
+          : `${companyId}:${((intake as { projectName?: string }).projectName ?? "project").slice(0, 64)}`;
+        const initialIdea = [
+          (intake as { projectName?: string }).projectName ?? "",
+          (intake as { oneLineGoal?: string }).oneLineGoal ?? "",
+          (intake as { description?: string }).description ?? "",
+        ].filter(Boolean).join("\n\n");
+
+        // The most recent answer drives the next engine turn.
+        const lastAnswer = answers.length > 0
+          ? String((answers[answers.length - 1] as { text?: unknown })?.text ?? "")
+          : "";
+
+        const turn = await engine.nextTurn({
+          scope: "assess_project" as DeepInterviewScope,
+          scopeRefId: projectId,
+          userId: req.actor.userId ?? "board",
+          companyId,
+          initialIdea,
+          adapter: defaultAdapter(),
+          userAnswer: lastAnswer || undefined,
+        });
+
+        res.json({
+          rephrased: typeof rephrased === "string" ? rephrased : "",
+          questions: turn.kind === "question"
+            ? [{ id: `r${turn.round}`, question: turn.question, hint: "", options: [] }]
+            : [],
+        });
+        return;
+      }
+
       const result = await projectSvc.generateFollowUp(intake, answers, rephrased ?? "");
       res.json(result);
     } catch (err: unknown) {
@@ -150,6 +281,47 @@ export function assessRoutes(db: Db) {
       const { intake, answers, rephrased } = req.body ?? {};
       if (!intake || !Array.isArray(answers)) {
         res.status(400).json({ error: "Missing intake or answers" });
+        return;
+      }
+
+      if (deepInterviewEnabled()) {
+        // AgentDash (Phase D): engine path — drive one final turn, stream out
+        // the next question or the crystallization marker. Phase F will
+        // replace this with the crystallizeAndAdvanceCos handoff.
+        const projectId = typeof (intake as { projectId?: string }).projectId === "string"
+          ? (intake as { projectId: string }).projectId
+          : `${companyId}:${((intake as { projectName?: string }).projectName ?? "project").slice(0, 64)}`;
+        const initialIdea = [
+          (intake as { projectName?: string }).projectName ?? "",
+          (intake as { oneLineGoal?: string }).oneLineGoal ?? "",
+          (intake as { description?: string }).description ?? "",
+        ].filter(Boolean).join("\n\n");
+
+        const lastAnswer = answers.length > 0
+          ? String((answers[answers.length - 1] as { text?: unknown })?.text ?? "")
+          : "";
+
+        const turn = await engine.nextTurn({
+          scope: "assess_project" as DeepInterviewScope,
+          scopeRefId: projectId,
+          userId: req.actor.userId ?? "board",
+          companyId,
+          initialIdea,
+          adapter: defaultAdapter(),
+          userAnswer: lastAnswer || undefined,
+        });
+
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        if (turn.kind === "question") {
+          res.write(turn.question);
+        } else {
+          res.write(
+            `[deep-interview] Ready to crystallize at round ${turn.round} (ambiguity ${turn.ambiguityScore.toFixed(3)}).`,
+          );
+        }
+        res.end();
         return;
       }
 
@@ -256,6 +428,52 @@ export function assessRoutes(db: Db) {
       const result = await projectSvc.getProjectAssessment(companyId, slug);
       if (!result) { res.status(404).json({ error: "No project assessment found" }); return; }
       res.json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Internal server error";
+      res.status(httpStatus(err)).json({ error: message });
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // AgentDash (Phase D): GET /onboarding/in-progress
+  //
+  // Resume support (Pre-mortem #2 mitigation): the SPA calls this on
+  // /assess load to determine whether to offer "resume your interview".
+  // Returns the in-progress deep_interview_states row for (scope, scopeRefId);
+  // null when none. Mounted under /api at the app level so the final URL is
+  // GET /api/onboarding/in-progress?scope=...&scopeRefId=...
+  // ────────────────────────────────────────────────────────────────────
+  router.get("/onboarding/in-progress", async (req, res) => {
+    try {
+      const scope = String(req.query.scope ?? "");
+      const scopeRefId = String(req.query.scopeRefId ?? "");
+      if (scope !== "cos_onboarding" && scope !== "assess_project") {
+        res.status(400).json({ error: "scope must be 'cos_onboarding' or 'assess_project'" });
+        return;
+      }
+      if (!scopeRefId) {
+        res.status(400).json({ error: "scopeRefId required" });
+        return;
+      }
+      // Authorization: the caller must have access to the company associated
+      // with this state row. For cos_onboarding scope, scopeRefId is the
+      // companyId (per Phase D wiring). For assess_project, scopeRefId is a
+      // synthetic project key prefixed with "<companyId>:" — we extract the
+      // companyId for the access check.
+      let companyIdForAuthz = scopeRefId;
+      if (scope === "assess_project") {
+        const sep = scopeRefId.indexOf(":");
+        if (sep > 0) companyIdForAuthz = scopeRefId.slice(0, sep);
+      }
+      assertCompanyAccess(req, companyIdForAuthz);
+
+      const state = await engine.getInProgress(scope as DeepInterviewScope, scopeRefId);
+      const resumeUrl = state
+        ? scope === "cos_onboarding"
+          ? `/assess?onboarding=1`
+          : `/assess?mode=project`
+        : null;
+      res.json({ state, resumeUrl });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Internal server error";
       res.status(httpStatus(err)).json({ error: message });


### PR DESCRIPTION
## Summary

Phase D of the AgentDash onboarding redesign — wires the deep-interview engine
(Phase C) into the existing `/assess` (company) and `/assess/project` (project)
routes behind `AGENTDASH_DEEP_INTERVIEW_ASSESS`, **default OFF in production**.

- Flag is read at request-handling time (not module load) so a flag flip takes
  effect without a restart.
- When OFF: existing assess engine behavior is byte-identical (legacy
  MiniMax streaming markdown + project clarify/followup paths).
- When ON: each route branches into `deepInterviewEngine.nextTurn()` —
  - `POST /companies/:cid/assess` → `scope='cos_onboarding'`, `scopeRefId=companyId`
  - `POST /assess/project/{clarify,followup,run}` → `scope='assess_project'`,
    `scopeRefId='<companyId>:<projectName>'` (synthetic key — Phase D has no
    project_id substrate yet)
- New `GET /api/onboarding/in-progress?scope=...&scopeRefId=...` endpoint
  (Pre-mortem #2 mitigation — returns the in-progress
  `deep_interview_states` row so the SPA can offer "resume your interview"
  on `/assess` load).

## Hand-off conditions met

- **Flag default OFF.** Phase F flips the default and removes the legacy branch.
- **UI shape preserved.** No changes to `ui/src/api/assess.ts` or `AssessPage.tsx`.
- **No DB schema changes.** Reuses `deep_interview_states` and `deep_interview_specs` from Phase B.
- **No CoS handoff.** Phase F handles `crystallizeAndAdvanceCos`.

## Flag

`AGENTDASH_DEEP_INTERVIEW_ASSESS` — set `="true"` to route through the new
engine; unset/anything else → legacy path. Default OFF.

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` — passes
- [x] `pnpm --filter @paperclipai/server exec vitest run assess` — 34 tests pass
  (4 files: assess-prompts, assess-retrieval, assess-routes [+12 new cases], assess-service)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)