### PR TITLE
feat: multi-company as Pro-tier feature with friendly error messages

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -203,6 +203,8 @@ export async function createApp(
   api.use("/companies", companyRoutes(db, opts.storageService, {
     requireCorpEmail: opts.requireCorpEmail ?? false,
     allowMultiTenantPerDomain: true,
+    deploymentMode: opts.deploymentMode,
+    allowMultiCompany: process.env.AGENTDASH_ALLOW_MULTI_COMPANY === "true",
   }));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db, { pluginWorkerManager: workerManager }));

--- a/server/src/middleware/require-tier.ts
+++ b/server/src/middleware/require-tier.ts
@@ -19,7 +19,7 @@ const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
  * Production deployments set STRIPE_SECRET_KEY → caps are enforced as designed.
  * Local-trusted dev never sets the key → caps never block.
  */
-function isBillingDisabled(): boolean {
+export function isBillingDisabled(): boolean {
   if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
   if (!process.env.STRIPE_SECRET_KEY) return true;
   return false;

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -29,14 +29,9 @@ import {
 import { DomainAlreadyClaimedError } from "../services/companies.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
+import { isBillingDisabled } from "../middleware/require-tier.js";
 
 const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
-
-function isBillingDisabled(): boolean {
-  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
-  if (!process.env.STRIPE_SECRET_KEY) return true;
-  return false;
-}
 
 // AgentDash (AGE-55): per-route options. Mirrors the env-var-driven flag
 // from server/src/config.ts so test/integration harnesses can override.

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -30,6 +30,14 @@ import { DomainAlreadyClaimedError } from "../services/companies.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
+const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
+
+function isBillingDisabled(): boolean {
+  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
+  if (!process.env.STRIPE_SECRET_KEY) return true;
+  return false;
+}
+
 // AgentDash (AGE-55): per-route options. Mirrors the env-var-driven flag
 // from server/src/config.ts so test/integration harnesses can override.
 export interface CompanyRoutesOptions {
@@ -39,11 +47,18 @@ export interface CompanyRoutesOptions {
   // this on; self-hosted Free leaves it off so a single user with any
   // email can stand up a workspace.
   requireCorpEmail?: boolean;
+  // AgentDash (#102): passed through from server startup config so the
+  // POST /companies guard can check local_trusted + AGENTDASH_DEV_MODE.
+  deploymentMode?: string;
+  // AgentDash (#102): when true, bypass the single-company-installation guard.
+  // Set by the CLI onboard --allow-multi-company flag.
+  allowMultiCompany?: boolean;
 }
 
 export function companyRoutes(db: Db, storage?: StorageService, options: CompanyRoutesOptions = {}) {
   const allowMultiTenantPerDomain = options.allowMultiTenantPerDomain ?? false;
   const requireCorpEmail = options.requireCorpEmail ?? false;
+  const allowMultiCompany = options.allowMultiCompany ?? false;
   const router = Router();
   const svc = companyService(db);
   const agents = agentService(db);
@@ -51,6 +66,19 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+
+  // AgentDash (#102): true when the single-company-installation constraint should
+  // be bypassed. Covers: AGENTDASH_ALLOW_MULTI_COMPANY env var, and the dev-mode
+  // combination (local_trusted + AGENTDASH_DEV_MODE).
+  function isSingleCompanyOverrideActive() {
+    if (allowMultiCompany) return true;
+    if (process.env.AGENTDASH_ALLOW_MULTI_COMPANY === "true") return true;
+    if (
+      options.deploymentMode === "local_trusted" &&
+      process.env.AGENTDASH_DEV_MODE === "true"
+    ) return true;
+    return false;
+  }
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -304,9 +332,35 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
           code: "already_member",
           existingCompanyId: existingCompanyIds[0] ?? null,
           message:
-            "User is already a member of a workspace; redirect to it instead of creating another.",
+            "You're already a member of a workspace. Switch to it instead of creating a new one.",
         });
         return;
+      }
+    }
+
+    // AgentDash (#102): single-workspace-per-self-hosted-installation guard.
+    // Bypassed when: AGENTDASH_ALLOW_MULTI_COMPANY env var, local_trusted +
+    // AGENTDASH_DEV_MODE, --allow-multi-company CLI flag, OR the existing
+    // company is on a Pro plan (unlimited workspaces).
+    if (!isSingleCompanyOverrideActive()) {
+      const hasExisting = await svc.hasActiveCompany();
+      if (hasExisting) {
+        const firstCompany = await svc.list().then((cs) => cs[0] ?? null);
+        const existingPlanTier = firstCompany?.planTier ?? "free";
+        const isPro = isBillingDisabled() || PRO_LIVE.has(existingPlanTier);
+
+        if (isPro) {
+          // Pro installation — allow through (DB unique index handles races)
+        } else {
+          res.status(409).json({
+            code: "single_company_installation",
+            existingCompanyId: firstCompany?.id ?? null,
+            message:
+              "Free workspaces are limited to 1 workspace. Upgrade to Pro to create additional workspaces.",
+            upgradeUrl: "/settings/billing",
+          });
+          return;
+        }
       }
     }
 
@@ -360,6 +414,7 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
             res.status(409).json({
               code: "domain_already_claimed",
               existingCompanyId: existingCompany.id,
+              message: "A workspace for this email domain already exists. Contact your administrator to join it.",
               contactEmail: null,
             });
             return;


### PR DESCRIPTION
## Summary
- **Multi-company is now a Pro-tier feature**: Free workspaces are limited to 1 workspace; Pro workspaces get unlimited
- **Friendly 409 errors** with `upgradeUrl: "/settings/billing"` to guide Free users to upgrade
- **Fix bug**: `app.ts` now passes `deploymentMode` + `allowMultiCompany` to `companyRoutes()`, so the `local_trusted + AGENTDASH_DEV_MODE` bypass works from the HTTP API path again
- **Improved error copy** for `already_member` and `domain_already_claimed` errors

## Changes
- `server/src/routes/companies.ts`: Pro-tier check in single-company guard, friendly messages, `PRO_LIVE` + `isBillingDisabled()` helpers
- `server/src/app.ts`: Pass `deploymentMode` + `allowMultiCompany` to `companyRoutes()`

## Test plan
- [ ] Create a Free workspace → attempt second workspace → expect 409 with upgrade CTA
- [ ] Set workspace to Pro (`pro_trial` or `pro_active` in DB) → create second workspace → expect success
- [ ] `AGENTDASH_BILLING_DISABLED=true` → Free workspace can create multiple (billing disabled = bypasses tier check)
- [ ] `local_trusted + AGENTDASH_DEV_MODE` → still bypasses as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)