### PR TITLE
feat(cos-onboarding): Phase E — post-signup → /company-create redirect

### DIFF
--- a/server/src/__tests__/auth-hook-removal.test.ts
+++ b/server/src/__tests__/auth-hook-removal.test.ts
@@ -1,0 +1,89 @@
+// AgentDash (Phase E): the post-signup auto-bootstrap auth hook is dropped
+// in v2 — fresh signups now flow through /company-create → /assess → /cos
+// in the SPA. This test verifies that:
+//
+// 1. With the legacy flag UNSET (default v2 behavior), createBetterAuthInstance
+//    is invoked WITHOUT an `onUserCreated` callback. The orchestrator's
+//    bootstrap() is therefore unreachable from sign-up.
+// 2. With AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP=true, the hook IS wired and
+//    invoking it calls orchestrator.bootstrap(userId).
+//
+// We exercise the same env-driven branch in server/src/index.ts (lines around
+// the createBetterAuthInstance call) without booting the full server.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_FLAG = process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP;
+
+afterEach(() => {
+  if (ORIGINAL_FLAG === undefined) {
+    delete process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP;
+  } else {
+    process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP = ORIGINAL_FLAG;
+  }
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  delete process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP;
+});
+
+/**
+ * Mirrors the branch in server/src/index.ts that decides whether to wire
+ * the legacy auto-bootstrap hook on Better Auth. We re-implement the small
+ * decision shape here so the test stays a unit (no Express + DB boot) but
+ * still covers the real flag string and the orchestrator-call shape.
+ */
+function decideOnUserCreated(opts: {
+  bootstrap: (userId: string) => Promise<{ companyId: string; cosAgentId: string }>;
+}): ((user: { id: string; email: string; name: string | null }) => Promise<void>) | undefined {
+  const legacyAutoBootstrap =
+    process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP === "true";
+  if (!legacyAutoBootstrap) return undefined;
+  return async (user) => {
+    await opts.bootstrap(user.id);
+  };
+}
+
+describe("Phase E — Better Auth onUserCreated hook (authenticated mode only)", () => {
+  it("does NOT wire onUserCreated when AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP is unset (v2 default)", async () => {
+    const bootstrap = vi.fn().mockResolvedValue({ companyId: "c1", cosAgentId: "a1" });
+
+    const onUserCreated = decideOnUserCreated({ bootstrap });
+
+    expect(onUserCreated).toBeUndefined();
+    expect(bootstrap).not.toHaveBeenCalled();
+  });
+
+  it("does NOT wire onUserCreated when the flag is set to anything other than 'true'", async () => {
+    const bootstrap = vi.fn().mockResolvedValue({ companyId: "c1", cosAgentId: "a1" });
+    process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP = "false";
+
+    expect(decideOnUserCreated({ bootstrap })).toBeUndefined();
+
+    process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP = "1";
+    expect(decideOnUserCreated({ bootstrap })).toBeUndefined();
+
+    expect(bootstrap).not.toHaveBeenCalled();
+  });
+
+  it("wires onUserCreated and calls orchestrator.bootstrap(user.id) when AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP=true", async () => {
+    process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP = "true";
+    const bootstrap = vi.fn().mockResolvedValue({ companyId: "c1", cosAgentId: "a1" });
+
+    const onUserCreated = decideOnUserCreated({ bootstrap });
+    expect(onUserCreated).toBeTypeOf("function");
+
+    await onUserCreated!({ id: "user-42", email: "alice@acme.com", name: "Alice" });
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(bootstrap).toHaveBeenCalledWith("user-42");
+  });
+});
+
+// Out-of-scope documentation:
+// local_trusted deployment mode is intentionally NOT covered here. The
+// short-circuit at server/src/index.ts:486-488 routes local_trusted boots
+// to ensureLocalTrustedBoardPrincipal BEFORE createBetterAuthInstance is
+// called, so the hook never runs in that mode and Phase E's flag has no
+// effect. local_trusted bootstrap continues to work via its own code path.

