### PR TITLE
feat(cos-onboarding): Phase F — CoS reads spec + crystallize helper

### DIFF
--- a/server/src/__tests__/deep-interview-crystallize.test.ts
+++ b/server/src/__tests__/deep-interview-crystallize.test.ts
@@ -1,0 +1,243 @@
+// AgentDash (Phase F): unit tests for crystallizeAndAdvanceCos.
+//
+// Mocks Drizzle's transaction + chain calls at the call-site shape. The
+// helper does:
+//   tx.select().from().where().for("update")        — lock state row
+//   tx.select().from().where().limit(1)             — look up prior spec
+//                                                       (idempotent branch)
+//   tx.insert(specsTable).values(...).returning()   — write new spec
+//   tx.update(statesTable).set(...).where(...)      — flip status
+//   tx.update(cosTable).set(...).where(...)         — advance CoS phase
+//                                                       (cos_onboarding scope)
+//
+// We don't stand up an embedded postgres for these. We assert the writes
+// happen in the right order and that idempotency is rock-solid: a second
+// call on a `crystallized` state must not insert again.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { crystallizeAndAdvanceCos } from "../services/deep-interview-crystallize.js";
+import type {
+  DimensionScores,
+  OntologySnapshot,
+  TranscriptTurn,
+} from "@paperclipai/shared/deep-interview";
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+interface FakeStateRow {
+  id: string;
+  scope: "cos_onboarding" | "assess_project";
+  scopeRefId: string;
+  status: "in_progress" | "ready_to_crystallize" | "crystallized" | "abandoned";
+  ambiguityScore: number | null;
+  dimensionScores: DimensionScores | null;
+  ontologySnapshots: OntologySnapshot[];
+  transcript: TranscriptTurn[];
+}
+
+interface FakeSpecRow {
+  id: string;
+  stateId: string;
+}
+
+interface UpdateRecord {
+  table: "deep_interview_states" | "cos_onboarding_states";
+  patch: Record<string, unknown>;
+}
+
+interface InsertRecord {
+  table: "deep_interview_specs";
+  values: Record<string, unknown>;
+  returnedId: string;
+}
+
+function makeStateRow(overrides?: Partial<FakeStateRow>): FakeStateRow {
+  return {
+    id: "state-aaaa-bbbb",
+    scope: "cos_onboarding",
+    scopeRefId: "conv-1234",
+    status: "ready_to_crystallize",
+    ambiguityScore: 0.15,
+    dimensionScores: { goal: 0.95, constraints: 0.9, criteria: 0.9, context: 0.85 },
+    ontologySnapshots: [
+      {
+        round: 5,
+        entities: [{ name: "Customer", type: "core_domain" }],
+        newCount: 1,
+        changedCount: 0,
+        stableCount: 0,
+        stabilityRatio: null,
+      },
+    ],
+    transcript: [
+      { round: 1, question: "Goal?", targetDimension: "goal", answer: "Grow ARR", ambiguityAfter: 0.6 },
+      { round: 2, question: "Constraints?", targetDimension: "constraints", answer: "No PII storage", ambiguityAfter: 0.4 },
+      { round: 3, question: "Criteria?", targetDimension: "criteria", answer: "10x faster than baseline", ambiguityAfter: 0.2 },
+    ],
+    ...overrides,
+  };
+}
+
+function makeFakeDb(args: {
+  stateRow: FakeStateRow | null;
+  priorSpecRow?: FakeSpecRow | null;
+  insertedSpecId?: string;
+}) {
+  const inserts: InsertRecord[] = [];
+  const updates: UpdateRecord[] = [];
+  let mutableState = args.stateRow ? { ...args.stateRow } : null;
+  const insertedSpecId = args.insertedSpecId ?? "spec-xxxx-yyyy";
+
+  // Track which select chain the helper is about to walk: state lookup uses
+  // `.for("update")`, prior-spec lookup uses `.limit(1)`. We branch on the
+  // terminal call to return the right rows.
+  const buildSelect = () => ({
+    from: (_table: unknown) => ({
+      where: (_predicate: unknown) => ({
+        for: async (_mode: string) =>
+          mutableState ? [{ ...mutableState }] : [],
+        limit: async (_n: number) =>
+          args.priorSpecRow ? [{ ...args.priorSpecRow }] : [],
+      }),
+    }),
+  });
+
+  const buildInsert = (_table: unknown) => ({
+    values: (val: Record<string, unknown>) => ({
+      returning: async () => {
+        inserts.push({
+          table: "deep_interview_specs",
+          values: val,
+          returnedId: insertedSpecId,
+        });
+        return [{ id: insertedSpecId, ...val }];
+      },
+    }),
+  });
+
+  // Drizzle's table objects expose `Symbol.for("drizzle:Name")` etc. We can't
+  // rely on those in unit-land, so we differentiate writes by the patch shape
+  // (status change vs phase change) instead of the table object.
+  const buildUpdate = (_table: unknown) => ({
+    set: (patch: Record<string, unknown>) => ({
+      where: async (_predicate: unknown) => {
+        const isStateFlip = "status" in patch;
+        const tableName: UpdateRecord["table"] = isStateFlip
+          ? "deep_interview_states"
+          : "cos_onboarding_states";
+        updates.push({ table: tableName, patch });
+        if (isStateFlip && mutableState) {
+          const nextStatus = patch.status as FakeStateRow["status"];
+          mutableState = { ...mutableState, status: nextStatus };
+        }
+      },
+    }),
+  });
+
+  const tx = {
+    select: buildSelect,
+    insert: buildInsert,
+    update: buildUpdate,
+  };
+
+  const db = {
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(tx),
+  } as unknown as Parameters<typeof crystallizeAndAdvanceCos>[0]["db"];
+
+  return {
+    db,
+    inserts,
+    updates,
+    getMutableState: () => mutableState,
+  };
+}
+
+describe("crystallizeAndAdvanceCos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inserts a spec, flips state status, and advances CoS phase (cos_onboarding scope)", async () => {
+    const fake = makeFakeDb({ stateRow: makeStateRow() });
+    const helper = crystallizeAndAdvanceCos({ db: fake.db });
+
+    const result = await helper("state-aaaa-bbbb");
+
+    expect(result.specId).toBe("spec-xxxx-yyyy");
+    expect(result.conversationId).toBe("conv-1234");
+
+    // Spec insert happened with goal/constraints/criteria pulled from the transcript.
+    expect(fake.inserts).toHaveLength(1);
+    const insert = fake.inserts[0]!;
+    expect(insert.values.goal).toBe("Grow ARR");
+    expect(insert.values.constraints).toEqual(["No PII storage"]);
+    expect(insert.values.criteria).toEqual(["10x faster than baseline"]);
+    expect(insert.values.finalAmbiguity).toBeCloseTo(0.15, 5);
+
+    // Two updates: deep_interview_states.status='crystallized', cos_onboarding_states.phase='plan'.
+    const stateUpdate = fake.updates.find((u) => u.table === "deep_interview_states");
+    const cosUpdate = fake.updates.find((u) => u.table === "cos_onboarding_states");
+    expect(stateUpdate?.patch.status).toBe("crystallized");
+    expect(cosUpdate?.patch.phase).toBe("plan");
+    expect(cosUpdate?.patch.deepInterviewSpecId).toBe("spec-xxxx-yyyy");
+  });
+
+  it("is idempotent: a second call on a crystallized state returns the prior spec without inserting", async () => {
+    // Pretend the first crystallize already ran: status is "crystallized" and a
+    // spec row already exists. The helper should early-return that prior spec.
+    const fake = makeFakeDb({
+      stateRow: makeStateRow({ status: "crystallized" }),
+      priorSpecRow: { id: "spec-prior-zzzz", stateId: "state-aaaa-bbbb" },
+    });
+    const helper = crystallizeAndAdvanceCos({ db: fake.db });
+
+    const result = await helper("state-aaaa-bbbb");
+
+    expect(result.specId).toBe("spec-prior-zzzz");
+    expect(result.conversationId).toBe("conv-1234");
+    expect(fake.inserts).toHaveLength(0);
+    expect(fake.updates).toHaveLength(0);
+  });
+
+  it("throws when the state row is not found", async () => {
+    const fake = makeFakeDb({ stateRow: null });
+    const helper = crystallizeAndAdvanceCos({ db: fake.db });
+
+    await expect(helper("nope")).rejects.toThrow(/not found/);
+    expect(fake.inserts).toHaveLength(0);
+  });
+
+  it("throws when status=crystallized but no spec row exists (hard inconsistency)", async () => {
+    const fake = makeFakeDb({
+      stateRow: makeStateRow({ status: "crystallized" }),
+      priorSpecRow: null,
+    });
+    const helper = crystallizeAndAdvanceCos({ db: fake.db });
+
+    await expect(helper("state-aaaa-bbbb")).rejects.toThrow(/no spec row exists/);
+  });
+
+  it("does NOT advance CoS phase for assess_project scope", async () => {
+    const fake = makeFakeDb({
+      stateRow: makeStateRow({ scope: "assess_project", scopeRefId: "company:Project Alpha" }),
+    });
+    const helper = crystallizeAndAdvanceCos({ db: fake.db });
+
+    const result = await helper("state-aaaa-bbbb");
+
+    expect(result.specId).toBe("spec-xxxx-yyyy");
+    // Spec inserted + state flipped, but no cos_onboarding_states update.
+    expect(fake.inserts).toHaveLength(1);
+    expect(fake.updates.find((u) => u.table === "cos_onboarding_states")).toBeUndefined();
+    expect(fake.updates.find((u) => u.table === "deep_interview_states")?.patch.status).toBe(
+      "crystallized",
+    );
+  });
+});

