### PR TITLE
fix(cos-onboarding): Phase E UI tests — use native value setter + click

### DIFF
--- a/ui/src/pages/Auth.test.tsx
+++ b/ui/src/pages/Auth.test.tsx
@@ -74,30 +74,42 @@ describe("AuthPage post-signup redirect (Phase E)", () => {
     return root;
   }
 
+  function setNativeValue(el: HTMLInputElement, value: string) {
+    const desc = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    );
+    desc?.set?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
   it("navigates to /company-create after a successful sign-up", async () => {
     mockSignUp.mockResolvedValue(undefined);
 
     render();
+    // Wait for the session-loading branch to finish so the form mounts.
+    await flushReact();
+    await flushReact();
     await flushReact();
 
-    const inputs = container.querySelectorAll("input");
-    const nameInput = inputs[0] as HTMLInputElement;
-    const emailInput = inputs[1] as HTMLInputElement;
-    const passwordInput = inputs[2] as HTMLInputElement;
-    const form = container.querySelector("form") as HTMLFormElement;
+    const nameInput = container.querySelector("input#name") as HTMLInputElement | null;
+    const emailInput = container.querySelector("input#email") as HTMLInputElement;
+    const passwordInput = container.querySelector("input#password") as HTMLInputElement;
+    const button = container.querySelector("button[type='submit']") as HTMLButtonElement;
+
+    expect(nameInput, "name input must be rendered in sign_up mode").not.toBeNull();
 
     await act(async () => {
-      nameInput.value = "Alice";
-      nameInput.dispatchEvent(new Event("input", { bubbles: true }));
-      emailInput.value = "alice@acme.com";
-      emailInput.dispatchEvent(new Event("input", { bubbles: true }));
-      passwordInput.value = "supersecret";
-      passwordInput.dispatchEvent(new Event("input", { bubbles: true }));
+      setNativeValue(nameInput!, "Alice");
+      setNativeValue(emailInput, "alice@acme.com");
+      setNativeValue(passwordInput, "supersecret");
     });
+    await flushReact();
 
     await act(async () => {
-      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      button.click();
     });
+    await flushReact();
     await flushReact();
     await flushReact();
 

--- a/ui/src/pages/CompanyCreate.test.tsx
+++ b/ui/src/pages/CompanyCreate.test.tsx
@@ -76,21 +76,31 @@ describe("CompanyCreatePage", () => {
     expect(input).not.toBeNull();
   });
 
+  function setNativeValue(el: HTMLInputElement, value: string) {
+    const desc = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    );
+    desc?.set?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
   it("submits to companiesApi.create with fromSignup and navigates to /assess?onboarding=1", async () => {
     mockCreate.mockResolvedValue({ id: "company-1", name: "Acme" });
 
     render();
     const input = container.querySelector("input#company-name") as HTMLInputElement;
-    const form = container.querySelector("form") as HTMLFormElement;
+    const button = container.querySelector("button[type='submit']") as HTMLButtonElement;
 
     await act(async () => {
-      input.value = "Acme";
-      input.dispatchEvent(new Event("input", { bubbles: true }));
+      setNativeValue(input, "Acme");
     });
+    await flushReact();
 
     await act(async () => {
-      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      button.click();
     });
+    await flushReact();
     await flushReact();
     await flushReact();
 
@@ -106,15 +116,16 @@ describe("CompanyCreatePage", () => {
 
     render();
     const input = container.querySelector("input#company-name") as HTMLInputElement;
-    const form = container.querySelector("form") as HTMLFormElement;
+    const button = container.querySelector("button[type='submit']") as HTMLButtonElement;
 
     await act(async () => {
-      input.value = "Acme";
-      input.dispatchEvent(new Event("input", { bubbles: true }));
+      setNativeValue(input, "Acme");
     });
+    await flushReact();
     await act(async () => {
-      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      button.click();
     });
+    await flushReact();
     await flushReact();
     await flushReact();
 


### PR DESCRIPTION
## Summary
Phase E (#145) merged with two new UI tests (\`CompanyCreate.test.tsx\` and \`Auth.test.tsx\`) that pass locally on a clean checkout but fail with React 19's synthetic event dispatch — three of the five test cases never fired the React submit handler so the spies recorded zero calls.

## Fix
- Replace \`input.value = "…"\` with the HTMLInputElement \`value\` descriptor setter so React's synthetic input handler picks up the change.
- Replace \`form.dispatchEvent("submit")\` with \`button.click()\` so React's synthetic submit handler runs.
- Use \`querySelector('input#id')\` for stable element lookup.

5/5 UI tests pass after the fix.

## Test plan
- [x] \`pnpm --filter @paperclipai/ui exec vitest run CompanyCreate Auth\` → 2 files / 5 tests pass.
- [ ] CI green; auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)