--- a/server/src/__tests__/companies-routes-from-signup.test.ts
+++ b/server/src/__tests__/companies-routes-from-signup.test.ts
@@ -1,0 +1,144 @@
+// AgentDash (Phase E): POST /api/companies?fromSignup=1 must return 409 if
+// the user is already a member of any workspace. The SPA's /company-create
+// page sets that query param so an invitee who navigates back from /cos
+// gets redirected instead of accidentally creating a duplicate workspace.
+//
+// Plain POST /api/companies (without ?fromSignup=1) keeps existing behavior
+// — non-Better-Auth callers (CLI bootstrap, scripts, e2e helpers) that
+// legitimately create multiple companies are unaffected.
+
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { companyRoutes } from "../routes/companies.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+const acmeUser = { id: "user-1", email: "alice@acme.com" };
+
+const fakeDb = {
+  select: vi.fn(() => ({
+    from: () => ({
+      where: () => Promise.resolve([{ email: acmeUser.email }]),
+    }),
+  })),
+} as any;
+
+let createMock: ReturnType<typeof vi.fn>;
+let findByEmailDomainMock: ReturnType<typeof vi.fn>;
+let ensureMembershipMock: ReturnType<typeof vi.fn>;
+let setPrincipalPermissionMock: ReturnType<typeof vi.fn>;
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    list: vi.fn().mockResolvedValue([]),
+    stats: vi.fn().mockResolvedValue({}),
+    getById: vi.fn(),
+    create: (...args: unknown[]) => createMock(...args),
+    findByEmailDomain: (...args: unknown[]) => findByEmailDomainMock(...args),
+    update: vi.fn(),
+    archive: vi.fn(),
+    remove: vi.fn(),
+  }),
+  companyPortabilityService: () => ({
+    exportBundle: vi.fn(),
+    previewExport: vi.fn(),
+    previewImport: vi.fn(),
+    importBundle: vi.fn(),
+  }),
+  accessService: () => ({
+    canUser: vi.fn(),
+    ensureMembership: (...args: unknown[]) => ensureMembershipMock(...args),
+    setPrincipalPermission: (...args: unknown[]) => setPrincipalPermissionMock(...args),
+  }),
+  budgetService: () => ({ upsertPolicy: vi.fn() }),
+  agentService: () => ({ getById: vi.fn() }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(),
+    listFeedbackTraces: vi.fn(),
+    getFeedbackTraceById: vi.fn(),
+    saveIssueVote: vi.fn(),
+  }),
+  logActivity: vi.fn(),
+}));
+
+function buildApp(actor: {
+  userId: string;
+  companyIds: string[];
+  isInstanceAdmin?: boolean;
+}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: actor.userId,
+      companyIds: actor.companyIds,
+      isInstanceAdmin: actor.isInstanceAdmin ?? false,
+      source: "session",
+    };
+    next();
+  });
+  app.use("/api/companies", companyRoutes(fakeDb, undefined, {}));
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  createMock = vi.fn().mockResolvedValue({
+    id: "company-1",
+    name: "Acme",
+    budgetMonthlyCents: 0,
+    emailDomain: "acme.com",
+  });
+  findByEmailDomainMock = vi.fn().mockResolvedValue(null);
+  ensureMembershipMock = vi.fn().mockResolvedValue({});
+  setPrincipalPermissionMock = vi.fn().mockResolvedValue(undefined);
+});
+
+describe("POST /api/companies?fromSignup=1 — Phase E invite-flow guard", () => {
+  it("returns 409 already_member when the user already has a company membership", async () => {
+    const app = buildApp({ userId: "user-1", companyIds: ["company-existing"] });
+    const res = await request(app)
+      .post("/api/companies?fromSignup=1")
+      .send({ name: "Acme Two" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "already_member",
+      existingCompanyId: "company-existing",
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 also when fromSignup=true (string variant)", async () => {
+    const app = buildApp({ userId: "user-1", companyIds: ["company-existing"] });
+    const res = await request(app)
+      .post("/api/companies?fromSignup=true")
+      .send({ name: "Acme Two" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("already_member");
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("creates the company normally when the user has no existing membership (first signup)", async () => {
+    const app = buildApp({ userId: "user-1", companyIds: [] });
+    const res = await request(app)
+      .post("/api/companies?fromSignup=1")
+      .send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+  });
+
+  it("does NOT trigger the 409 when fromSignup is absent (CLI / scripts / e2e helpers)", async () => {
+    // Non-Better-Auth callers that legitimately create multiple companies
+    // must continue to work. The guard is opt-in via the SPA's query param.
+    const app = buildApp({ userId: "user-1", companyIds: ["company-existing"] });
+    const res = await request(app).post("/api/companies").send({ name: "Acme Two" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -512,39 +512,61 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Authenticated mode auth origin configuration",
     );
-    // Lazy-imported so the auth bootstrap doesn't pull in service deps
-    // (and their plugin SDK pinholes) at module load. The callback runs
-    // once per fresh sign-up and provisions a company + CoS agent +
-    // conversation for the new user — without it the SPA's
-    // CloudAccessGate parks them at "No company access" because they
-    // have zero memberships.
-    const onUserCreated = async (user: { id: string; email: string; name: string | null }) => {
-      const services = await import("./services/index.js");
-      const { authUsers } = await import("@paperclipai/db");
-      const { eq } = await import("drizzle-orm");
-      const orch = services.onboardingOrchestrator({
-        access: services.accessService(db as any),
-        companies: services.companyService(db as any),
-        agents: services.agentService(db as any),
-        instructions: services.agentInstructionsService(),
-        conversations: services.conversationService(db as any),
-        users: {
-          getById: async (id: string) => {
-            const rows = await (db as any)
-              .select()
-              .from(authUsers)
-              .where(eq(authUsers.id, id));
-            return rows[0] ?? null;
-          },
-        },
-      });
-      const result = await orch.bootstrap(user.id);
+    // AgentDash (Phase E): the auto-bootstrap auth hook is dropped in v2.
+    // Fresh signups now flow through /company-create → /assess?onboarding=1
+    // → /cos in the SPA (see ui/src/pages/Auth.tsx onSuccess and
+    // ui/src/pages/CompanyCreate.tsx). The hook only runs in `authenticated`
+    // deployment mode — server/src/index.ts:486-488 short-circuits
+    // local_trusted before createBetterAuthInstance is ever called, so
+    // local_trusted bootstrap (ensureLocalTrustedBoardPrincipal) is OUT OF
+    // SCOPE for this change and follows a different code path.
+    //
+    // Behind a one-release-window rollback flag: setting
+    // AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP=true re-arms the legacy hook so
+    // operators can fall back if the SPA-driven flow regresses. Default off.
+    // Removal calendar reminder: 2026-05-24 (two stable weeks after Phase E).
+    const legacyAutoBootstrap =
+      process.env.AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP === "true";
+    const onUserCreated = legacyAutoBootstrap
+      ? async (user: { id: string; email: string; name: string | null }) => {
+          const services = await import("./services/index.js");
+          const { authUsers } = await import("@paperclipai/db");
+          const { eq } = await import("drizzle-orm");
+          const orch = services.onboardingOrchestrator({
+            access: services.accessService(db as any),
+            companies: services.companyService(db as any),
+            agents: services.agentService(db as any),
+            instructions: services.agentInstructionsService(),
+            conversations: services.conversationService(db as any),
+            users: {
+              getById: async (id: string) => {
+                const rows = await (db as any)
+                  .select()
+                  .from(authUsers)
+                  .where(eq(authUsers.id, id));
+                return rows[0] ?? null;
+              },
+            },
+          });
+          const result = await orch.bootstrap(user.id);
+          logger.info(
+            { userId: user.id, companyId: result.companyId, cosAgentId: result.cosAgentId },
+            "[auth] bootstrapped workspace for new sign-up (legacy autoboot flag enabled)",
+          );
+        }
+      : undefined;
+    if (!legacyAutoBootstrap) {
       logger.info(
-        { userId: user.id, companyId: result.companyId, cosAgentId: result.cosAgentId },
-        "[auth] bootstrapped workspace for new sign-up",
+        { deploymentMode: "authenticated" },
+        "[auth] auto-bootstrap on signup is disabled (v2 flow); set AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP=true to re-enable",
       );
-    };
-    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins, { onUserCreated });
+    }
+    const auth = createBetterAuthInstance(
+      db as any,
+      config,
+      effectiveTrustedOrigins,
+      onUserCreated ? { onUserCreated } : undefined,
+    );
     betterAuthHandler = createBetterAuthHandler(auth);
     resolveSession = (req) => resolveBetterAuthSession(auth, req);
     resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -289,6 +289,27 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
     // Free-mail rejection (AGE-60), domain uniqueness (AGE-55), and the
     // free single-seat cap (AGE-100) are the real safeguards.
 
+    // AgentDash (Phase E): post-signup /company-create flow guard. When the
+    // SPA's /company-create page submits, it sets ?fromSignup=1 to opt into
+    // a 409 if the user already has any company membership (invite-path
+    // mitigation: an invitee who navigates back must NOT double-create a
+    // workspace — the UI catches the 409 and routes them to /cos). Scoped
+    // to the query param so non-Better-Auth callers (CLI bootstrap, scripts,
+    // e2e helpers) that legitimately create multiple companies are not
+    // affected.
+    if (req.query.fromSignup === "1" || req.query.fromSignup === "true") {
+      const existingCompanyIds = req.actor.companyIds ?? [];
+      if (existingCompanyIds.length > 0) {
+        res.status(409).json({
+          code: "already_member",
+          existingCompanyId: existingCompanyIds[0] ?? null,
+          message:
+            "User is already a member of a workspace; redirect to it instead of creating another.",
+        });
+        return;
+      }
+    }
+
     // AgentDash (AGE-55): FRE Plan B — derive email_domain from the creator's
     // authenticated email. local_implicit actors (single-machine dev) have no
     // email, so we leave the domain NULL and grandfather them in.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,6 +49,7 @@ import BillingPage from "./pages/BillingPage";
 import { AssessPage } from "./pages/AssessPage";
 import { AssessHistoryPage } from "./pages/AssessHistoryPage";
 import { AuthPage } from "./pages/Auth";
+import { CompanyCreatePage } from "./pages/CompanyCreate";
 import { ForgotPasswordPage } from "./pages/ForgotPassword";
 import { ResetPasswordPage } from "./pages/ResetPassword";
 import { BoardClaimPage } from "./pages/BoardClaim";
@@ -294,6 +295,10 @@ export function App() {
         <Route path="assess/history" element={<AssessHistoryPage />} />
 
         <Route element={<CloudAccessGate />}>
+          {/* AgentDash (Phase E): post-signup → /company-create.
+              The user has no company yet, so this lives outside the
+              :companyPrefix boardRoutes block. */}
+          <Route path="company-create" element={<CompanyCreatePage />} />
           {/* AgentDash: CoS onboarding v2 conversation */}
           <Route path="cos" element={<CoSConversation />} />
           <Route path="onboarding" element={<OnboardingRoutePage />} />

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -17,12 +17,18 @@ export const companiesApi = {
   list: () => api.get<Company[]>("/companies"),
   get: (companyId: string) => api.get<Company>(`/companies/${companyId}`),
   stats: () => api.get<CompanyStats>("/companies/stats"),
-  create: (data: {
-    name: string;
-    description?: string | null;
-    budgetMonthlyCents?: number;
-  }) =>
-    api.post<Company>("/companies", data),
+  create: (
+    data: {
+      name: string;
+      description?: string | null;
+      budgetMonthlyCents?: number;
+    },
+    options?: { fromSignup?: boolean },
+  ) =>
+    api.post<Company>(
+      options?.fromSignup ? "/companies?fromSignup=1" : "/companies",
+      data,
+    ),
   update: (
     companyId: string,
     data: Partial<

--- a/ui/src/pages/Auth.test.tsx
+++ b/ui/src/pages/Auth.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthPage } from "./Auth";
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockSignUp = vi.hoisted(() => vi.fn());
+const mockSignIn = vi.hoisted(() => vi.fn());
+const mockGetSession = vi.hoisted(() =>
+  vi.fn().mockRejectedValue(new Error("no session")),
+);
+
+vi.mock("@/lib/router", () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [new URLSearchParams("?mode=sign_up"), vi.fn()],
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+vi.mock("@/api/auth", () => ({
+  authApi: {
+    getSession: () => mockGetSession(),
+    signUpEmail: (...args: unknown[]) => mockSignUp(...args),
+    signInEmail: (...args: unknown[]) => mockSignIn(...args),
+  },
+}));
+
+vi.mock("@/marketing/sections/LiveBriefing", () => ({
+  LiveBriefing: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("AuthPage post-signup redirect (Phase E)", () => {
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    mockNavigate.mockReset();
+    mockSignUp.mockReset();
+    mockSignIn.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function render() {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <AuthPage />
+        </QueryClientProvider>,
+      );
+    });
+    return root;
+  }
+
+  it("navigates to /company-create after a successful sign-up", async () => {
+    mockSignUp.mockResolvedValue(undefined);
+
+    render();
+    await flushReact();
+
+    const inputs = container.querySelectorAll("input");
+    const nameInput = inputs[0] as HTMLInputElement;
+    const emailInput = inputs[1] as HTMLInputElement;
+    const passwordInput = inputs[2] as HTMLInputElement;
+    const form = container.querySelector("form") as HTMLFormElement;
+
+    await act(async () => {
+      nameInput.value = "Alice";
+      nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+      emailInput.value = "alice@acme.com";
+      emailInput.dispatchEvent(new Event("input", { bubbles: true }));
+      passwordInput.value = "supersecret";
+      passwordInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(mockSignUp).toHaveBeenCalledWith({
+      name: "Alice",
+      email: "alice@acme.com",
+      password: "supersecret",
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/company-create", { replace: true });
+  });
+});

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -62,8 +62,11 @@ export function AuthPage() {
       setError(null);
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
       await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
-      // AgentDash: new sign-ups land on the CoS onboarding v2 conversation.
-      const destination = mode === "sign_up" ? "/cos" : nextPath;
+      // AgentDash (Phase E): fresh sign-ups land on /company-create so the
+      // user explicitly names their workspace before the assess + CoS flow.
+      // Sign-ins go to wherever they were already heading (preserves
+      // ?next=… deep links and the remembered invite path).
+      const destination = mode === "sign_up" ? "/company-create" : nextPath;
       navigate(destination, { replace: true });
     },
     onError: (err) => {

--- a/ui/src/pages/CompanyCreate.test.tsx
+++ b/ui/src/pages/CompanyCreate.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompanyCreatePage } from "./CompanyCreate";
+import { ApiError } from "../api/client";
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockCreate = vi.hoisted(() => vi.fn());
+const mockSetSelectedCompanyId = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/api/companies", () => ({
+  companiesApi: {
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+}));
+
+vi.mock("@/context/CompanyContext", () => ({
+  useCompany: () => ({
+    setSelectedCompanyId: mockSetSelectedCompanyId,
+  }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("CompanyCreatePage", () => {
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    mockNavigate.mockReset();
+    mockCreate.mockReset();
+    mockSetSelectedCompanyId.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function render() {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CompanyCreatePage />
+        </QueryClientProvider>,
+      );
+    });
+    return root;
+  }
+
+  it("renders the workspace name form", () => {
+    render();
+    const heading = container.querySelector("h1");
+    expect(heading?.textContent).toContain("Name your workspace");
+    const input = container.querySelector("input#company-name") as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+  });
+
+  it("submits to companiesApi.create with fromSignup and navigates to /assess?onboarding=1", async () => {
+    mockCreate.mockResolvedValue({ id: "company-1", name: "Acme" });
+
+    render();
+    const input = container.querySelector("input#company-name") as HTMLInputElement;
+    const form = container.querySelector("form") as HTMLFormElement;
+
+    await act(async () => {
+      input.value = "Acme";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(mockCreate).toHaveBeenCalledWith({ name: "Acme" }, { fromSignup: true });
+    expect(mockSetSelectedCompanyId).toHaveBeenCalledWith("company-1");
+    expect(mockNavigate).toHaveBeenCalledWith("/assess?onboarding=1", { replace: true });
+  });
+
+  it("redirects to /cos when the server returns 409 already_member (invite-flow safety)", async () => {
+    mockCreate.mockRejectedValue(
+      new ApiError("already_member", 409, { code: "already_member" }),
+    );
+
+    render();
+    const input = container.querySelector("input#company-name") as HTMLInputElement;
+    const form = container.querySelector("form") as HTMLFormElement;
+
+    await act(async () => {
+      input.value = "Acme";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/cos", { replace: true });
+  });
+
+  it("disables submit when the workspace name is empty", () => {
+    render();
+    const button = container.querySelector("button[type='submit']") as HTMLButtonElement;
+    expect(button.getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/ui/src/pages/CompanyCreate.tsx
+++ b/ui/src/pages/CompanyCreate.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@/lib/router";
+import { companiesApi } from "../api/companies";
+import { ApiError } from "../api/client";
+import { queryKeys } from "../lib/queryKeys";
+import { Button } from "@/components/ui/button";
+import { useCompany } from "../context/CompanyContext";
+import { Sparkles, Building2 } from "lucide-react";
+
+// AgentDash (Phase E): standalone /company-create page for the post-signup
+// redirect chain. Lifted out of OnboardingWizard.tsx step 1 so the wizard's
+// later steps (agent + task + launch) stay available for returning users
+// while fresh signups go through this page → /assess → /cos.
+//
+// On submit we POST /api/companies. If the user already has a membership the
+// server returns 409 (companies.ts guard); we treat that as "go straight to
+// CoS" so an invitee who navigates back from /cos doesn't double-create.
+export function CompanyCreatePage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setSelectedCompanyId } = useCompany();
+  const [companyName, setCompanyName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      // fromSignup=1 opts into the server-side 409 guard so an invitee who
+      // already has a workspace gets redirected to /cos instead of
+      // accidentally creating a duplicate workspace.
+      return companiesApi.create(
+        { name: companyName.trim() },
+        { fromSignup: true },
+      );
+    },
+    onSuccess: async (company) => {
+      setSelectedCompanyId(company.id);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+      navigate("/assess?onboarding=1", { replace: true });
+    },
+    onError: (err) => {
+      // 409 means the user already has a workspace (invite path or duplicate
+      // submission). Route them to /cos rather than dead-ending on an error.
+      if (err instanceof ApiError && err.status === 409) {
+        navigate("/cos", { replace: true });
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Failed to create workspace");
+    },
+  });
+
+  const canSubmit = companyName.trim().length > 0 && !mutation.isPending;
+
+  return (
+    <div className="fixed inset-0 flex bg-surface-page">
+      <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
+        <div className="flex items-center gap-2 mb-8">
+          <Sparkles className="h-4 w-4 text-text-tertiary" />
+          <span className="text-sm font-medium text-text-primary">AgentDash</span>
+        </div>
+
+        <div className="flex items-center gap-3 mb-4">
+          <div className="bg-muted/50 p-2 rounded-md">
+            <Building2 className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-text-primary">Name your workspace</h1>
+            <p className="mt-1 text-sm text-text-secondary">
+              This is the organization your agents will work for.
+            </p>
+          </div>
+        </div>
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!canSubmit) {
+              setError("Please enter a workspace name.");
+              return;
+            }
+            mutation.mutate();
+          }}
+        >
+          <div>
+            <label
+              htmlFor="company-name"
+              className="text-xs text-text-secondary mb-1 block font-medium"
+            >
+              Workspace name
+            </label>
+            <input
+              id="company-name"
+              name="name"
+              className="w-full rounded-md border border-border-soft bg-surface-raised px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-accent-500 focus:ring-2 focus:ring-accent-200 transition-[color,box-shadow]"
+              value={companyName}
+              onChange={(event) => setCompanyName(event.target.value)}
+              placeholder="Acme Corp"
+              autoFocus
+              autoComplete="organization"
+            />
+          </div>
+          {error && <p className="text-xs text-danger-500">{error}</p>}
+          <Button
+            type="submit"
+            disabled={mutation.isPending}
+            aria-disabled={!canSubmit}
+            className={`w-full ${!canSubmit ? "opacity-50" : ""}`}
+          >
+            {mutation.isPending ? "Creating…" : "Continue"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Phase E of the onboarding redesign: fresh signups now flow signup → `/company-create` → `/assess?onboarding=1` → `/cos`.
- The auto-bootstrap auth hook (`databaseHooks.user.create.after`) is dropped in `authenticated` deployment mode behind the rollback flag `AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP=true` (default off). `local_trusted` is OUT OF SCOPE — that path short-circuits before `createBetterAuthInstance` is ever called (server/src/index.ts:486-488).
- `POST /api/companies?fromSignup=1` returns 409 `already_member` if the user has any existing membership; the SPA catches it and redirects to `/cos`. Scoped to the query param so non-Better-Auth callers (CLI, scripts, e2e) are unaffected.

## Files
- `ui/src/pages/CompanyCreate.tsx` (new) — extracted from `OnboardingWizard.tsx:392`
- `ui/src/pages/Auth.tsx` — `sign_up` redirects to `/company-create`
- `ui/src/App.tsx` — registers `/company-create` inside `CloudAccessGate`, outside `:companyPrefix`
- `ui/src/api/companies.ts` — adds `fromSignup` option
- `server/src/index.ts` — gates `onUserCreated` behind `AGENTDASH_LEGACY_AUTH_AUTOBOOTSTRAP`
- `server/src/routes/companies.ts` — 409 guard on `?fromSignup=1`
- Tests: `auth-hook-removal`, `companies-routes-from-signup`, `CompanyCreate`, `Auth`

## Test plan
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `pnpm --filter @paperclipai/ui typecheck`
- [ ] `pnpm --filter @paperclipai/server exec vitest run auth-hook-removal companies-routes-from-signup`
- [ ] `pnpm --filter @paperclipai/ui exec vitest run CompanyCreate Auth`
- [ ] CI green; auto-merge after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)