--- a/server/src/routes/assess.ts
+++ b/server/src/routes/assess.ts
@@ -94,9 +94,15 @@ export function assessRoutes(db: Db) {
         if (turn.kind === "question") {
           res.write(turn.question);
         } else {
-          res.write(
-            `[deep-interview] Ready to crystallize at round ${turn.round} (ambiguity ${turn.ambiguityScore.toFixed(3)}).`,
-          );
+          // AgentDash (Phase F): emit a parseable JSON envelope so the SPA
+          // can extract the stateId and call /api/onboarding/finalize-assessment.
+          // Format: `[deep-interview-ready] {"stateId":"…","round":N,"ambiguity":0.x}`
+          const env = JSON.stringify({
+            stateId: turn.stateId,
+            round: turn.round,
+            ambiguity: Number(turn.ambiguityScore.toFixed(3)),
+          });
+          res.write(`[deep-interview-ready] ${env}`);
         }
         res.end();
         return;
@@ -317,9 +323,13 @@ export function assessRoutes(db: Db) {
         if (turn.kind === "question") {
           res.write(turn.question);
         } else {
-          res.write(
-            `[deep-interview] Ready to crystallize at round ${turn.round} (ambiguity ${turn.ambiguityScore.toFixed(3)}).`,
-          );
+          // AgentDash (Phase F): structured marker — see company-mode emission above.
+          const env = JSON.stringify({
+            stateId: turn.stateId,
+            round: turn.round,
+            ambiguity: Number(turn.ambiguityScore.toFixed(3)),
+          });
+          res.write(`[deep-interview-ready] ${env}`);
         }
         res.end();
         return;

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
-import type { Db } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { type Db, deepInterviewSpecs as deepInterviewSpecsTable } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 import { unauthorized, badRequest } from "../errors.js";
 import {
@@ -10,6 +11,7 @@ import {
   cosOnboardingStateService,
   agentSummoner,
 } from "../services/index.js";
+import type { DeepInterviewSpecsService } from "../services/cos-replier.js";
 import { dispatchLLM } from "../services/dispatch-llm.js";
 
 export function conversationRoutes(db: Db) {
@@ -44,6 +46,7 @@ export function conversationRoutes(db: Db) {
       conversations: svc,
       llm: dispatchLLM,
       cosState: cosOnboardingStateService(db),
+      deepInterviewSpecs: deepInterviewSpecsLoader(db),
     } as any),
     cosResolver,
   });
@@ -128,4 +131,26 @@ export function conversationRoutes(db: Db) {
   });
 
   return router;
