### PR TITLE
fix(test): align verdicts.test.ts assertions with badRequest convention (#187)

### DIFF
--- a/server/src/__tests__/verdicts.test.ts
+++ b/server/src/__tests__/verdicts.test.ts
@@ -462,7 +462,7 @@ describe("verdictsService.setProjectDoD", () => {
       svc.setProjectDoD(COMPANY_ID, PROJECT_ID, { summary: "" } as any),
     ).rejects.toMatchObject({
       status: 400,
-      code: "DOD_INVALID",
+      details: expect.objectContaining({ code: "DOD_INVALID" }),
     });
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
@@ -500,7 +500,10 @@ describe("verdictsService.setIssueDoD", () => {
         summary: "",
         criteria: [],
       } as any),
-    ).rejects.toMatchObject({ status: 400, code: "DOD_INVALID" });
+    ).rejects.toMatchObject({
+      status: 400,
+      details: expect.objectContaining({ code: "DOD_INVALID" }),
+    });
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 });
@@ -538,7 +541,10 @@ describe("verdictsService.setGoalMetricDefinition", () => {
         // Missing required `unit` and `source`.
         target: 10,
       } as any),
-    ).rejects.toMatchObject({ status: 400, code: "METRIC_DEFINITION_INVALID" });
+    ).rejects.toMatchObject({
+      status: 400,
+      details: expect.objectContaining({ code: "METRIC_DEFINITION_INVALID" }),
+    });
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the 3 failing tests in \`server/src/__tests__/verdicts.test.ts\` flagged in #187. The tests asserted \`code: \"DOD_INVALID\"\` (and \"METRIC_DEFINITION_INVALID\") directly on the thrown \`HttpError\`, but \`badRequest(msg, {code})\` from \`server/src/errors.ts\` stores the code inside \`details\`, not as a top-level field.

## Fix

3 assertion sites updated to use the \`details: expect.objectContaining({ code: \"...\" })\` pattern. No production code touched.

## Test plan

- [x] \`git diff server/src/services/approvals.ts | wc -l\` = 0 (caller-only invariant)
- [ ] \`pnpm --filter @paperclipai/server test src/__tests__/verdicts.test.ts\` — 3 previously-failing tests now pass

Closes #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)