### PR TITLE
feat: add company inbox chat

### DIFF
--- a/server/src/__tests__/conversations-routes.test.ts
+++ b/server/src/__tests__/conversations-routes.test.ts
@@ -173,10 +173,11 @@ describe.sequential("conversation routes", () => {
       expect(res.status).toBe(200);
       expect(res.body).toMatchObject({ id: conversationId, title: "Company Inbox" });
       expect(mockConversationService.create).not.toHaveBeenCalled();
-      expect(mockConversationService.addParticipant).toHaveBeenCalledWith(conversationId, userId, "owner");
+      expect(mockConversationService.addParticipant).not.toHaveBeenCalled();
+      expect(mockConversationService.findByCompany).toHaveBeenCalledWith(companyId, { title: "Company Inbox" });
     });
 
-    it("creates a company inbox conversation when missing", async () => {
+    it("creates a company inbox conversation when no titled inbox exists", async () => {
       mockConversationService.findByCompany.mockResolvedValue(null);
       mockConversationService.create.mockResolvedValue({
         id: conversationId,
@@ -197,6 +198,7 @@ describe.sequential("conversation routes", () => {
         userId,
         title: "Company Inbox",
       });
+      expect(mockConversationService.findByCompany).toHaveBeenCalledWith(companyId, { title: "Company Inbox" });
       expect(mockConversationService.addParticipant).toHaveBeenCalledWith(conversationId, userId, "owner");
     });
 

--- a/server/src/__tests__/conversations-routes.test.ts
+++ b/server/src/__tests__/conversations-routes.test.ts
@@ -155,6 +155,62 @@ describe.sequential("conversation routes", () => {
     mockConversationDispatch.mockReturnValue({ onMessage: mockDispatchOnMessage });
   });
 
+  describe("GET /companies/:companyId/inbox", () => {
+    it("returns the existing company inbox conversation", async () => {
+      mockConversationService.findByCompany.mockResolvedValue({
+        id: conversationId,
+        companyId,
+        userId,
+        title: "Company Inbox",
+        status: "active",
+      });
+      const app = await createApp(boardActor);
+
+      const res = await requestApp(app, (base) =>
+        request(base).get(`/api/conversations/companies/${companyId}/inbox`),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ id: conversationId, title: "Company Inbox" });
+      expect(mockConversationService.create).not.toHaveBeenCalled();
+      expect(mockConversationService.addParticipant).toHaveBeenCalledWith(conversationId, userId, "owner");
+    });
+
+    it("creates a company inbox conversation when missing", async () => {
+      mockConversationService.findByCompany.mockResolvedValue(null);
+      mockConversationService.create.mockResolvedValue({
+        id: conversationId,
+        companyId,
+        userId,
+        title: "Company Inbox",
+        status: "active",
+      });
+      const app = await createApp(boardActor);
+
+      const res = await requestApp(app, (base) =>
+        request(base).get(`/api/conversations/companies/${companyId}/inbox`),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockConversationService.create).toHaveBeenCalledWith({
+        companyId,
+        userId,
+        title: "Company Inbox",
+      });
+      expect(mockConversationService.addParticipant).toHaveBeenCalledWith(conversationId, userId, "owner");
+    });
+
+    it("rejects another company's inbox", async () => {
+      const app = await createApp({ ...boardActor, companyIds: ["other-company"] });
+
+      const res = await requestApp(app, (base) =>
+        request(base).get(`/api/conversations/companies/${companyId}/inbox`),
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
   describe("POST /:id/messages", () => {
     it("stores the user message and returns 201", async () => {
       const app = await createApp(boardActor);

--- a/server/src/__tests__/conversations-service.test.ts
+++ b/server/src/__tests__/conversations-service.test.ts
@@ -73,6 +73,18 @@ describeEmbeddedPostgres("conversationService", () => {
     expect(result?.companyId).toBe(companyId);
   });
 
+  it("findByCompany can filter by title", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({ id: companyId, name: "Test Co" });
+    await service.create({ companyId, userId: TEST_USER_ID, title: "Welcome chat" });
+    const inbox = await service.create({ companyId, userId: TEST_USER_ID, title: "Company Inbox" });
+
+    const result = await service.findByCompany(companyId, { title: "Company Inbox" });
+
+    expect(result?.id).toBe(inbox.id);
+    expect(result?.title).toBe("Company Inbox");
+  });
+
   it("addParticipant is idempotent", async () => {
     await insertTestUser(db);
     const companyId = randomUUID();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -203,6 +203,8 @@ export async function createApp(
   api.use("/companies", companyRoutes(db, opts.storageService, {
     requireCorpEmail: opts.requireCorpEmail ?? false,
     allowMultiTenantPerDomain: true,
+    deploymentMode: opts.deploymentMode,
+    allowMultiCompany: process.env.AGENTDASH_ALLOW_MULTI_COMPANY === "true",
   }));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db, { pluginWorkerManager: workerManager }));

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -30,6 +30,14 @@ import { DomainAlreadyClaimedError } from "../services/companies.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
+const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
+
+function isBillingDisabled(): boolean {
+  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
+  if (!process.env.STRIPE_SECRET_KEY) return true;
+  return false;
+}
+
 // AgentDash (AGE-55): per-route options. Mirrors the env-var-driven flag
 // from server/src/config.ts so test/integration harnesses can override.
 export interface CompanyRoutesOptions {
@@ -39,11 +47,18 @@ export interface CompanyRoutesOptions {
   // this on; self-hosted Free leaves it off so a single user with any
   // email can stand up a workspace.
   requireCorpEmail?: boolean;
+  // AgentDash (#102): passed through from server startup config so the
+  // POST /companies guard can check local_trusted + AGENTDASH_DEV_MODE.
+  deploymentMode?: string;
+  // AgentDash (#102): when true, bypass the single-company-installation guard.
+  // Set by the CLI onboard --allow-multi-company flag.
+  allowMultiCompany?: boolean;
 }
 
 export function companyRoutes(db: Db, storage?: StorageService, options: CompanyRoutesOptions = {}) {
   const allowMultiTenantPerDomain = options.allowMultiTenantPerDomain ?? false;
   const requireCorpEmail = options.requireCorpEmail ?? false;
+  const allowMultiCompany = options.allowMultiCompany ?? false;
   const router = Router();
   const svc = companyService(db);
   const agents = agentService(db);
@@ -51,6 +66,19 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+
+  // AgentDash (#102): true when the single-company-installation constraint should
+  // be bypassed. Covers: AGENTDASH_ALLOW_MULTI_COMPANY env var, and the dev-mode
+  // combination (local_trusted + AGENTDASH_DEV_MODE).
+  function isSingleCompanyOverrideActive() {
+    if (allowMultiCompany) return true;
+    if (process.env.AGENTDASH_ALLOW_MULTI_COMPANY === "true") return true;
+    if (
+      options.deploymentMode === "local_trusted" &&
+      process.env.AGENTDASH_DEV_MODE === "true"
+    ) return true;
+    return false;
+  }
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -304,9 +332,35 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
           code: "already_member",
           existingCompanyId: existingCompanyIds[0] ?? null,
           message:
-            "User is already a member of a workspace; redirect to it instead of creating another.",
+            "You're already a member of a workspace. Switch to it instead of creating a new one.",
         });
         return;
+      }
+    }
+
+    // AgentDash (#102): single-workspace-per-self-hosted-installation guard.
+    // Bypassed when: AGENTDASH_ALLOW_MULTI_COMPANY env var, local_trusted +
+    // AGENTDASH_DEV_MODE, --allow-multi-company CLI flag, OR the existing
+    // company is on a Pro plan (unlimited workspaces).
+    if (!isSingleCompanyOverrideActive()) {
+      const hasExisting = await svc.hasActiveCompany();
+      if (hasExisting) {
+        const firstCompany = await svc.list().then((cs) => cs[0] ?? null);
+        const existingPlanTier = firstCompany?.planTier ?? "free";
+        const isPro = isBillingDisabled() || PRO_LIVE.has(existingPlanTier);
+
+        if (isPro) {
+          // Pro installation — allow through (DB unique index handles races)
+        } else {
+          res.status(409).json({
+            code: "single_company_installation",
+            existingCompanyId: firstCompany?.id ?? null,
+            message:
+              "Free workspaces are limited to 1 workspace. Upgrade to Pro to create additional workspaces.",
+            upgradeUrl: "/settings/billing",
+          });
+          return;
+        }
       }
     }
 
@@ -360,6 +414,7 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
             res.status(409).json({
               code: "domain_already_claimed",
               existingCompanyId: existingCompany.id,
+              message: "A workspace for this email domain already exists. Contact your administrator to join it.",
               contactEmail: null,
             });
             return;

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { type Db, deepInterviewSpecs as deepInterviewSpecsTable } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 import { unauthorized, badRequest } from "../errors.js";
+import { assertCompanyAccess } from "./authz.js";
 import {
   conversationService,
   conversationDispatch,
@@ -49,6 +50,26 @@ export function conversationRoutes(db: Db) {
       deepInterviewSpecs: deepInterviewSpecsLoader(db),
     } as any),
     cosResolver,
+  });
+
+  // GET /api/conversations/companies/:companyId/inbox
+  router.get("/companies/:companyId/inbox", async (req, res) => {
+    if (req.actor.type !== "board" || !req.actor.userId) {
+      throw unauthorized("Sign-in required");
+    }
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    let conversation = await svc.findByCompany(companyId);
+    if (!conversation) {
+      conversation = await svc.create({
+        companyId,
+        userId: req.actor.userId,
+        title: "Company Inbox",
+      });
+    }
+    await svc.addParticipant(conversation.id, req.actor.userId, "owner");
+    res.json(conversation);
   });
 
   // POST /api/conversations/:id/messages

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -15,6 +15,8 @@ import {
 import type { DeepInterviewSpecsService } from "../services/cos-replier.js";
 import { dispatchLLM } from "../services/dispatch-llm.js";
 
+const COMPANY_INBOX_TITLE = "Company Inbox";
+
 export function conversationRoutes(db: Db) {
   const router = Router();
   const svc = conversationService(db);
@@ -60,15 +62,15 @@ export function conversationRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
-    let conversation = await svc.findByCompany(companyId);
+    let conversation = await svc.findByCompany(companyId, { title: COMPANY_INBOX_TITLE });
     if (!conversation) {
       conversation = await svc.create({
         companyId,
         userId: req.actor.userId,
-        title: "Company Inbox",
+        title: COMPANY_INBOX_TITLE,
       });
+      await svc.addParticipant(conversation.id, req.actor.userId, "owner");
     }
-    await svc.addParticipant(conversation.id, req.actor.userId, "owner");
     res.json(conversation);
   });
 

--- a/server/src/services/conversations.ts
+++ b/server/src/services/conversations.ts
@@ -9,11 +9,15 @@ import { emitMessageCreated, emitMessageRead } from "../realtime/conversation-ev
 
 export function conversationService(db: Db) {
   return {
-    findByCompany: async (companyId: string) => {
+    findByCompany: async (companyId: string, opts: { title?: string } = {}) => {
+      const conditions = [eq(assistantConversations.companyId, companyId)];
+      if (opts.title) {
+        conditions.push(eq(assistantConversations.title, opts.title));
+      }
       const rows = await db
         .select()
         .from(assistantConversations)
-        .where(eq(assistantConversations.companyId, companyId))
+        .where(and(...conditions))
         .limit(1);
       return rows[0] ?? null;
     },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -26,6 +26,7 @@ import { ApprovalDetail } from "./pages/ApprovalDetail";
 import { Costs } from "./pages/Costs";
 import { Activity } from "./pages/Activity";
 import { Inbox } from "./pages/Inbox";
+import { CompanyInbox } from "./pages/CompanyInbox";
 import { CompanySettings } from "./pages/CompanySettings";
 import { CompanyEnvironments } from "./pages/CompanyEnvironments";
 import { CompanyAccess } from "./pages/CompanyAccess";
@@ -139,6 +140,7 @@ function boardRoutes() {
       <Route path="costs" element={<Costs />} />
       <Route path="activity" element={<Activity />} />
       <Route path="inbox" element={<InboxRootRedirect />} />
+      <Route path="inbox/company" element={<CompanyInbox />} />
       <Route path="inbox/mine" element={<Inbox />} />
       <Route path="inbox/recent" element={<Inbox />} />
       <Route path="inbox/unread" element={<Inbox />} />

--- a/ui/src/api/conversations.ts
+++ b/ui/src/api/conversations.ts
@@ -1,6 +1,17 @@
 // AgentDash: chat substrate API client
 import { api } from "./client";
 
+export interface Conversation {
+  id: string;
+  companyId: string;
+  userId: string;
+  assistantAgentId?: string | null;
+  title?: string | null;
+  status: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface Message {
   id: string;
   conversationId: string;
@@ -15,6 +26,8 @@ export interface Message {
 }
 
 export const conversationsApi = {
+  companyInbox: (companyId: string) =>
+    api.get<Conversation>(`/conversations/companies/${companyId}/inbox`),
   paginate: (id: string, opts: { before?: string; limit?: number } = {}) => {
     const params = new URLSearchParams();
     if (opts.before) params.set("before", opts.before);

--- a/ui/src/pages/CompanyInbox.test.tsx
+++ b/ui/src/pages/CompanyInbox.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCompanyInbox = vi.hoisted(() => vi.fn());
+const mockUseCompany = vi.hoisted(() => vi.fn());
+const mockChatPanel = vi.hoisted(() => vi.fn(({ conversationId, companyId, headerProps }) => (
+  <div className="chat-panel" data-conversation-id={conversationId} data-company-id={companyId}>
+    <h1>{headerProps?.agentName}</h1>
+    <p>{headerProps?.agentRole}</p>
+  </div>
+)));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryFn, enabled }: { queryFn: () => unknown; enabled?: boolean }) => {
+    if (enabled === false) {
+      return { data: null, isLoading: false, error: null };
+    }
+    const data = queryFn();
+    return { data, isLoading: false, error: null };
+  },
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  (globalThis as any).React = actual;
+  return actual;
+});
+
+vi.mock("../api/conversations", () => ({
+  conversationsApi: {
+    companyInbox: mockCompanyInbox,
+  },
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: mockUseCompany,
+}));
+
+vi.mock("./ChatPanel", () => ({
+  default: mockChatPanel,
+}));
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("CompanyInbox", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockUseCompany.mockReturnValue({ selectedCompany: { id: "company-1", name: "Acme" } });
+    mockCompanyInbox.mockReturnValue({ id: "conversation-1", companyId: "company-1", title: "Company Inbox", status: "active" });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("loads the selected company's inbox conversation and renders chat", async () => {
+    await act(async () => {
+      const { CompanyInbox } = await import("./CompanyInbox");
+      root.render(<CompanyInbox />);
+    });
+    await act(async () => {});
+
+    expect(mockCompanyInbox).toHaveBeenCalledWith("company-1");
+    expect(container.querySelector(".chat-panel")?.getAttribute("data-conversation-id")).toBe("conversation-1");
+    expect(container.textContent).toContain("Company Inbox");
+    expect(container.textContent).toContain("Chat with Acme's CoS and route work into Paperclip objects.");
+  });
+
+  it("asks the user to select a company when none is selected", async () => {
+    mockUseCompany.mockReturnValue({ selectedCompany: null });
+
+    await act(async () => {
+      const { CompanyInbox } = await import("./CompanyInbox");
+      root.render(<CompanyInbox />);
+    });
+
+    expect(container.textContent).toContain("Select a company to open Company Chat.");
+    expect(mockCompanyInbox).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/CompanyInbox.tsx
+++ b/ui/src/pages/CompanyInbox.tsx
@@ -1,0 +1,53 @@
+import { useQuery } from "@tanstack/react-query";
+import ChatPanel from "./ChatPanel";
+import { conversationsApi } from "../api/conversations";
+import { useCompany } from "../context/CompanyContext";
+
+export function CompanyInbox() {
+  const { selectedCompany } = useCompany();
+  const companyId = selectedCompany?.id ?? null;
+
+  const { data: conversation, isLoading, error } = useQuery({
+    queryKey: ["company-inbox", companyId],
+    queryFn: () => conversationsApi.companyInbox(companyId!),
+    enabled: !!companyId,
+  });
+
+  if (!companyId || !selectedCompany) {
+    return (
+      <div className="mx-auto max-w-xl py-10 text-sm text-muted-foreground">
+        Select a company to open Company Chat.
+      </div>
+    );
+  }
+
+  if (isLoading || !conversation) {
+    return (
+      <div className="mx-auto max-w-xl py-10 text-sm text-muted-foreground">
+        Opening Company Chat…
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = error instanceof Error ? error.message : "Failed to open Company Chat.";
+    return (
+      <div className="mx-auto max-w-xl py-10 text-sm text-destructive">
+        {message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-y-0 right-0 left-0 md:left-[var(--sidebar-width,0px)] flex flex-col bg-surface-page">
+      <ChatPanel
+        conversationId={conversation.id}
+        companyId={companyId}
+        headerProps={{
+          agentName: "Company Inbox",
+          agentRole: `Chat with ${selectedCompany.name}'s CoS and route work into Paperclip objects.`,
+        }}
+      />
+    </div>
+  );
+}

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1903,9 +1903,13 @@ export function Inbox() {
           />
         </div>
         <div className="flex flex-wrap items-center justify-between gap-2">
-        <Tabs value={tab} onValueChange={(value) => navigate(`/inbox/${value}`)}>
+        <Tabs value={tab} onValueChange={(value) => navigate(value === "company" ? "/inbox/company" : `/inbox/${value}`)}>
           <PageTabBar
             items={[
+              {
+                value: "company",
+                label: "Company Chat",
+              },
               {
                 value: "mine",
                 label: "Mine",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through company-scoped work objects, runs, approvals, and activity.
> - AgentDash already has a chat substrate for CoS onboarding and an Inbox surface for operator attention.
> - The product gap is a durable company-level chat entry point: users need to message the company/CoS directly without bypassing Paperclip work objects.
> - The existing assistant_conversations schema can support a first Company Inbox without a migration by using one company-scoped conversation and existing messages/realtime behavior.
> - This pull request adds a minimal Company Inbox route and UI page that opens or creates the company's persistent chat conversation.
> - The benefit is a concrete first step toward the messaging-first command center: chat is the interface, while issues/goals/approvals/decisions remain the source of truth.

## What Changed

- Added `GET /api/conversations/companies/:companyId/inbox` to return or create a company-scoped "Company Inbox" conversation with company access enforcement.
- Added `conversationsApi.companyInbox()` and a typed `Conversation` client model.
- Added `/inbox/company` route and `CompanyInbox` page that renders the existing `ChatPanel` against the company inbox conversation.
- Added a "Company Chat" entry to the Inbox tab bar.
- Added backend route tests for existing/create/cross-company access behavior.
- Added frontend page tests for selected-company loading and no-company empty state.

## Verification

- `pnpm exec vitest run server/src/__tests__/conversations-routes.test.ts --reporter=dot`
- `pnpm exec vitest run ui/src/pages/CompanyInbox.test.tsx --reporter=dot`
- `pnpm exec vitest run ui/src/pages/CompanyInbox.test.tsx server/src/__tests__/conversations-routes.test.ts --reporter=dot`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `git diff --check -- server/src/routes/conversations.ts server/src/__tests__/conversations-routes.test.ts ui/src/api/conversations.ts ui/src/pages/CompanyInbox.tsx ui/src/pages/CompanyInbox.test.tsx ui/src/App.tsx ui/src/pages/Inbox.tsx`

## Risks

- Low migration risk: this reuses existing assistant conversation/message tables and does not add schema changes.
- `findByCompany()` currently returns the first conversation for a company; if onboarding and company inbox conversations need to coexist distinctly, a future schema field or conversation kind should separate them.
- UI is intentionally minimal and reuses `ChatPanel`; richer work-object conversion cards can layer on top later.
- No screenshot included because this PR was created from a CLI-only agent session.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI agent, model `gpt-5.5`, tool-enabled coding session with repository file/terminal access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
