### PR TITLE
feat(cos): materialize onboarding goals into the goals table (#174)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1059,6 +1059,10 @@ export const ACTIVITY_LOG_ACTIONS_GOALS_EVAL_HITL = [
   "dod_set",
   "metric_updated",
   "reviewer_hired",
+  // AgentDash (issue #174): emitted by materializeOnboardingGoals when CoS
+  // turns the captured {shortTerm, longTerm} interview answers into rows
+  // in the goals table during the onboarding `materializing` phase.
+  "goal_created_from_onboarding",
 ] as const;
 export type ActivityLogActionGoalsEvalHitl =
   (typeof ACTIVITY_LOG_ACTIONS_GOALS_EVAL_HITL)[number];

--- a/server/src/__tests__/materialize-onboarding-goals.test.ts
+++ b/server/src/__tests__/materialize-onboarding-goals.test.ts
@@ -1,0 +1,346 @@
+// AgentDash (issue #174): unit tests for the materializeOnboardingGoals
+// service helper. Mirrors the mock-DB style used by verdicts.test.ts so we
+// don't need an embedded postgres for these shape-level assertions.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import {
+  materializeOnboardingGoals,
+  OnboardingStateNotFoundError,
+} from "../services/materialize-onboarding-goals.ts";
+
+const mockLogActivity = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+  setPluginEventBus: vi.fn(),
+  publishPluginDomainEvent: vi.fn(),
+}));
+
+interface OnboardingStateFixture {
+  conversationId: string;
+  goals: { shortTerm?: string; longTerm?: string };
+}
+
+interface GoalRow {
+  id: string;
+  companyId: string;
+  ownerAgentId: string | null;
+  title: string;
+  level: string;
+  status: string;
+  parentId: string | null;
+  metricDefinition: unknown;
+}
+
+interface DbStubOptions {
+  state?: OnboardingStateFixture | null;
+  existingGoals?: GoalRow[];
+}
+
+/**
+ * Lightweight stub mimicking the drizzle query chain used inside the
+ * transaction. The first `.select()` returns the cos_onboarding_states row;
+ * the second returns the existing goals (idempotency lookup). Inserts are
+ * recorded and synthesize an id for `.returning()`.
+ */
+function makeDb(opts: DbStubOptions = {}) {
+  const insertedGoals: GoalRow[] = [];
+  // Pre-seed `existingGoals` so the idempotency lookup can find them.
+  const goalStore: GoalRow[] = [...(opts.existingGoals ?? [])];
+
+  let selectCallCount = 0;
+
+  const select = vi.fn(() => {
+    selectCallCount += 1;
+    const callIdx = selectCallCount;
+    const chain: any = {};
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => chain);
+    chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) => {
+      // Call 1: cos_onboarding_states lookup.
+      // Call 2+: existing goals lookup for idempotency.
+      let rows: unknown[] = [];
+      if (callIdx === 1) {
+        rows = opts.state ? [opts.state] : [];
+      } else {
+        rows = goalStore;
+      }
+      return Promise.resolve(rows).then(resolve, reject);
+    };
+    return chain;
+  });
+
+  const insertReturning = vi.fn(async () => {
+    const last = insertedGoals[insertedGoals.length - 1];
+    return last ? [last] : [];
+  });
+  const insertValues = vi.fn((values: Partial<GoalRow>) => {
+    const row: GoalRow = {
+      id: randomUUID(),
+      companyId: values.companyId!,
+      ownerAgentId: values.ownerAgentId ?? null,
+      title: values.title!,
+      level: values.level ?? "task",
+      status: values.status ?? "planned",
+      parentId: values.parentId ?? null,
+      metricDefinition: values.metricDefinition ?? null,
+    };
+    insertedGoals.push(row);
+    goalStore.push(row);
+    return { returning: insertReturning };
+  });
+
+  const db = {
+    select,
+    insert: vi.fn(() => ({ values: insertValues })),
+    transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
+  };
+
+  return { db, insertedGoals };
+}
+
+const COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+const COS_AGENT_ID = "22222222-2222-2222-2222-222222222222";
+const CONVERSATION_ID = "33333333-3333-3333-3333-333333333333";
+
+beforeEach(() => {
+  mockLogActivity.mockClear();
+});
+
+describe("materializeOnboardingGoals", () => {
+  it("creates parent + child goals when both shortTerm and longTerm are present", async () => {
+    const { db, insertedGoals } = makeDb({
+      state: {
+        conversationId: CONVERSATION_ID,
+        goals: {
+          shortTerm: "ship v2 by Q3",
+          longTerm: "self-running ops org by next year",
+        },
+      },
+    });
+
+    const result = await materializeOnboardingGoals({ db: db as any })({
+      conversationId: CONVERSATION_ID,
+      companyId: COMPANY_ID,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    expect(result.alreadyMaterialized).toBe(false);
+    expect(result.longTermGoalId).toBeTruthy();
+    expect(result.shortTermGoalId).toBeTruthy();
+    expect(insertedGoals).toHaveLength(2);
+
+    // Long-term inserted first as company-level top-level goal.
+    expect(insertedGoals[0]).toMatchObject({
+      title: "self-running ops org by next year",
+      level: "company",
+      status: "planned",
+      parentId: null,
+      ownerAgentId: COS_AGENT_ID,
+      companyId: COMPANY_ID,
+    });
+    // Short-term parented to the long-term goal.
+    expect(insertedGoals[1]).toMatchObject({
+      title: "ship v2 by Q3",
+      level: "task",
+      status: "planned",
+      parentId: insertedGoals[0]!.id,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    // Activity log: one per created goal.
+    expect(mockLogActivity).toHaveBeenCalledTimes(2);
+    expect(mockLogActivity.mock.calls[0]![1]).toMatchObject({
+      action: "goal_created_from_onboarding",
+      entityType: "goal",
+      entityId: insertedGoals[0]!.id,
+      actorType: "agent",
+      actorId: COS_AGENT_ID,
+      details: {
+        conversationId: CONVERSATION_ID,
+        source: "cos_onboarding",
+        originalText: "self-running ops org by next year",
+        horizon: "long_term",
+      },
+    });
+    expect(mockLogActivity.mock.calls[1]![1]).toMatchObject({
+      action: "goal_created_from_onboarding",
+      entityId: insertedGoals[1]!.id,
+      details: {
+        conversationId: CONVERSATION_ID,
+        source: "cos_onboarding",
+        horizon: "short_term",
+        parentGoalId: insertedGoals[0]!.id,
+      },
+    });
+  });
+
+  it("creates only a long-term goal when shortTerm is absent", async () => {
+    const { db, insertedGoals } = makeDb({
+      state: {
+        conversationId: CONVERSATION_ID,
+        goals: { longTerm: "build the best agent platform" },
+      },
+    });
+
+    const result = await materializeOnboardingGoals({ db: db as any })({
+      conversationId: CONVERSATION_ID,
+      companyId: COMPANY_ID,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    expect(result.longTermGoalId).toBeTruthy();
+    expect(result.shortTermGoalId).toBeNull();
+    expect(insertedGoals).toHaveLength(1);
+    expect(insertedGoals[0]).toMatchObject({
+      title: "build the best agent platform",
+      level: "company",
+      parentId: null,
+    });
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates only a top-level short-term goal when longTerm is absent", async () => {
+    const { db, insertedGoals } = makeDb({
+      state: {
+        conversationId: CONVERSATION_ID,
+        goals: { shortTerm: "set up onboarding flow" },
+      },
+    });
+
+    const result = await materializeOnboardingGoals({ db: db as any })({
+      conversationId: CONVERSATION_ID,
+      companyId: COMPANY_ID,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    expect(result.longTermGoalId).toBeNull();
+    expect(result.shortTermGoalId).toBeTruthy();
+    expect(insertedGoals).toHaveLength(1);
+    expect(insertedGoals[0]).toMatchObject({
+      title: "set up onboarding flow",
+      level: "task",
+      parentId: null, // no long-term parent → top-level
+    });
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns no-op result when both shortTerm and longTerm are absent", async () => {
+    const { db, insertedGoals } = makeDb({
+      state: { conversationId: CONVERSATION_ID, goals: {} },
+    });
+
+    const result = await materializeOnboardingGoals({ db: db as any })({
+      conversationId: CONVERSATION_ID,
+      companyId: COMPANY_ID,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    expect(result).toEqual({
+      longTermGoalId: null,
+      shortTermGoalId: null,
+      alreadyMaterialized: false,
+    });
+    expect(insertedGoals).toHaveLength(0);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("idempotent: a second call with the same input returns the existing ids without inserting", async () => {
+    const longGoalId = randomUUID();
+    const shortGoalId = randomUUID();
+    const { db, insertedGoals } = makeDb({
+      state: {
+        conversationId: CONVERSATION_ID,
+        goals: {
+          shortTerm: "ship v2 by Q3",
+          longTerm: "self-running ops org",
+        },
+      },
+      existingGoals: [
+        {
+          id: longGoalId,
+          companyId: COMPANY_ID,
+          ownerAgentId: COS_AGENT_ID,
+          title: "self-running ops org",
+          level: "company",
+          status: "planned",
+          parentId: null,
+          metricDefinition: null,
+        },
+        {
+          id: shortGoalId,
+          companyId: COMPANY_ID,
+          ownerAgentId: COS_AGENT_ID,
+          title: "ship v2 by Q3",
+          level: "task",
+          status: "planned",
+          parentId: longGoalId,
+          metricDefinition: null,
+        },
+      ],
+    });
+
+    const result = await materializeOnboardingGoals({ db: db as any })({
+      conversationId: CONVERSATION_ID,
+      companyId: COMPANY_ID,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    expect(result).toEqual({
+      longTermGoalId: longGoalId,
+      shortTermGoalId: shortGoalId,
+      alreadyMaterialized: true,
+    });
+    expect(insertedGoals).toHaveLength(0);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("throws OnboardingStateNotFoundError when no cos_onboarding_states row exists", async () => {
+    const { db } = makeDb({ state: null });
+
+    await expect(
+      materializeOnboardingGoals({ db: db as any })({
+        conversationId: CONVERSATION_ID,
+        companyId: COMPANY_ID,
+        ownerAgentId: COS_AGENT_ID,
+      }),
+    ).rejects.toBeInstanceOf(OnboardingStateNotFoundError);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("writes an activity_log row for each created goal with conversationId in details", async () => {
+    const { db, insertedGoals } = makeDb({
+      state: {
+        conversationId: CONVERSATION_ID,
+        goals: {
+          shortTerm: "validate first 10 customers",
+          longTerm: "$1M ARR by year-end",
+        },
+      },
+    });
+
+    await materializeOnboardingGoals({ db: db as any })({
+      conversationId: CONVERSATION_ID,
+      companyId: COMPANY_ID,
+      ownerAgentId: COS_AGENT_ID,
+    });
+
+    expect(mockLogActivity).toHaveBeenCalledTimes(2);
+    for (let i = 0; i < 2; i++) {
+      expect(mockLogActivity.mock.calls[i]![1]).toMatchObject({
+        companyId: COMPANY_ID,
+        actorType: "agent",
+        actorId: COS_AGENT_ID,
+        action: "goal_created_from_onboarding",
+        entityType: "goal",
+        entityId: insertedGoals[i]!.id,
+        agentId: COS_AGENT_ID,
+        details: expect.objectContaining({
+          conversationId: CONVERSATION_ID,
+          source: "cos_onboarding",
+        }),
+      });
+    }
+  });
+});

--- a/server/src/onboarding-assets/chief_of_staff/AGENTS.md
+++ b/server/src/onboarding-assets/chief_of_staff/AGENTS.md
@@ -94,6 +94,10 @@ Both card payloads are validated by Zod schemas in `packages/shared/src/validato
 ---
 
 **Service guard authoritative.** The verdicts service enforces the neutral-validator rule (reviewer must not be the assignee), the DoD-required-at-creation rule (when the company's `dod_guard_enabled` flag is true), and the entity-FK shape rules (exactly one of goalId/projectId/issueId is non-null). If anything in this prompt conflicts with the service-layer guards, the service wins.
+
+### 5. Onboarding goals materialization (issue #174)
+
+When the user confirms the agent plan during onboarding (POST `/api/onboarding/confirm-plan`), the `{shortTerm, longTerm}` answers captured by the goals-phase interview are auto-materialized into the `goals` table by `materializeOnboardingGoals`. The long-term goal is inserted as `level: "company"` (top-level), and the short-term goal as `level: "task"` parented to the long-term row. Both are owned by you (CoS) and emit a `goal_created_from_onboarding` activity-log row. The call is idempotent on `(conversationId, ownerAgentId)`, so retries don't duplicate rows. `metricDefinition` starts null — fill it later via the Edit Metric flow on the GoalDetail page when the user gives you a concrete target/unit.
 <!-- /AgentDash: goals-eval-hitl -->
 
 <!-- AgentDash: agent-api-auth — DO NOT REMOVE OR REORDER THIS BLOCK -->

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -17,6 +17,8 @@ import {
 import { unauthorized, badRequest, notFound } from "../errors.js";
 import { SingleCompanyInstallationError } from "../services/companies.js";
 import { crystallizeAndAdvanceCos } from "../services/deep-interview-crystallize.js";
+import { materializeOnboardingGoals } from "../services/materialize-onboarding-goals.js";
+import { logger } from "../middleware/logger.js";
 import {
   FIXED_QUESTIONS,
   type AgentPlanProposalV1Payload,
@@ -224,6 +226,27 @@ export function onboardingV2Routes(db: Db) {
     const allAgents = await agents.list(companyId);
     const cos = allAgents.find((a: any) => a.role === "chief_of_staff") ?? null;
     const reportsToAgentId = cos?.id ?? null;
+
+    // AgentDash (issue #174): materialize the captured onboarding goals
+    // ({shortTerm, longTerm}) into the goals table so the user sees them on
+    // /goals immediately. Idempotent on (conversationId, ownerAgentId), so
+    // a retry won't duplicate rows. Failures are logged but never block
+    // the materialization phase — the user's UX matters more than 100%
+    // goal materialization, and CoS can retry from the next turn.
+    if (cos) {
+      try {
+        await materializeOnboardingGoals({ db })({
+          conversationId,
+          companyId,
+          ownerAgentId: cos.id,
+        });
+      } catch (err) {
+        logger.error(
+          { err, conversationId, companyId, cosAgentId: cos.id },
+          "[onboarding-v2] materializeOnboardingGoals failed; continuing with agent materialization",
+        );
+      }
+    }
 
     const instructions = agentInstructionsService();
     const createdAgentIds: string[] = [];

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -24,6 +24,13 @@ export { issueTreeControlService } from "./issue-tree-control.js";
 export { issueApprovalService } from "./issue-approvals.js";
 export { issueReferenceService } from "./issue-references.js";
 export { goalService } from "./goals.js";
+export {
+  materializeOnboardingGoals,
+  OnboardingStateNotFoundError,
+  type MaterializeOnboardingGoalsResult,
+  type MaterializeOnboardingGoalsInput,
+  type MaterializeOnboardingGoalsDeps,
+} from "./materialize-onboarding-goals.js";
 export { activityService, type ActivityFilters } from "./activity.js";
 export { approvalService } from "./approvals.js";
 export { budgetService } from "./budgets.js";

--- a/server/src/services/materialize-onboarding-goals.ts
+++ b/server/src/services/materialize-onboarding-goals.ts
@@ -1,0 +1,204 @@
+// AgentDash (issue #174): materialize the goals captured by the CoS
+// onboarding interview into actual rows in the `goals` table so the user
+// sees them on /goals immediately after onboarding.
+//
+// Called from the `/api/onboarding/confirm-plan` route right before the
+// phase advances to `materializing`. Idempotent on (conversationId,
+// ownerAgentId): a second call with the same input returns the existing
+// goal ids without creating duplicates.
+//
+// Single-transaction guarantee mirrors `crystallizeAndAdvanceCos`: the
+// onboarding-state read, idempotency check, INSERTs, and activity-log
+// writes all run in one Drizzle transaction so a mid-helper failure rolls
+// back cleanly.
+
+import { and, eq, or } from "drizzle-orm";
+import {
+  cosOnboardingStates,
+  goals,
+  type Db,
+  type CosOnboardingGoals,
+} from "@paperclipai/db";
+import { logActivity } from "./activity-log.js";
+
+export interface MaterializeOnboardingGoalsResult {
+  longTermGoalId: string | null;
+  shortTermGoalId: string | null;
+  /** True when a previous call already created the rows; second call is a no-op. */
+  alreadyMaterialized: boolean;
+}
+
+export interface MaterializeOnboardingGoalsDeps {
+  db: Db;
+}
+
+export interface MaterializeOnboardingGoalsInput {
+  conversationId: string;
+  companyId: string;
+  /** CoS agent id; the onboarding goals will be owned by CoS. */
+  ownerAgentId: string;
+}
+
+export class OnboardingStateNotFoundError extends Error {
+  readonly code = "ONBOARDING_STATE_NOT_FOUND" as const;
+  constructor(public readonly conversationId: string) {
+    super(`[materialize-onboarding-goals] cos_onboarding_states row not found for conversationId=${conversationId}`);
+    this.name = "OnboardingStateNotFoundError";
+  }
+}
+
+/**
+ * Materialize the {shortTerm, longTerm} captured during CoS onboarding into
+ * `goals` rows. Idempotent: a second call with the same input returns the
+ * existing goal ids and `alreadyMaterialized: true`.
+ *
+ * Level convention:
+ *  - longTerm is materialized as `level: "company"` (the highest tier in
+ *    GOAL_LEVELS — the natural fit for a 6-12 month vision).
+ *  - shortTerm is materialized as `level: "task"` and parented to the
+ *    long-term goal when one was created; otherwise it's top-level.
+ *
+ * `metricDefinition` is intentionally null. The user's natural-language
+ * goal in onboarding doesn't typically include a structured target/unit;
+ * CoS can fill it later via the Edit Metric flow on the GoalDetail page.
+ */
+export function materializeOnboardingGoals(deps: MaterializeOnboardingGoalsDeps) {
+  const { db } = deps;
+
+  return async (
+    input: MaterializeOnboardingGoalsInput,
+  ): Promise<MaterializeOnboardingGoalsResult> => {
+    return await db.transaction(async (tx) => {
+      // 1. Load the onboarding state row.
+      const stateRows = await tx
+        .select()
+        .from(cosOnboardingStates)
+        .where(eq(cosOnboardingStates.conversationId, input.conversationId));
+      if (stateRows.length === 0) {
+        throw new OnboardingStateNotFoundError(input.conversationId);
+      }
+      const captured = (stateRows[0]!.goals ?? {}) as CosOnboardingGoals;
+      const longTermText = captured.longTerm?.trim() ?? "";
+      const shortTermText = captured.shortTerm?.trim() ?? "";
+
+      // Both absent → nothing to materialize.
+      if (!longTermText && !shortTermText) {
+        return {
+          longTermGoalId: null,
+          shortTermGoalId: null,
+          alreadyMaterialized: false,
+        };
+      }
+
+      // 2. Idempotency: look up existing goals owned by this agent that
+      //    match the captured titles. If both expected rows already exist,
+      //    return them as-is.
+      const existing = await tx
+        .select()
+        .from(goals)
+        .where(
+          and(
+            eq(goals.companyId, input.companyId),
+            eq(goals.ownerAgentId, input.ownerAgentId),
+            or(
+              longTermText ? eq(goals.title, longTermText) : undefined,
+              shortTermText ? eq(goals.title, shortTermText) : undefined,
+            )!,
+          ),
+        );
+      const existingLong = longTermText
+        ? existing.find((g) => g.title === longTermText) ?? null
+        : null;
+      const existingShort = shortTermText
+        ? existing.find((g) => g.title === shortTermText) ?? null
+        : null;
+
+      const expectLong = Boolean(longTermText);
+      const expectShort = Boolean(shortTermText);
+      const haveAllExpected =
+        (!expectLong || existingLong !== null) &&
+        (!expectShort || existingShort !== null);
+      if (haveAllExpected && (existingLong || existingShort)) {
+        return {
+          longTermGoalId: existingLong?.id ?? null,
+          shortTermGoalId: existingShort?.id ?? null,
+          alreadyMaterialized: true,
+        };
+      }
+
+      // 3. Insert long-term goal first (so short-term can parent to it).
+      let longTermGoalId: string | null = existingLong?.id ?? null;
+      if (longTermText && !existingLong) {
+        const [inserted] = await tx
+          .insert(goals)
+          .values({
+            companyId: input.companyId,
+            title: longTermText,
+            level: "company",
+            status: "planned",
+            parentId: null,
+            ownerAgentId: input.ownerAgentId,
+            metricDefinition: null,
+          })
+          .returning();
+        longTermGoalId = inserted!.id;
+        await logActivity(tx as unknown as Db, {
+          companyId: input.companyId,
+          actorType: "agent",
+          actorId: input.ownerAgentId,
+          action: "goal_created_from_onboarding",
+          entityType: "goal",
+          entityId: longTermGoalId,
+          agentId: input.ownerAgentId,
+          details: {
+            conversationId: input.conversationId,
+            source: "cos_onboarding",
+            originalText: longTermText,
+            horizon: "long_term",
+          },
+        });
+      }
+
+      // 4. Insert short-term goal, parenting to long-term when present.
+      let shortTermGoalId: string | null = existingShort?.id ?? null;
+      if (shortTermText && !existingShort) {
+        const [inserted] = await tx
+          .insert(goals)
+          .values({
+            companyId: input.companyId,
+            title: shortTermText,
+            level: "task",
+            status: "planned",
+            parentId: longTermGoalId,
+            ownerAgentId: input.ownerAgentId,
+            metricDefinition: null,
+          })
+          .returning();
+        shortTermGoalId = inserted!.id;
+        await logActivity(tx as unknown as Db, {
+          companyId: input.companyId,
+          actorType: "agent",
+          actorId: input.ownerAgentId,
+          action: "goal_created_from_onboarding",
+          entityType: "goal",
+          entityId: shortTermGoalId,
+          agentId: input.ownerAgentId,
+          details: {
+            conversationId: input.conversationId,
+            source: "cos_onboarding",
+            originalText: shortTermText,
+            horizon: "short_term",
+            parentGoalId: longTermGoalId,
+          },
+        });
+      }
+
+      return {
+        longTermGoalId,
+        shortTermGoalId,
+        alreadyMaterialized: false,
+      };
+    });
+  };
+}
+


### PR DESCRIPTION
## Summary

Closes #174.

The CoS onboarding interview captured `{shortTerm, longTerm}` into
`cos_onboarding_states.goals` (JSONB) but never inserted rows into the `goals`
table — so users saw an empty Goals page after onboarding bootstrap. This PR
materializes those captured strings into actual goal rows.

- **New service helper** `server/src/services/materialize-onboarding-goals.ts` —
  factory with single-transaction idempotent materialization. Long-term goal is
  inserted at `level: "company"` (top-level), short-term at `level: "task"`
  parented to long-term when both are present (top-level otherwise). Both rows
  are owned by the CoS agent. `metricDefinition` is left null intentionally —
  CoS fills it later via the Edit Metric flow on the GoalDetail page.
- **Wired in** `server/src/routes/onboarding-v2.ts` inside the `/confirm-plan`
  handler, right after the phase advances to `materializing`. Wrapped in
  try/catch — failures are logged but don't block agent materialization or the
  phase transition (UX > 100% goal materialization).
- **Idempotency** on `(conversationId, ownerAgentId)`: a second call with the
  same titles returns the existing ids with `alreadyMaterialized: true` and
  does not re-INSERT or re-log activity.
- **Audit** via `goal_created_from_onboarding` activity-log rows (new value
  added to `ACTIVITY_LOG_ACTIONS_GOALS_EVAL_HITL`). The `activity_log.action`
  column is plain text, so no migration.

## Files

- `server/src/services/materialize-onboarding-goals.ts` (new)
- `server/src/__tests__/materialize-onboarding-goals.test.ts` (new, 7 cases)
- `server/src/services/index.ts` (export)
- `server/src/routes/onboarding-v2.ts` (call helper from `/confirm-plan`)
- `packages/shared/src/constants.ts` (add `goal_created_from_onboarding`)
- `server/src/onboarding-assets/chief_of_staff/AGENTS.md` (prompt-surface
  drift-check; tells CoS that onboarding goals are auto-materialized)

UI: no change. `ui/src/pages/Goals.tsx` already renders all goals for the
active company via `<GoalTree>` without level filtering.

## Test plan

- [x] `pnpm --filter @paperclipai/shared typecheck` → passes
- [x] `pnpm --filter @paperclipai/server typecheck` → passes
- [x] `pnpm --filter @paperclipai/ui typecheck` → passes
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/materialize-onboarding-goals.test.ts` → 7/7 pass
- [x] `git diff main -- server/src/services/approvals.ts | wc -l` → 0
- [ ] CI: agents-md drift-check passes (chief_of_staff/AGENTS.md touched)
- [ ] CI: full server vitest suite passes
- [ ] Manual: bootstrap → finish CoS interview → confirm plan → land on /goals
      and see the long-term + short-term goals tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)