+}
+
+// AgentDash (Phase F): minimal spec loader the cos-replier uses to fetch a
+// crystallized deep_interview_specs row by id. Kept inline here (not a full
+// service) because no other call site reads specs in v1.
+function deepInterviewSpecsLoader(db: Db): DeepInterviewSpecsService {
+  return {
+    getById: async (specId: string) => {
+      const rows = await db
+        .select()
+        .from(deepInterviewSpecsTable)
+        .where(eq(deepInterviewSpecsTable.id, specId))
+        .limit(1);
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        goal: row.goal,
+        constraints: Array.isArray(row.constraints) ? (row.constraints as unknown[]) : [],
+        criteria: Array.isArray(row.criteria) ? (row.criteria as unknown[]) : [],
+      };
+    },
+  };
 }

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -15,6 +15,7 @@ import {
   cosOnboardingStateService,
 } from "../services/index.js";
 import { unauthorized, badRequest, notFound } from "../errors.js";
+import { crystallizeAndAdvanceCos } from "../services/deep-interview-crystallize.js";
 import {
   FIXED_QUESTIONS,
   type AgentPlanProposalV1Payload,
@@ -266,6 +267,26 @@ ${kpis || "- (none captured)"}
     await cosState.advancePhase(conversationId, "ready");
 
     res.status(201).json({ companyId, createdAgentIds });
+  });
+
+  // POST /api/onboarding/finalize-assessment
+  // AgentDash (Phase F): called by the SPA when the deep-interview engine
+  // returns a "ready_to_crystallize" marker from /assess?onboarding=1. Runs
+  // the single-transaction crystallize-and-advance helper and returns the
+  // redirect URL the SPA should navigate to (always /cos for v1).
+  //
+  // Idempotent because crystallizeAndAdvanceCos is idempotent on stateId.
+  router.post("/finalize-assessment", async (req, res) => {
+    if (req.actor.type !== "board" || !req.actor.userId) {
+      throw unauthorized("Sign-in required");
+    }
+    const { stateId } = req.body as { stateId?: string };
+    if (!stateId || typeof stateId !== "string") {
+      throw badRequest("stateId required");
+    }
+    const finalize = crystallizeAndAdvanceCos({ db });
+    const { specId, conversationId } = await finalize(stateId);
+    res.json({ specId, conversationId, redirectUrl: "/cos" });
   });
 
   // POST /api/onboarding/revise-plan

