### PR TITLE
fix: typecheck blockers on main — duplicate PRO_LIVE + missing openclaw-gateway deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-openclaw-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/openclaw-gateway
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local
@@ -692,6 +695,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-openclaw-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/openclaw-gateway
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -33,14 +33,6 @@ import { isBillingDisabled } from "../middleware/require-tier.js";
 
 const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
 
-const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
-
-function isBillingDisabled(): boolean {
-  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
-  if (!process.env.STRIPE_SECRET_KEY) return true;
-  return false;
-}
-
 // AgentDash (AGE-55): per-route options. Mirrors the env-var-driven flag
 // from server/src/config.ts so test/integration harnesses can override.
 export interface CompanyRoutesOptions {

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",


### PR DESCRIPTION
## Summary

Main currently fails typecheck on both \`@paperclipai/server\` and \`@paperclipai/ui\`. Two unrelated blockers introduced by merge interactions between recent PRs:

### Bug 1: \`server/src/routes/companies.ts\` — duplicate \`PRO_LIVE\` declaration
\`\`\`
src/routes/companies.ts(34,7): error TS2451: Cannot redeclare block-scoped variable 'PRO_LIVE'.
src/routes/companies.ts(36,7): error TS2451: Cannot redeclare block-scoped variable 'PRO_LIVE'.
\`\`\`
Lines 34 + 36 both declared the same const. Lines 38-42 also redefined \`isBillingDisabled\` alongside the imported one. Dedup'd both.

### Bug 2: UI + server can't resolve \`@paperclipai/adapter-openclaw-gateway/{ui,server}\`
\`\`\`
src/adapters/openclaw-gateway/index.ts(2,48): error TS2307: Cannot find module '@paperclipai/adapter-openclaw-gateway/ui'
\`\`\`
The workspace dep was dropped from \`ui/package.json\` and \`server/package.json\` (lockfile drift in #186), but \`server/src/adapters/registry.ts\` and \`ui/src/adapters/openclaw-gateway/index.ts\` both still import from the package. Restored the deps + refreshed lockfile.

## Test plan

- [x] \`pnpm --filter @paperclipai/server typecheck\` → exit 0
- [x] \`pnpm --filter @paperclipai/ui typecheck\` → exit 0
- [x] \`pnpm --filter @paperclipai/shared typecheck\` → exit 0
- [x] \`pnpm --filter @paperclipai/db typecheck\` → exit 0
- [x] \`git diff main -- server/src/services/approvals.ts\` = 0 lines

Without these fixes, main does not typecheck and the platform cannot be prepared for human testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)