### PR TITLE
fix(ui): surface ServiceWorker registration errors (#165)

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -28,7 +28,12 @@ initPluginBridge(React, ReactDOM);
 
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js");
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      // Closes #165: surface registration failures so they aren't silently
+      // swallowed (permissions, network, missing /sw.js). Offline capability
+      // is best-effort; the app still loads if registration fails.
+      console.error("ServiceWorker registration failed:", err);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds `.catch` to the SW registration Promise so failures aren't silently swallowed
- One-line fix; offline capability stays best-effort

Closes #165.

## Test plan
- [x] Manual: simulate `/sw.js` 404 → verify error logged in DevTools console
- [x] Verified existing app boot path still works when registration succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)