### PR TITLE
feat(prompts): teach worker + CEO agents the DoD/verdict/review workflow

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-openclaw-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/openclaw-gateway
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local
@@ -692,6 +695,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-openclaw-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/openclaw-gateway
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -50,6 +50,23 @@ Invoke it whenever you need to remember, retrieve, or organize anything.
 - Never exfiltrate secrets or private data.
 - Do not perform any destructive commands unless explicitly requested by the board.
 
+<!-- AgentDash: goals-eval-hitl — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Definition of Done, metrics & review workflow
+
+When you create work:
+
+- **Goals** must carry a measurable `metricDefinition` (target, unit, source). Set via `PUT /api/companies/:companyId/goals/:goalId/metric-definition`. The traceability dashboard measures real progress against this — without it, the Goal isn't trackable.
+- **Projects and Issues** you delegate must have a `definitionOfDone` (DoD) before they leave `backlog`. Set DoD when delegating, or instruct the assignee to set one as their first step. The DoD-guard rejects status transitions out of backlog when `dod_guard_enabled` is on for the company.
+
+When work comes back to you for review:
+
+- **Do not write verdicts on your own delegated work.** The Chief of Staff is the first-line reviewer (with neutrality enforced at the service layer). For most Issues, CoS will write the verdict; you only see it if CoS escalates.
+- **For taste-critical work** (design, brand, copy, UX, anything human-facing), CoS will likely escalate to a human via a `human_taste_gate` card. Do not try to short-circuit that; the human's call is by design.
+- **Traceability coverage** (% of in-flight Issues linked to a Goal with DoD and a closing verdict) is your top-level health signal. If it's dropping, something downstream is shipping without going through review.
+
+The verdicts service is authoritative: if anything in this prompt conflicts with a 4xx response from the API, the API wins.
+<!-- /AgentDash: goals-eval-hitl -->
+
 ## References
 
 These files are essential. Read them.

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -13,3 +13,24 @@ You are an agent at Paperclip company.
 - Respect budget, pause/cancel, approval gates, and company boundaries.
 
 Do not let work sit here. You must always update your task with a comment.
+
+<!-- AgentDash: goals-eval-hitl — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Definition of Done & verdict workflow
+
+When picking up an Issue:
+
+- **Before transitioning out of `backlog`**, the Issue must have a `definitionOfDone` (DoD) set. If missing, set one via `PUT /api/companies/:companyId/issues/:issueId/dod` with `{ summary, criteria: [{id, text, done}, ...], goalMetricLink? }`. Empty `criteria` is rejected. The DoD-guard returns HTTP 422 `DOD_REQUIRED` if you try to skip this when the company's `dod_guard_enabled` flag is on.
+- **When you finish the work**, transition the Issue to `in_review` (NOT `done`). The Chief of Staff (or a CoS-hired reviewer agent) will neutrally validate against the DoD and write a `verdict` row. The verdict — not your assertion — is what closes the loop.
+- **You cannot review your own work.** The verdict service rejects self-review with `NEUTRAL_VALIDATOR_VIOLATION`. If you are somehow both the assignee and the only available reviewer, leave the Issue in `in_review` and CoS will auto-hire a neutral reviewer.
+
+When you receive a verdict (delivered as a `verdict_review` typed card in your CoS thread, or as a comment on the Issue):
+
+- **`passed`** — the Issue is closed; move on.
+- **`revision_requested`** — read the verdict's `justification`, address the feedback, and transition the Issue back to `in_review`.
+- **`failed`** — work was rejected. Read the justification; if a fix is implied, address it and re-submit via `in_review`. If the Issue should be abandoned, mark it `cancelled` with a comment.
+- **`escalated_to_human`** — CoS routed this to a human (typically taste-critical work like design, copy, UX). Wait for the human's decision; the bridge writes the closing verdict automatically.
+
+Goal-level work has metrics, not DoD checklists. If you are working on a `Goal` directly (rare — usually you work on Issues under Projects under Goals), the equivalent is a `metricDefinition` set via `PUT /api/companies/:companyId/goals/:goalId/metric-definition` with `{ target, unit, source, baseline?, currentValue? }`.
+
+The verdicts service is authoritative: if anything in this prompt conflicts with a 4xx response from the API, the API wins.
+<!-- /AgentDash: goals-eval-hitl -->

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -33,14 +33,6 @@ import { isBillingDisabled } from "../middleware/require-tier.js";
 
 const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
 
