### PR TITLE
fix: friendly "Failed to fetch" errors + retry on network failures

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -19,11 +19,23 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     headers.set("Content-Type", "application/json");
   }
 
-  const res = await fetch(`${BASE}${path}`, {
-    headers,
-    credentials: "include",
-    ...init,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      headers,
+      credentials: "include",
+      ...init,
+    });
+  } catch (err) {
+    if (err instanceof TypeError && err.message === "Failed to fetch") {
+      throw new ApiError(
+        "Unable to reach the server — check your connection and try again.",
+        0,
+        null,
+      );
+    }
+    throw err;
+  }
   if (!res.ok) {
     const errorBody = await res.json().catch(() => null);
     throw new ApiError(

--- a/ui/src/context/CompanyContext.tsx
+++ b/ui/src/context/CompanyContext.tsx
@@ -98,7 +98,8 @@ export function CompanyProvider({ children }: { children: ReactNode }) {
         throw err;
       }
     },
-    retry: false,
+    retry: 2,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10_000),
   });
   const companies = companiesResult.companies;
   const companyListUnauthorized = companiesResult.unauthorized;


### PR DESCRIPTION
## Summary

- **Root cause**: When `fetch()` fails at the network level (server down, CORS, etc.), the browser throws a raw `TypeError` with message `"Failed to fetch"`. The API client didn't catch this — it propagated as an untyped error with the raw browser message shown directly to users.
- **Why it appeared frequently**: `CompanyContext` had `retry: false`, so even a brief server hiccup immediately surfaced an error. React Query's `refetchOnWindowFocus: true` meant every tab switch could refetch and hit the same failure.

## Changes

### `ui/src/api/client.ts`
Catch `TypeError` in the fetch try/catch and re-throw as `ApiError(status=0)` with the friendly message:
> "Unable to reach the server — check your connection and try again."

### `ui/src/context/CompanyContext.tsx`
Replace `retry: false` with `retry: 2` + exponential backoff (1s → 2s → 4s, max 10s). Transient network failures now recover silently instead of showing errors to users.

## Test plan

1. Kill the dev server briefly → browser should show "Unable to reach the server" (friendly), not "Failed to fetch"
2. Restart server → UI should recover automatically without manual refresh
3. Normal usage → no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)