### PR TITLE
chore(ci): enforce prompt-surface updates on agent-facing changes

### DIFF
--- a/.github/workflows/agents-md-drift-check.yml
+++ b/.github/workflows/agents-md-drift-check.yml
@@ -1,0 +1,35 @@
+name: Agents MD Drift Check
+
+# Enforces the "agent-facing feature convention" documented in repo-root
+# AGENTS.md. When a PR adds new files under server/src/routes/,
+# server/src/services/, or packages/db/src/schema/, it must also touch at
+# least one of the four agent prompt surfaces (or carry the
+# `[no-prompt-update]` bypass flag in the PR title/body).
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: agents-md-drift-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run agents-md drift check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/ci/check-agents-md-drift.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cli/tmp/
 # Scratch/seed scripts (but not scripts/ dir)
 check-*.mjs
 !scripts/check-*.mjs
+!scripts/ci/check-*.mjs
 new-agent*.json
 newcompany.json
 seed-*.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,3 +216,48 @@ PR #2218 (`feat/external-adapter-phase1`) adds external adapter support. See roo
 - `createServerAdapter()` must include ALL optional fields (especially `detectModel`)
 - Built-in UI adapters can shadow external plugin parsers — remove built-in when fully externalizing
 - Reference external adapters: Hermes (`@henkey/hermes-paperclip-adapter` or `file:`) and Droid (npm)
+
+<!-- AgentDash: agent-facing-feature-convention — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## AgentDash Fork: Adding Agent-Facing Features
+
+This section is AgentDash-specific and lives in a named block so upstream cherry-picks (which never touch our agent prompts) can be reasoned about safely. It complements `doc/UPSTREAM-POLICY.md`, which governs the broader fork relationship with `paperclipai/paperclip`.
+
+### Why this convention exists
+
+When AgentDash adds a feature that requires agent behavior changes — a new endpoint workers must call, a new state transition, a new approval gate, a new failure mode they must recover from — every agent must learn about it regardless of which adapter (Claude, Codex, Cursor, Gemini, Pi, OpenCode, OpenClaw, Hermes, etc.) is dispatching that worker. Agent prompts are the harness, not the adapter; if a prompt surface is missed, that adapter's worker silently runs the old behavior and the regression is invisible until production. PR #191 made this concrete: workers without prompt updates were silently broken on the new DoD/verdict workflow.
+
+### The four prompt surfaces that MUST be updated
+
+When a change touches agent-facing behavior, update **every** surface below in the same PR:
+
+1. `server/src/onboarding-assets/default/AGENTS.md` — default worker prompt baseline.
+2. `server/src/onboarding-assets/ceo/AGENTS.md` — CEO agent prompt.
+3. `server/src/onboarding-assets/chief_of_staff/AGENTS.md` — Chief of Staff agent prompt.
+4. `server/src/services/agent-creator-from-proposal.ts` — `renderAgents` (agent-creator template that synthesizes per-hire prompts from proposals).
+
+If the new behavior genuinely doesn't apply to a surface, still touch the file with a short comment explaining why — that gives reviewers and CI an explicit signal rather than silent omission.
+
+### Adapter-agnostic content rules
+
+The four surfaces are read by every adapter, so write them in adapter-neutral terms:
+
+- **HTTP endpoints over adapter-specific tool calls.** Refer to `POST /api/companies/:companyId/...` rather than to a specific adapter's tool name. Workers reach the control plane the same way regardless of harness.
+- **JSON payload field names, not visual representations.** Say `{ "verdict": "pass" }` rather than "click the green Pass button" — adapters with no UI must still understand the contract.
+- **Mention "card OR comment" fallback patterns.** When a behavior can be expressed via a typed card *or* a plain comment, document both — adapters that can't render cards still need the comment fallback to participate.
+
+### Named-block convention for upstream cherry-pick safety
+
+AgentDash-specific additions to files we share with upstream should be wrapped in an HTML-comment block of the form:
+
+```
+<!-- AgentDash: <feature-slug> — DO NOT REMOVE OR REORDER THIS BLOCK -->
+... AgentDash-specific content ...
+<!-- /AgentDash: <feature-slug> -->
+```
+
+This makes the conflict surface explicit if an upstream cherry-pick later touches the same file. Pair the block with `// AgentDash:` inline comments for source code, per `CLAUDE.md` §"Key Rules". See `doc/UPSTREAM-POLICY.md` for the broader cherry-pick rubric.
+
+### CI enforcement
+
+`.github/workflows/agents-md-drift-check.yml` runs on every pull request against `main` and fails when a PR adds new files under `server/src/routes/`, `server/src/services/`, or `packages/db/src/schema/` without also touching at least one of the four prompt surfaces. Bypass when the change genuinely doesn't apply to agent prompts by including `[no-prompt-update]` (case-insensitive) in the PR title or body. Use the bypass sparingly — the default assumption is that agent-facing infrastructure changes need prompt updates.
+<!-- /AgentDash: agent-facing-feature-convention -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,10 @@ export type MyStatus = (typeof MY_STATUSES)[number];
 
 Deployment: XS/S auto-ship after local test. M+ requires human verification. XL may use `staging` branch. The detailed handoff/sizing rules live inline in each agent's `.claude/commands/*.md` file.
 