--- a/server/src/services/cos-onboarding-state.ts
+++ b/server/src/services/cos-onboarding-state.ts
@@ -17,6 +17,9 @@ export interface CosOnboardingStateRow {
   goals: CosOnboardingGoals;
   proposalMessageId: string | null;
   turnsInPhase: number;
+  // AgentDash (Phase F): set when the deep-interview engine has crystallized
+  // a spec for this conversation. The cos-replier reads it to skip Phase 1.
+  deepInterviewSpecId: string | null;
   updatedAt: Date;
 }
 
@@ -47,6 +50,7 @@ function normalizeRow(row: typeof cosOnboardingStates.$inferSelect): CosOnboardi
     goals: (row.goals ?? {}) as CosOnboardingGoals,
     proposalMessageId: row.proposalMessageId,
     turnsInPhase: row.turnsInPhase,
+    deepInterviewSpecId: row.deepInterviewSpecId ?? null,
     updatedAt: row.updatedAt,
   };
 }

--- a/server/src/services/cos-replier.ts
+++ b/server/src/services/cos-replier.ts
@@ -19,6 +19,10 @@ interface CosStateRow {
   goals: { shortTerm?: string; longTerm?: string; constraints?: Record<string, unknown> };
   proposalMessageId: string | null;
   turnsInPhase: number;
+  // AgentDash (Phase F): when set, the deep-interview engine has already
+  // crystallized a spec for this conversation; cos-replier reads the spec
+  // and skips Phase 1 (goals capture).
+  deepInterviewSpecId?: string | null;
 }
 
 interface CosStateService {
@@ -35,6 +39,18 @@ interface CosStateService {
   ): Promise<unknown>;
 }
 
