### PR TITLE
feat(prompts): teach agents how to authenticate to the API

### DIFF
--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -67,6 +67,19 @@ When work comes back to you for review:
 The verdicts service is authoritative: if anything in this prompt conflicts with a 4xx response from the API, the API wins.
 <!-- /AgentDash: goals-eval-hitl -->
 
+<!-- AgentDash: agent-api-auth — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## API authentication
+
+When you make HTTP calls to the AgentDash API (`/api/...` endpoints):
+
+- Send your agent key as the `x-agent-key: <value>` header on every request. The key is provisioned in your environment as `PAPERCLIP_API_KEY` by the adapter that launched you. Read it from `process.env.PAPERCLIP_API_KEY` or your language's equivalent.
+- Browser-session cookies are not accepted from CLI/non-browser origins. The board-mutation-guard rejects POST/PATCH/PUT/DELETE from `board` actors without a trusted browser Origin header. Authenticating as an agent (via `x-agent-key`) bypasses that guard cleanly.
+- If `PAPERCLIP_API_KEY` is not set in your environment, your adapter is misconfigured — comment on your task naming the adapter and escalate to your boss rather than retrying without auth.
+- WebSocket subscriptions to live events use the same key (`?token=<key>` query param or `Authorization: Bearer <key>` header).
+
+The same key works for all `/api/companies/:companyId/...` endpoints under your company; cross-company access is rejected with HTTP 403.
+<!-- /AgentDash: agent-api-auth -->
+
 ## References
 
 These files are essential. Read them.

--- a/server/src/onboarding-assets/chief_of_staff/AGENTS.md
+++ b/server/src/onboarding-assets/chief_of_staff/AGENTS.md
@@ -95,3 +95,16 @@ Both card payloads are validated by Zod schemas in `packages/shared/src/validato
 
 **Service guard authoritative.** The verdicts service enforces the neutral-validator rule (reviewer must not be the assignee), the DoD-required-at-creation rule (when the company's `dod_guard_enabled` flag is true), and the entity-FK shape rules (exactly one of goalId/projectId/issueId is non-null). If anything in this prompt conflicts with the service-layer guards, the service wins.
 <!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## API authentication
+
+When you make HTTP calls to the AgentDash API (`/api/...` endpoints):
+
+- Send your agent key as the `x-agent-key: <value>` header on every request. The key is provisioned in your environment as `PAPERCLIP_API_KEY` by the adapter that launched you. Read it from `process.env.PAPERCLIP_API_KEY` or your language's equivalent.
+- Browser-session cookies are not accepted from CLI/non-browser origins. The board-mutation-guard rejects POST/PATCH/PUT/DELETE from `board` actors without a trusted browser Origin header. Authenticating as an agent (via `x-agent-key`) bypasses that guard cleanly.
+- If `PAPERCLIP_API_KEY` is not set in your environment, your adapter is misconfigured — comment on your task naming the adapter and escalate to your boss rather than retrying without auth.
+- WebSocket subscriptions to live events use the same key (`?token=<key>` query param or `Authorization: Bearer <key>` header).
+
+The same key works for all `/api/companies/:companyId/...` endpoints under your company; cross-company access is rejected with HTTP 403.
+<!-- /AgentDash: agent-api-auth -->

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -34,3 +34,16 @@ Goal-level work has metrics, not DoD checklists. If you are working on a `Goal` 
 
 The verdicts service is authoritative: if anything in this prompt conflicts with a 4xx response from the API, the API wins.
 <!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## API authentication
+
+When you make HTTP calls to the AgentDash API (`/api/...` endpoints):
+
+- Send your agent key as the `x-agent-key: <value>` header on every request. The key is provisioned in your environment as `PAPERCLIP_API_KEY` by the adapter that launched you. Read it from `process.env.PAPERCLIP_API_KEY` or your language's equivalent.
+- Browser-session cookies are not accepted from CLI/non-browser origins. The board-mutation-guard rejects POST/PATCH/PUT/DELETE from `board` actors without a trusted browser Origin header. Authenticating as an agent (via `x-agent-key`) bypasses that guard cleanly.
+- If `PAPERCLIP_API_KEY` is not set in your environment, your adapter is misconfigured — comment on your task naming the adapter and escalate to your boss rather than retrying without auth.
+- WebSocket subscriptions to live events use the same key (`?token=<key>` query param or `Authorization: Bearer <key>` header).
+
+The same key works for all `/api/companies/:companyId/...` endpoints under your company; cross-company access is rejected with HTTP 403.
+<!-- /AgentDash: agent-api-auth -->

--- a/server/src/services/agent-creator-from-proposal.ts
+++ b/server/src/services/agent-creator-from-proposal.ts
@@ -101,6 +101,19 @@ When you receive a verdict (\`verdict_review\` typed card or Issue comment):
 
 The verdicts service is authoritative. If anything here conflicts with a 4xx from the API, the API wins.
 <!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## API authentication
+
+When you make HTTP calls to the AgentDash API (\`/api/...\` endpoints):
+
+- Send your agent key as the \`x-agent-key: <value>\` header on every request. The key is provisioned in your environment as \`PAPERCLIP_API_KEY\` by the adapter that launched you. Read it from \`process.env.PAPERCLIP_API_KEY\` or your language's equivalent.
+- Browser-session cookies are not accepted from CLI/non-browser origins. The board-mutation-guard rejects POST/PATCH/PUT/DELETE from \`board\` actors without a trusted browser Origin header. Authenticating as an agent (via \`x-agent-key\`) bypasses that guard cleanly.
+- If \`PAPERCLIP_API_KEY\` is not set in your environment, your adapter is misconfigured — comment on your task naming the adapter and escalate to your boss rather than retrying without auth.
+- WebSocket subscriptions to live events use the same key (\`?token=<key>\` query param or \`Authorization: Bearer <key>\` header).
+
+The same key works for all \`/api/companies/:companyId/...\` endpoints under your company; cross-company access is rejected with HTTP 403.
+<!-- /AgentDash: agent-api-auth -->
 `;
 }
 