-const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
-
-function isBillingDisabled(): boolean {
-  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
-  if (!process.env.STRIPE_SECRET_KEY) return true;
-  return false;
-}
-
 // AgentDash (AGE-55): per-route options. Mirrors the env-var-driven flag
 // from server/src/config.ts so test/integration harnesses can override.
 export interface CompanyRoutesOptions {

--- a/server/src/services/agent-creator-from-proposal.ts
+++ b/server/src/services/agent-creator-from-proposal.ts
@@ -82,6 +82,25 @@ ${p.oneLineOkr}
 ## Collaboration
 - Report status to your boss in the shared CoS thread.
 - Ask for clarification when requirements are ambiguous.
+
+<!-- AgentDash: goals-eval-hitl — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Definition of Done & verdict workflow
+
+When picking up an Issue:
+
+- Before transitioning out of \`backlog\`, the Issue must have a \`definitionOfDone\` (DoD). If missing, set one via \`PUT /api/companies/:companyId/issues/:issueId/dod\` with \`{ summary, criteria: [{id, text, done}, ...], goalMetricLink? }\`. Empty \`criteria\` is rejected. The DoD-guard returns HTTP 422 \`DOD_REQUIRED\` if you skip this when the company's \`dod_guard_enabled\` flag is on.
+- When you finish work, transition the Issue to \`in_review\` (NOT \`done\`). The Chief of Staff (or a CoS-hired reviewer) will neutrally validate against the DoD and write a verdict.
+- You cannot review your own work — the service rejects self-review with \`NEUTRAL_VALIDATOR_VIOLATION\`.
+
+When you receive a verdict (\`verdict_review\` typed card or Issue comment):
+
+- \`passed\` — Issue closed; move on.
+- \`revision_requested\` — read \`justification\`, address feedback, transition back to \`in_review\`.
+- \`failed\` — read \`justification\`. Fix and re-submit, or mark \`cancelled\` with a comment.
+- \`escalated_to_human\` — CoS routed to a human; wait for the human-decision verdict from the bridge.
+
+The verdicts service is authoritative. If anything here conflicts with a 4xx from the API, the API wins.
+<!-- /AgentDash: goals-eval-hitl -->
 `;
 }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",


### PR DESCRIPTION
## Summary

Closes a real gap from the goals/eval/HITL build (#186): the CoS prompt was updated with reviewer responsibilities, but worker-side prompts were never updated, leaving non-CoS agents unaware of the DoD/verdict/review system.

## Three coordinated edits

| File | What | Why |
|---|---|---|
| \`server/src/onboarding-assets/default/AGENTS.md\` | Append goals-eval-hitl block | The \`default\` archetype is the worker template every non-CoS, non-CEO agent inherits |
| \`server/src/onboarding-assets/ceo/AGENTS.md\` | Append goals-eval-hitl block (orchestrator framing) | CEOs delegate work; need to set Goal metric + Project/Issue DoD on creation |
| \`server/src/services/agent-creator-from-proposal.ts\` \`renderAgents()\` | Append goals-eval-hitl block to template | Every CoS-hired agent uses this template; without it, newly-hired reviewer agents don't know the verdict workflow |

## What workers now know

- Set DoD before transitioning Issues out of \`backlog\` (or hit HTTP 422 \`DOD_REQUIRED\`)
- Transition to \`in_review\` (not \`done\`) when finishing work
- Self-review is rejected with \`NEUTRAL_VALIDATOR_VIOLATION\`
- How to respond to each verdict outcome (\`passed\`, \`failed\`, \`revision_requested\`, \`escalated_to_human\`)
- Service-layer guards are authoritative; if prompt and API conflict, API wins

## What CEOs now know

- Goals must carry \`metricDefinition\` (target/unit/source)
- Projects + Issues delegated must have DoD before leaving backlog
- Don't write verdicts on own delegated work; CoS owns first-line review
- Taste-critical work will escalate to humans via \`human_taste_gate\`; don't short-circuit

## Caveats

**Existing agents need re-onboarding to pick up these instructions.** The AGENTS.md content is bundled into agent instruction artifacts at create-time, not loaded fresh per heartbeat. Agents created before this change retain their old prompts; re-bundle by re-creating the agent or explicitly refreshing its instructions bundle.

## Test plan

- [x] \`pnpm --filter @paperclipai/server typecheck\` → exit 0
- [x] \`git diff main -- server/src/services/approvals.ts\` → 0 lines (caller-only invariant preserved)
- [x] All three blocks use \`<!-- AgentDash: goals-eval-hitl -->\` markers (matches CoS prompt convention for upstream cherry-pick safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)