+// AgentDash (Phase F): minimal spec view that the cos-replier reads from a
+// deep_interview_specs row. Mirrors the columns the prompt builder needs.
+export interface DeepInterviewSpecView {
+  goal: string;
+  constraints: unknown[];
+  criteria: unknown[];
+}
+
+export interface DeepInterviewSpecsService {
+  getById(specId: string): Promise<DeepInterviewSpecView | null>;
+}
+
 interface Deps {
   conversations: any; // conversationService
   llm: (input: {
@@ -42,6 +58,11 @@ interface Deps {
     messages: Array<{ role: "user" | "assistant"; content: string }>;
   }) => Promise<string>;
   cosState?: CosStateService;
+  // AgentDash (Phase F): deep-interview spec loader. When provided AND the
+  // current conversation's cos_onboarding_state has a deepInterviewSpecId,
+  // cos-replier builds a "spec-aware" plan-phase prompt instead of running
+  // Phase 1 (goals capture).
+  deepInterviewSpecs?: DeepInterviewSpecsService;
 }
 
 const STEADY_STATE_PROMPT = `You are the Chief of Staff in an AgentDash workspace. Be warm, concise, and specific. When a human asks about an agent's progress, answer based on the conversation history. If you don't have the data, say so plainly. No greetings, no preamble, no markdown headings.`;
@@ -69,6 +90,45 @@ Your reply MUST end with a fenced JSON block like:
 The "captured" object is a delta — only include keys you newly heard this turn. Omit a key when nothing new was said about it.
 
 The visible chat body comes BEFORE the fenced block. Do not repeat the JSON in prose. No greetings. No markdown headings.`;
+}
+
+// AgentDash (Phase F): plan-phase prompt fed by a crystallized deep-interview
+// spec. The interview already captured goal/constraints/criteria via the
+// Socratic engine, so the LLM jumps directly to plan presentation. The
+// "ALREADY-CAPTURED" framing tells the model not to re-ask Phase 1 questions.
+function planPromptFromSpec(spec: DeepInterviewSpecView): string {
+  const constraintsJson = JSON.stringify(spec.constraints, null, 2);
+  const criteriaJson = JSON.stringify(spec.criteria, null, 2);
+  return `You are the Chief of Staff for AgentDash. The user already completed a deep-interview, so goals, constraints, and success criteria are ALREADY-CAPTURED. Do NOT re-ask Phase 1 (goals capture) questions; jump directly to Phase 2 (plan presentation).
+
+ALREADY-CAPTURED CONTEXT
+Goal: ${spec.goal}
+Constraints: ${constraintsJson}
+Success criteria: ${criteriaJson}
+
+Propose a concrete agent team that hits this goal under the listed constraints and meets the success criteria. Use 2-5 agents. Each agent gets a role, a short human name, an adapterType (one of: "claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local"), 2-4 responsibilities, and 1-3 KPIs.
+
+In the visible body (before the JSON), give the user a short paragraph of rationale that references at least one constraint and one success criterion verbatim from the captured context, then a one-line tour of each agent. End with the question "Want me to set them up, or revise?"
+
+Your reply MUST end with a fenced JSON block emitting an agent_plan_proposal_v1 payload:
+
+\`\`\`json
+{
+  "phase_decision": "stay_in_plan" | "advance_to_materializing",
+  "plan": {
+    "rationale": "...",
+    "agents": [
+      { "role": "engineering_lead", "name": "Ellie", "adapterType": "claude_local", "responsibilities": ["..."], "kpis": ["..."] }
+    ],
+    "alignmentToShortTerm": "...",
+    "alignmentToLongTerm": "..."
+  }
+}
+\`\`\`
+
+Set phase_decision to "stay_in_plan" the first time you propose — the user confirms or revises before we materialize.
+
+No greetings. No markdown headings outside the JSON block.`;
 }
 
 function planPrompt(state: CosStateRow): string {
@@ -145,6 +205,7 @@ function isGoalsPatch(
 
 export function cosReplier(deps: Deps) {
   const cosState = deps.cosState;
+  const deepInterviewSpecs = deps.deepInterviewSpecs;
 
   return {
     reply: async (input: { conversationId: string; cosAgentId: string }) => {
@@ -163,10 +224,46 @@ export function cosReplier(deps: Deps) {
       if (cosState) {
         try {
           state = await cosState.getOrCreate(input.conversationId);
-          if (state.phase === "goals") system = goalsPrompt(state);
-          else if (state.phase === "plan") system = planPrompt(state);
-          else if (state.phase === "materializing" || state.phase === "ready")
+          // AgentDash (Phase F): if a deep-interview spec is linked to this
+          // conversation, build the plan prompt from the spec and SKIP Phase 1
+          // (goals capture). When no spec is set, fall back to legacy
+          // phase-aware prompts so in-flight conversations and assess-flag-OFF
+          // users keep working.
+          let specView: DeepInterviewSpecView | null = null;
+          if (state.deepInterviewSpecId && deepInterviewSpecs) {
+            try {
+              specView = await deepInterviewSpecs.getById(
+                state.deepInterviewSpecId,
+              );
+            } catch (err) {
+              logger.warn(
+                {
+                  err,
+                  conversationId: input.conversationId,
+                  specId: state.deepInterviewSpecId,
+                },
+                "cos-replier: deep-interview spec lookup failed; falling back to phase-aware prompt",
+              );
+            }
+          }
+
+          if (specView) {
+            // Spec-driven path: always plan-presentation, regardless of the
+            // (possibly-stale) phase column.
+            system = planPromptFromSpec(specView);
+            // Force the in-memory state phase to "plan" so the trailer
+            // handler below takes the plan-card branch.
+            state = { ...state, phase: "plan" };
+          } else if (state.phase === "goals") {
+            system = goalsPrompt(state);
+          } else if (state.phase === "plan") {
+            system = planPrompt(state);
+          } else if (
+            state.phase === "materializing" ||
+            state.phase === "ready"
+          ) {
             system = STEADY_STATE_PROMPT;
+          }
         } catch (err) {
           logger.warn(
             { err, conversationId: input.conversationId },

--- a/server/src/services/deep-interview-crystallize.ts
+++ b/server/src/services/deep-interview-crystallize.ts
@@ -1,0 +1,177 @@
+// AgentDash (Phase F): single-transaction helper that stitches the
+// deep-interview state machine to the CoS-onboarding state machine.
+//
+// Called from two callsites:
+//   1. The deep-interview engine, when ambiguity drops below threshold (via
+//      a `/assess` route helper that hands off to CoS).
+//   2. The orchestrator, when CoS needs to advance past Phase 1 because a
+//      spec was already crystallized in `/assess`.
+//
+// Idempotency contract (Critic hand-off condition #4): calling this twice
+// with the same `stateId` must return the same `{ specId, conversationId }`
+// without inserting duplicate rows. The early-return branch covers the
+// "user double-clicks Finish" and "engine retries on transient failure"
+// cases without leaving partially-written state behind.
+//
+// Single-transaction guarantee: deep_interview_specs INSERT,
+// deep_interview_states UPDATE, and cos_onboarding_states UPDATE all happen
+// in one Drizzle transaction. A DB error mid-helper rolls back all three.
+//
+// See docs/superpowers/plans/2026-05-04-onboarding-redesign-deep-interview-plan.md
+// (Phase F) for the full design rationale.
+
+import { eq, sql } from "drizzle-orm";
+import {
+  cosOnboardingStates,
+  deepInterviewSpecs,
+  deepInterviewStates,
+  type Db,
+} from "@paperclipai/db";
+import type {
+  DimensionScores,
+  OntologySnapshot,
+  TranscriptTurn,
+} from "@paperclipai/shared/deep-interview";
+import { logger } from "../middleware/logger.js";
+
+export interface CrystallizeAndAdvanceResult {
+  specId: string;
+  conversationId: string;
+}
+
+export interface CrystallizeAndAdvanceDeps {
+  db: Db;
+}
+
+/**
+ * Crystallize a deep-interview state into a `deep_interview_specs` row, flip
+ * the state to `crystallized`, and advance `cos_onboarding_states.phase` to
+ * `plan` for the linked conversation — all in a single transaction.
+ *
+ * Idempotent: a second call with the same `stateId` returns the prior result
+ * without writing.
+ */
+export function crystallizeAndAdvanceCos(deps: CrystallizeAndAdvanceDeps) {
+  const { db } = deps;
+
+  return async (stateId: string): Promise<CrystallizeAndAdvanceResult> => {
+    return await db.transaction(async (tx) => {
+      // 1. Lock the state row. SELECT … FOR UPDATE prevents concurrent
+      //    crystallizers from racing past the idempotency check.
+      const stateRows = await tx
+        .select()
+        .from(deepInterviewStates)
+        .where(eq(deepInterviewStates.id, stateId))
+        .for("update");
+
+      if (stateRows.length === 0) {
+        throw new Error(
+          `[deep-interview-crystallize] state ${stateId} not found`,
+        );
+      }
+      const state = stateRows[0]!;
+
+      // 2. IDEMPOTENCY: if already crystallized, return the prior spec id
+      //    (looked up via the linked deep_interview_specs row) and the
+      //    conversation id without inserting again.
+      if (state.status === "crystallized") {
+        const priorSpecRows = await tx
+          .select()
+          .from(deepInterviewSpecs)
+          .where(eq(deepInterviewSpecs.stateId, state.id))
+          .limit(1);
+        if (priorSpecRows.length === 0) {
+          // Should never happen — state flipped to crystallized but no spec.
+          // Treat as a hard inconsistency rather than silently re-crystallizing.
+          throw new Error(
+            `[deep-interview-crystallize] state ${stateId} status=crystallized but no spec row exists`,
+          );
+        }
+        logger.info(
+          { stateId, specId: priorSpecRows[0]!.id },
+          "[deep-interview-crystallize] idempotent no-op",
+        );
+        return {
+          specId: priorSpecRows[0]!.id,
+          conversationId: state.scopeRefId,
+        };
+      }
+
+      // 3. Build the spec payload from the state row.
+      const dims = (state.dimensionScores as DimensionScores | null) ?? {
+        goal: 0,
+        constraints: 0,
+        criteria: 0,
+        context: 0,
+      };
+      const transcript = (state.transcript as TranscriptTurn[]) ?? [];
+      const ontologySnapshots =
+        (state.ontologySnapshots as OntologySnapshot[]) ?? [];
+      const lastOntology =
+        ontologySnapshots.length > 0
+          ? ontologySnapshots[ontologySnapshots.length - 1]!.entities
+          : [];
+
+      const goalText =
+        transcript.find((t) => t.targetDimension === "goal")?.answer ?? "";
+      const constraints = transcript
+        .filter((t) => t.targetDimension === "constraints")
+        .map((t) => t.answer)
+        .filter((s) => s.length > 0);
+      const criteria = transcript
+        .filter((t) => t.targetDimension === "criteria")
+        .map((t) => t.answer)
+        .filter((s) => s.length > 0);
+
+      // 4. Insert the spec row.
+      const inserted = await tx
+        .insert(deepInterviewSpecs)
+        .values({
+          stateId: state.id,
+          goal: goalText,
+          constraints,
+          criteria,
+          nonGoals: [],
+          ontology: lastOntology,
+          transcript,
+          finalAmbiguity: state.ambiguityScore ?? 0,
+          dimensionScores: dims,
+        })
+        .returning();
+      const specId = inserted[0]!.id;
+
+      // 5. Flip the state's status. We do NOT also write
+      //    deep_interview_specs.id back onto the state — the linkage flows
+      //    the other direction (specs.state_id FK).
+      await tx
+        .update(deepInterviewStates)
+        .set({ status: "crystallized", updatedAt: sql`now()` })
+        .where(eq(deepInterviewStates.id, state.id));
+
+      // 6. For cos_onboarding scope, advance the linked conversation's CoS
+      //    phase to 'plan' and link the spec.
+      if (state.scope === "cos_onboarding") {
+        await tx
+          .update(cosOnboardingStates)
+          .set({
+            deepInterviewSpecId: specId,
+            phase: "plan",
+            updatedAt: sql`now()`,
+          })
+          .where(eq(cosOnboardingStates.conversationId, state.scopeRefId));
+      }
+
+      logger.info(
+        {
+          stateId: state.id,
+          specId,
+          scope: state.scope,
+          conversationId: state.scopeRefId,
+        },
+        "[deep-interview-crystallize] tx committed",
+      );
+
+      return { specId, conversationId: state.scopeRefId };
+    });
+  };
+}

--- a/ui/src/api/onboarding.ts
+++ b/ui/src/api/onboarding.ts
@@ -61,4 +61,13 @@ export const onboardingApi = {
   // Phase F (revision loop) is not implemented yet — this returns 501.
   revisePlan: (input: { conversationId: string; revisionText: string }) =>
     api.post<{ error: string; message: string }>("/onboarding/revise-plan", input),
+  // AgentDash (Phase F): the SPA calls this when the deep-interview engine
+  // emits its `[deep-interview-ready]` marker on `/assess?onboarding=1`. The
+  // server crystallizes the spec, advances the CoS phase, and returns the
+  // URL the SPA should redirect to. Idempotent on `stateId`.
+  finalizeAssessment: (stateId: string) =>
+    api.post<{ specId: string; conversationId: string; redirectUrl: string }>(
+      "/onboarding/finalize-assessment",
+      { stateId },
+    ),
 };

--- a/ui/src/pages/AssessPage.tsx
+++ b/ui/src/pages/AssessPage.tsx
@@ -2,12 +2,14 @@
 // (Entire company / Specific project) wrapping the existing CompanyWizard
 // and the new ProjectWizard. Both wizards share the marketing surface chrome
 // and the wizard chrome extracted into ./assess/wizard-chrome.tsx.
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useCompany } from "../context/CompanyContext";
 import { assessApi, type ProjectAssessmentSummary } from "../api/assess";
 import { authApi } from "../api/auth";
 import { healthApi } from "../api/health";
+import { onboardingApi } from "../api/onboarding";
 import { queryKeys } from "../lib/queryKeys";
 import { MarketingShell } from "../marketing/MarketingShell";
 import { SectionContainer } from "../marketing/components/SectionContainer";
@@ -22,7 +24,43 @@ import { AssessLocalStyles } from "./assess/wizard-chrome";
 export function AssessPage() {
   const { selectedCompany } = useCompany();
   const companyId = selectedCompany?.id;
-  const [mode, setMode] = useState<AssessmentMode | null>(null);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  // AgentDash (Phase F): `?onboarding=1` means the user just landed here
+  // from /company-create as part of the post-signup chain. Skip the mode
+  // chooser, jump straight into the company wizard, and on the deep-interview
+  // ready marker call /api/onboarding/finalize-assessment to crystallize the
+  // spec + flip the CoS phase, then redirect to /cos.
+  const onboardingFlow = useMemo(
+    () => searchParams.get("onboarding") === "1",
+    [searchParams],
+  );
+  const [mode, setMode] = useState<AssessmentMode | null>(
+    onboardingFlow ? "company" : null,
+  );
+  const [finalizing, setFinalizing] = useState(false);
+  const [finalizeError, setFinalizeError] = useState<string | null>(null);
+
+  // If the URL flips from a non-onboarding visit to `?onboarding=1` (rare,
+  // but covers SPA history pushes from CompanyCreate), force company mode.
+  useEffect(() => {
+    if (onboardingFlow && mode !== "company") setMode("company");
+  }, [onboardingFlow, mode]);
+
+  const handleReadyToFinalize = async (info: { stateId: string; round: number; ambiguity: number }) => {
+    if (finalizing) return;
+    setFinalizing(true);
+    setFinalizeError(null);
+    try {
+      const result = await onboardingApi.finalizeAssessment(info.stateId);
+      navigate(result.redirectUrl, { replace: true });
+    } catch (err) {
+      setFinalizeError(
+        err instanceof Error ? err.message : "Could not finalize the interview.",
+      );
+      setFinalizing(false);
+    }
+  };
 
   // Auth-state detection — mirror the Landing page pattern so anonymous
   // visitors hitting /assess directly get a sensible CTA instead of a
@@ -150,11 +188,34 @@ export function AssessPage() {
         )}
 
         {mode === "company" && (
-          <CompanyWizard
-            companyId={companyId}
-            defaultCompanyName={selectedCompany?.name}
-            onSwitchMode={() => setMode(null)}
-          />
+          <>
+            {onboardingFlow && finalizing && (
+              <div
+                role="status"
+                aria-live="polite"
+                style={{ marginTop: 16, color: "var(--mkt-ink-soft)" }}
+              >
+                Finalizing your interview and handing off to your Chief of Staff…
+              </div>
+            )}
+            {finalizeError && (
+              <div
+                role="alert"
+                style={{ marginTop: 16, color: "var(--mkt-error, #b91c1c)" }}
+              >
+                {finalizeError}
+              </div>
+            )}
+            <CompanyWizard
+              companyId={companyId}
+              defaultCompanyName={selectedCompany?.name}
+              // In the onboarding chain, the chooser is the entry point —
+              // hide the "switch mode" affordance so users don't bail out
+              // before crystallization.
+              onSwitchMode={onboardingFlow ? undefined : () => setMode(null)}
+              onReadyToFinalize={onboardingFlow ? handleReadyToFinalize : undefined}
+            />
+          </>
         )}
 
         {mode === "project" && (

--- a/ui/src/pages/assess/CompanyWizard.tsx
+++ b/ui/src/pages/assess/CompanyWizard.tsx
@@ -105,9 +105,19 @@ export interface CompanyWizardProps {
   companyId: string;
   defaultCompanyName?: string;
   onSwitchMode?: () => void;
+  /**
+   * AgentDash (Phase F): callback fired when the deep-interview engine emits
+   * the structured `[deep-interview-ready] {…}` marker into the streamed
+   * output. The parent (AssessPage on `?onboarding=1`) uses this to call
+   * /api/onboarding/finalize-assessment and navigate to /cos.
+   *
+   * Passes both the parsed stateId and the raw envelope JSON so the parent
+   * can log/telemeter as needed.
+   */
+  onReadyToFinalize?: (info: { stateId: string; round: number; ambiguity: number }) => void;
 }
 
-export function CompanyWizard({ companyId, defaultCompanyName, onSwitchMode }: CompanyWizardProps) {
+export function CompanyWizard({ companyId, defaultCompanyName, onSwitchMode, onReadyToFinalize }: CompanyWizardProps) {
   const [step, setStep] = useState(1);
   const [form, setForm] = useState<FormData>(INITIAL_FORM);
   const [output, setOutput] = useState("");
@@ -122,6 +132,35 @@ export function CompanyWizard({ companyId, defaultCompanyName, onSwitchMode }: C
       setForm((prev) => ({ ...prev, companyName: defaultCompanyName }));
     }
   }, [defaultCompanyName, form.companyName]);
+
+  // AgentDash (Phase F): scan streamed output for the deep-interview ready
+  // marker. Format: `[deep-interview-ready] {"stateId":"…","round":N,"ambiguity":0.x}`
+  // Fires the callback exactly once per page lifetime (firedRef guards repeats
+  // when output continues mutating after the marker lands).
+  const firedReadyRef = useRef(false);
+  useEffect(() => {
+    if (firedReadyRef.current || !onReadyToFinalize) return;
+    const match = output.match(
+      /\[deep-interview-ready\]\s*(\{[^\n}]*"stateId"[^\n}]*\})/,
+    );
+    if (!match) return;
+    try {
+      const env = JSON.parse(match[1]!) as {
+        stateId?: unknown;
+        round?: unknown;
+        ambiguity?: unknown;
+      };
+      if (typeof env.stateId !== "string" || env.stateId.length === 0) return;
+      firedReadyRef.current = true;
+      onReadyToFinalize({
+        stateId: env.stateId,
+        round: typeof env.round === "number" ? env.round : 0,
+        ambiguity: typeof env.ambiguity === "number" ? env.ambiguity : 1,
+      });
+    } catch {
+      // Malformed envelope — ignore. Engine should always emit valid JSON.
+    }
+  }, [output, onReadyToFinalize]);
 
   // Load any prior assessment for this company so the user lands on the report
   // instead of a blank wizard if one already exists.


### PR DESCRIPTION
## Summary
- Single-transaction `crystallizeAndAdvanceCos(stateId)` helper. Idempotent on stateId — second call returns prior `{specId, conversationId}` without inserting (Critic hand-off condition #4).
- New `POST /api/onboarding/finalize-assessment` endpoint backing the SPA crystallize → `/cos` handoff.
- `cos-replier` now reads a linked deep-interview spec and skips Phase 1 (goals capture), jumping directly to Phase 2 (plan presentation). Falls back to legacy phase-aware prompts when no spec is set.
- `/assess` engine emits a parseable `[deep-interview-ready] {…json…}` marker (both company + project modes). The SPA — under `?onboarding=1` only — detects it, calls finalize, and navigates to the returned redirect URL.

## Architectural notes
- The helper writes spec INSERT + state UPDATE + cos_onboarding UPDATE in one `db.transaction`. A DB error mid-helper rolls back all three.
- `SELECT … FOR UPDATE` locks the state row at the start of the transaction so concurrent crystallizers can't race past the idempotency check.
- `cos_onboarding_states.deep_interview_spec_id` linkage is set inside the helper (this column was added in Phase B). When the linkage is set, the replier forces `phase = 'plan'` regardless of the (possibly-stale) phase column.
- Phase F does NOT flip `AGENTDASH_DEEP_INTERVIEW_ASSESS`. Phase D already gated this path off in production. Flag flip is a separate deploy decision after Phase G E2E lands.

## Test plan
- [x] `pnpm -r typecheck` — clean across all packages
- [x] `pnpm build` — clean across all packages
- [x] `pnpm test:run` — 1083/1087 passing (3 pre-existing `workspace-runtime.test.ts > realizeExecutionWorkspace` flakes unrelated to this PR; 1 expected skip)
- [x] Targeted suites all green: cos-replier (8), deep-interview-engine (29), **deep-interview-crystallize (5 new)**, onboarding-v2-routes (7), conversations-routes (11), deep-interview-parser (13), deep-interview-prompts (19) → 92/92
- [x] New unit tests cover: happy-path inserts/updates; idempotency (no double-insert); state-not-found; `status=crystallized` w/ missing spec row (hard-error); `scope=assess_project` skips cos-states update

## Phase F hand-off conditions (Critic-imposed)
- [x] **#4 idempotency** — `crystallizeAndAdvanceCos` early-returns the prior `{specId, conversationId}` when called on a state already at `status='crystallized'`. Hard-errors instead of silently re-crystallizing if the prior spec row is missing.
- [x] Single-transaction guarantee — all writes wrapped in `db.transaction`, locked via `SELECT … FOR UPDATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)