### PR DESCRIPTION
## Problem

A production-testing agent ("Laura") reported:

> Paperclip API authentication is not accessible from my CLI session — the server uses browser-session cookies that can't be used from curl. Paperclip's board mutation guard blocks all API writes from non-browser origins.

She wasn't wrong about the symptom but wrong about the diagnosis.

## Diagnosis

The platform's auth pieces are correctly designed:

- **Paperclip-native adapters set `env.PAPERCLIP_API_KEY = authToken`** at agent launch (see [packages/adapters/claude-local/src/server/execute.ts:235](../packages/adapters/claude-local/src/server/execute.ts#L235)).
- **Auth middleware accepts `x-agent-key` header** → sets `req.actor.type = "agent"` ([server/src/middleware/auth.ts:124-167](../server/src/middleware/auth.ts#L124)).
- **`board-mutation-guard` exempts agent actors** at line 33-35: `if (req.actor.type !== "board") return next()`.

**The gap was prompt-level discoverability.** None of the 4 prompt surfaces (`default/AGENTS.md`, `ceo/AGENTS.md`, `chief_of_staff/AGENTS.md`, `renderAgents` template) told agents to read `PAPERCLIP_API_KEY` from env or send it as `x-agent-key`. So agents called API endpoints unauthenticated, hit the guard's "requires trusted browser origin" rejection, and looked for cookies as a fallback.

## Fix

Adds an `<!-- AgentDash: agent-api-auth -->` named block to all 4 prompt surfaces explaining:

- Read `PAPERCLIP_API_KEY` from your environment (set by your launching adapter)
- Send it as `x-agent-key: <value>` header on every API call
- Browser-session cookies are not accepted from CLI/non-browser origins
- If the env var is missing, comment + escalate rather than retry without auth
- Same key works for WebSocket subscriptions (`?token=` or `Authorization: Bearer`)

Block is **adapter-agnostic** — uses only an HTTP header name and an env var name, both universal across the 11 adapters.

## What's NOT addressed

**Per-adapter audit.** Some external adapters (Hermes, etc.) may not propagate `PAPERCLIP_API_KEY` at agent launch. If "Laura" is running on one of those, fixing this prompt alone won't unblock her — her runtime still won't have the env var to read. That's a separate triage task: walk `packages/adapters/*` (and any external adapters in use) and verify each calls the equivalent of `env.PAPERCLIP_API_KEY = authToken` in its `execute()` path.

## Test plan

- [x] \`pnpm --filter @paperclipai/server typecheck\` → exit 0
- [x] \`scripts/ci/check-agents-md-drift.mjs\` → "no trigger files in diff" (passes — only prompt surfaces touched, no new routes/services/schema)
- [x] \`git diff main -- server/src/services/approvals.ts | wc -l\` → 0 (caller-only invariant preserved)
- [x] All 4 prompt surfaces now contain BOTH the \`AgentDash: goals-eval-hitl\` block AND the new \`AgentDash: agent-api-auth\` block

## Caveat for existing agents

The AGENTS.md content is bundled into agent instruction artifacts at create-time, not loaded fresh per heartbeat. **Agents created before this PR retain their old prompts.** To activate the new behavior:

- Clean DB reset (recommended for human testing): \`rm -rf ~/.paperclip/instances/default/db && pnpm dev\` — fresh agents pick up the merged prompts automatically.
- Or recreate the affected agent via CoS hire flow (uses the new \`renderAgents\` template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)