+## Agent-facing feature convention
+
+Project conventions for adding agent-facing features (new endpoints, state transitions, gates, failure modes — DoD/verdict-style additions) live in repo-root [`AGENTS.md`](AGENTS.md), the harness-agnostic file read by Codex, Cursor, Aider, Continue, and other tools. When extending Paperclip's worker prompts, follow the rule there: update all four prompt surfaces (`server/src/onboarding-assets/{default,ceo,chief_of_staff}/AGENTS.md` plus `server/src/services/agent-creator-from-proposal.ts`). CI enforces this via `.github/workflows/agents-md-drift-check.yml`.
+
 ## Upstream Policy
 
 **Reference, don't merge.** Paperclip tracked as `upstream` remote for read-only reference only. We do NOT run continuous or scheduled upstream syncs — as of 2026-04-17 we were 339 commits behind with 37% of migrations AgentDash-owned, and every conflict-prone core file has AgentDash modifications. Continuous merging is not worth the cost.

--- a/doc/UPSTREAM-POLICY.md
+++ b/doc/UPSTREAM-POLICY.md
@@ -81,6 +81,10 @@ These systems do not exist in Paperclip. An upstream commit will never be releva
 
 ---
 
+## Agent-facing prompt surfaces (AgentDash-owned)
+
+Worker prompts are 100% AgentDash territory and never inherit upstream changes. When extending agent-facing behavior (new endpoints, state transitions, gates, failure modes), follow the convention in repo-root [`AGENTS.md`](../AGENTS.md) — update all four prompt surfaces (`server/src/onboarding-assets/{default,ceo,chief_of_staff}/AGENTS.md` plus `server/src/services/agent-creator-from-proposal.ts` `renderAgents`). CI enforces this via `.github/workflows/agents-md-drift-check.yml`.
+
 ## Cherry-pick rubric
 
 When is an upstream commit worth the evaluation cost? Check all four gates:

--- a/scripts/ci/check-agents-md-drift.mjs
+++ b/scripts/ci/check-agents-md-drift.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Enforces the "agent-facing feature convention" documented in repo-root
+ * AGENTS.md (`AgentDash Fork: Adding Agent-Facing Features`).
+ *
+ * Trigger: a PR adds NEW files (git status A) under any of:
+ *   - server/src/routes/**.ts          (excluding *.test.ts / *.spec.ts)
+ *   - server/src/services/**.ts        (excluding *.test.ts / *.spec.ts)
+ *   - packages/db/src/schema/**.ts     (excluding index.ts and *.test.ts / *.spec.ts)
+ *
+ * Rule: when triggered, the same diff MUST also touch (any status: A/M/D/R) at
+ * least one of the four prompt surfaces:
+ *   - server/src/onboarding-assets/default/AGENTS.md
+ *   - server/src/onboarding-assets/ceo/AGENTS.md
+ *   - server/src/onboarding-assets/chief_of_staff/AGENTS.md
+ *   - server/src/services/agent-creator-from-proposal.ts
+ *
+ * Bypass: include `[no-prompt-update]` (case-insensitive) in the PR title or body.
+ *
+ * Inputs (env):
+ *   BASE_SHA                  base commit SHA  (required for "diff" mode)
+ *   HEAD_SHA                  head commit SHA  (required for "diff" mode)
+ *   PR_TITLE                  PR title         (optional)
+ *   PR_BODY                   PR body          (optional)
+ *
+ * Inputs (CLI flags, override env — used by local self-tests):
+ *   --diff <path>             read newline-separated `<status>\t<path>` lines
+ *                             from the file instead of running git diff
+ *   --title <string>          override PR_TITLE
+ *   --body <string>           override PR_BODY
+ *
+ * Exit codes:
+ *   0 — pass (no trigger / opted out / properly updated)
+ *   1 — fail (trigger fired, no prompt surface touched, no bypass flag)
+ *   2 — usage / internal error
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const BYPASS_FLAG = "[no-prompt-update]";
+
+const PROMPT_SURFACES = [
+  "server/src/onboarding-assets/default/AGENTS.md",
+  "server/src/onboarding-assets/ceo/AGENTS.md",
+  "server/src/onboarding-assets/chief_of_staff/AGENTS.md",
+  "server/src/services/agent-creator-from-proposal.ts",
+];
+
+function parseArgs(argv) {
+  const args = { diffFile: null, title: null, body: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--diff") {
+      args.diffFile = value;
+      i += 1;
+    } else if (flag === "--title") {
+      args.title = value;
+      i += 1;
+    } else if (flag === "--body") {
+      args.body = value;
+      i += 1;
+    } else if (flag === "--help" || flag === "-h") {
+      process.stdout.write(
+        "Usage: check-agents-md-drift.mjs [--diff <file>] [--title <s>] [--body <s>]\n",
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`Unknown argument: ${flag}\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function readDiffFromFile(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function readDiffFromGit(baseSha, headSha) {
+  const out = execFileSync(
+    "git",
+    ["diff", "--name-status", `${baseSha}...${headSha}`],
+    { encoding: "utf8" },
+  );
+  return out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Parse a `git diff --name-status` line.
+ * Statuses: A (added), M (modified), D (deleted), R### (renamed), C### (copied).
+ * Renames/copies emit two paths; we treat the second (destination) path as the
+ * affected file. For status A/M/D there's only one path.
+ */
+function parseDiffLine(line) {
+  const parts = line.split(/\t/);
+  if (parts.length < 2) return null;
+  const status = parts[0];
+  const path = parts[parts.length - 1];
+  return { status, path };
+}
+
+function isTestFile(p) {
+  return /\.(test|spec)\.[mc]?[tj]sx?$/.test(p);
+}
+
+function isAgentFacingTrigger(entry) {
+  if (!entry || entry.status[0] !== "A") return false;
+  const p = entry.path;
+  if (!p.endsWith(".ts")) return false;
+  if (isTestFile(p)) return false;
+
+  if (p.startsWith("server/src/routes/")) return true;
+  if (p.startsWith("server/src/services/")) {
+    // Don't treat the agent-creator-from-proposal.ts file itself as a trigger
+    // when newly added — it's a prompt surface, not a generic service.
+    if (p === "server/src/services/agent-creator-from-proposal.ts") return false;
+    return true;
+  }
+  if (p.startsWith("packages/db/src/schema/")) {
+    if (p === "packages/db/src/schema/index.ts") return false;
+    return true;
+  }
+  return false;
+}
+
+function isPromptSurfaceTouch(entry) {
+  if (!entry) return false;
+  return PROMPT_SURFACES.includes(entry.path);
+}
+
+function hasBypassFlag(title, body) {
+  const haystack = `${title || ""}\n${body || ""}`.toLowerCase();
+  return haystack.includes(BYPASS_FLAG.toLowerCase());
+}
+
+function formatList(items) {
+  return items.map((p) => `  - ${p}`).join("\n");
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const title = args.title ?? process.env.PR_TITLE ?? "";
+  const body = args.body ?? process.env.PR_BODY ?? "";
+
+  let diffLines;
+  if (args.diffFile) {
+    diffLines = readDiffFromFile(args.diffFile);
+  } else {
+    const baseSha = process.env.BASE_SHA;
+    const headSha = process.env.HEAD_SHA;
+    if (!baseSha || !headSha) {
+      process.stderr.write(
+        "BASE_SHA and HEAD_SHA env vars are required when --diff is not provided.\n",
+      );
+      process.exit(2);
+    }
+    diffLines = readDiffFromGit(baseSha, headSha);
+  }
+
+  const entries = diffLines
+    .map(parseDiffLine)
+    .filter((e) => e !== null);
+
+  const triggers = entries.filter(isAgentFacingTrigger).map((e) => e.path);
+  const promptTouched = entries.some(isPromptSurfaceTouch);
+
+  if (triggers.length === 0) {
+    process.stdout.write(
+      "Agent-facing feature check passed (no trigger files in diff).\n",
+    );
+    process.exit(0);
+  }
+
+  if (hasBypassFlag(title, body)) {
+    process.stdout.write(
+      `Agent-facing feature check passed (bypass flag '${BYPASS_FLAG}' present in PR title/body).\n` +
+        `Trigger files detected:\n${formatList(triggers)}\n`,
+    );
+    process.exit(0);
+  }
+
+  if (promptTouched) {
+    process.stdout.write(
+      `Agent-facing feature check passed (trigger files detected, prompt surfaces updated).\n` +
+        `Trigger files:\n${formatList(triggers)}\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    [
+      "Agent-facing feature check FAILED.",
+      "",
+      "This PR adds new files that look like agent-facing infrastructure:",
+      formatList(triggers),
+      "",
+      "But it does not update any of the four agent prompt surfaces:",
+      formatList(PROMPT_SURFACES),
+      "",
+      "When AgentDash adds a feature that requires agent behavior changes —",
+      "new endpoints, state transitions, gates, failure modes — every agent",
+      "must learn about it regardless of adapter. Update the four prompt",
+      "surfaces above (or touch them with an explanatory comment if the new",
+      "behavior genuinely doesn't apply).",
+      "",
+      `If the change truly does not need a prompt update, include '${BYPASS_FLAG}'`,
+      "(case-insensitive) in the PR title or body to bypass this check.",
+      "",
+      "See repo-root AGENTS.md (`AgentDash Fork: Adding Agent-Facing Features`)",
+      "for the full convention.",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - AgentDash extends it with adapter-agnostic worker prompts that every adapter (Claude, Codex, Cursor, Gemini, Pi, OpenCode, OpenClaw, Hermes) reads to learn how to participate in the control plane.
> - PR #191 taught workers + CEO agents the new DoD/verdict workflow — but exposed a silent failure mode: when AgentDash adds an agent-facing feature (new endpoint, state transition, gate, failure mode) without updating every prompt surface, the adapters whose prompts weren't touched silently run the old behavior.
> - The repo had no convention or guardrail forcing the four prompt surfaces to stay in lockstep with new agent-facing infrastructure.
> - This PR documents the rule in repo-root \`AGENTS.md\` (the harness-agnostic file read by Codex, Cursor, Aider, Continue, etc.), cross-references it from \`CLAUDE.md\` and \`doc/UPSTREAM-POLICY.md\`, and adds a CI check that enforces it on every PR.
> - The benefit is regressions of the PR #191 shape become impossible to merge without an explicit acknowledgment (\`[no-prompt-update]\` flag) that the change genuinely doesn't apply to agent prompts.

## What Changed

- **\`AGENTS.md\`** — new \`## AgentDash Fork: Adding Agent-Facing Features\` section, wrapped in a named block (\`<!-- AgentDash: agent-facing-feature-convention -->\`) so future upstream cherry-picks can reason about it. Documents *why* the convention exists, the four prompt surfaces (\`server/src/onboarding-assets/{default,ceo,chief_of_staff}/AGENTS.md\` plus \`server/src/services/agent-creator-from-proposal.ts\`), adapter-agnostic content rules (HTTP endpoints over tool calls, JSON field names over visual cues, \"card OR comment\" fallback), the named-block convention, and how to bypass CI when genuinely not applicable.
- **\`CLAUDE.md\`** — adds a thin pointer titled \`## Agent-facing feature convention\` near \`## Upstream Policy\`. Does not duplicate the rule itself; \`AGENTS.md\` is the source of truth.
- **\`doc/UPSTREAM-POLICY.md\`** — cross-reference inserted just before the cherry-pick rubric explaining that worker prompts are 100% AgentDash territory and pointing at the convention in \`AGENTS.md\`.
- **\`.github/workflows/agents-md-drift-check.yml\`** — single-job, ubuntu-latest, 5-minute-timeout workflow that runs on \`pull_request\` against \`main\`. Checks out with \`fetch-depth: 0\` and runs the script with \`BASE_SHA\`, \`HEAD_SHA\`, \`PR_TITLE\`, \`PR_BODY\` from \`github.event.pull_request\`.
- **\`scripts/ci/check-agents-md-drift.mjs\`** — pure-Node script (no extra deps). Detects \"agent-facing changes\" as added \`.ts\` files (excluding \`*.test.ts\` / \`*.spec.ts\`) under \`server/src/routes/\`, \`server/src/services/\` (excluding the agent-creator file itself), or \`packages/db/src/schema/\` (excluding \`index.ts\`). When triggered, requires a touch on at least one prompt surface, OR \`[no-prompt-update]\` in PR title/body. Clear error message names trigger files, all four surfaces, and the bypass option. Supports \`--diff <file>\` / \`--title\` / \`--body\` flags for local self-tests.
- **\`.gitignore\`** — un-ignore \`scripts/ci/check-*.mjs\` (existing rule for scratch \`check-*.mjs\` files otherwise swallows the new CI script).

## Verification

Local self-tests (run from worktree on this branch):

\`\`\`
node scripts/ci/check-agents-md-drift.mjs --diff <synthetic> --title <...> --body <...>
\`\`\`

Seven cases, all behave as expected:

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | New \`server/src/routes/widgets.ts\`, no prompt update, no bypass | FAIL exit 1 | exit 1, error names trigger + 4 surfaces + bypass |
| 2 | Same + \`server/src/onboarding-assets/default/AGENTS.md\` modified | PASS exit 0 | exit 0, \"prompt surfaces updated\" |
| 3 | Same + \`[no-prompt-update]\` in title | PASS exit 0 | exit 0, \"bypass flag present\" |
| 4 | Real diff of THIS PR (\`origin/main...HEAD\`) | PASS exit 0 (no triggers) | exit 0 |
| 5 | New \`packages/db/src/schema/widgets.ts\`, no prompt update | FAIL exit 1 | exit 1 |
| 6 | Only \`packages/db/src/schema/index.ts\` modified | PASS (no trigger) | exit 0 |
| 7 | Only \`server/src/routes/widgets.test.ts\` added | PASS (no trigger) | exit 0 |

Sanity: \`pnpm --filter @paperclipai/server typecheck\` exits 0 (script doesn't ship in the build path; this just confirms unrelated regressions weren't introduced).

\`git diff main -- server/src/services/approvals.ts | wc -l\` = 0.

## Risks

- **Low risk.** The check is additive — it cannot break existing PRs that don't add new files under the watched directories. The bypass flag (\`[no-prompt-update]\`) provides an escape hatch for genuinely non-applicable changes (e.g., a new internal-only debugging route). Worst case: a developer hits the failure on a legitimate \"doesn't apply\" change, reads the error message, adds the bypass flag, retries. The error message names the bypass option explicitly.
- The script depends only on \`git\` and Node (already on every CI runner), no \`pnpm install\` step required, so the workflow's worst-case runtime is dominated by checkout (a few seconds).
- The convention will need to be re-evaluated if the prompt-surface set changes (e.g., a fifth role is added). The named block + the constant array in the script make this a focused two-file edit.

## Model Used

- Claude Opus 4.7 (1M context), via the OMC executor agent harness, no extended-thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (server typecheck + 7 synthetic CI script cases)
- [x] I have added or updated tests where applicable (CI script self-tests are documented in Verification)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI changes
- [x] I have updated relevant documentation to reflect my changes (AGENTS.md, CLAUDE.md, doc/UPSTREAM-POLICY.md)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge