### PR TITLE
feat(refresh): auto-refresh stale agent instructionsBundles [no-prompt-update]

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1063,6 +1063,10 @@ export const ACTIVITY_LOG_ACTIONS_GOALS_EVAL_HITL = [
   // turns the captured {shortTerm, longTerm} interview answers into rows
   // in the goals table during the onboarding `materializing` phase.
   "goal_created_from_onboarding",
+  // Emitted by agent-instruction-refresh-service when an agent's bundled
+  // AGENTS.md drifts from the AgentDash-owned named blocks in source and the
+  // service patches it back in place.
+  "instructions_refreshed",
 ] as const;
 export type ActivityLogActionGoalsEvalHitl =
   (typeof ACTIVITY_LOG_ACTIONS_GOALS_EVAL_HITL)[number];

--- a/server/src/__tests__/agent-instruction-refresh.test.ts
+++ b/server/src/__tests__/agent-instruction-refresh.test.ts
@@ -1,0 +1,561 @@
+// agent-instruction-refresh-service unit tests.
+//
+// Pattern: mock-DB style (matches verdicts.test.ts) plus an in-memory
+// fake instructions service so we can sequence reads/writes without touching
+// real disk paths.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  agentInstructionRefreshService,
+  __resetAgentInstructionRefreshCache,
+  type SourceArchetype,
+} from "../services/agent-instruction-refresh.ts";
+
+const mockLogActivity = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+  setPluginEventBus: vi.fn(),
+  publishPluginDomainEvent: vi.fn(),
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+interface AgentFixture {
+  id: string;
+  companyId: string;
+  name: string;
+  role: string;
+  status: string;
+  adapterConfig: Record<string, unknown>;
+}
+
+interface DbStubOptions {
+  agents?: AgentFixture[];
+  /** Rows to return for refreshAllForCompany's listing query. */
+  companyAgentIds?: Array<{ id: string }>;
+}
+
+/**
+ * Lightweight stub mimicking drizzle's chainable select. We always pop the
+ * next queued result on `.select()` — sequence matters for tests that call
+ * the service multiple times.
+ */
+function makeDb(opts: DbStubOptions = {}) {
+  const selectQueue: unknown[][] = [];
+
+  const select = vi.fn(() => {
+    const result = selectQueue.shift() ?? [];
+    const chain: any = {};
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => chain);
+    chain.limit = vi.fn(() => chain);
+    chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject);
+    return chain;
+  });
+
+  const db = {
+    select,
+    insert: vi.fn(() => ({
+      values: vi.fn(async () => undefined),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+    })),
+    transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
+  };
+
+  function queueAgent(agent: AgentFixture | null) {
+    selectQueue.push(agent ? [agent] : []);
+  }
+
+  function queueCompanyAgents(ids: string[]) {
+    selectQueue.push(ids.map((id) => ({ id })));
+  }
+
+  return { db, queueAgent, queueCompanyAgents };
+}
+
+/**
+ * Fake instructions service: keeps the bundled AGENTS.md in memory by agent.id,
+ * counts writes, and lets tests assert exact persisted content.
+ */
+function makeFakeInstructions(initialBundles: Record<string, string>) {
+  const bundles: Record<string, string> = { ...initialBundles };
+  const writes: Array<{ agentId: string; content: string }> = [];
+
+  const readFile = vi.fn(async (agent: { id: string }, _path: string) => {
+    const content = bundles[agent.id];
+    if (content === undefined) {
+      throw new Error("Instructions file not found");
+    }
+    return { path: "AGENTS.md", content, size: content.length };
+  });
+
+  const writeFile = vi.fn(async (agent: { id: string }, _path: string, content: string) => {
+    bundles[agent.id] = content;
+    writes.push({ agentId: agent.id, content });
+    return { adapterConfig: {} };
+  });
+
+  return {
+    instructions: { readFile, writeFile } as any,
+    bundles,
+    writes,
+  };
+}
+
+const COMPANY_ID = "company-1";
+const AGENT_ID = "agent-1";
+
+const SOURCE_DEFAULT = `Worker prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v2 (current)
+- new content
+<!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth -->
+## API auth v2
+- new auth content
+<!-- /AgentDash: agent-api-auth -->
+`;
+
+const SOURCE_CEO = `CEO prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## CEO DoD
+- ceo content
+<!-- /AgentDash: goals-eval-hitl -->
+`;
+
+const SOURCE_COS = `CoS prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## CoS DoD
+- cos content
+<!-- /AgentDash: goals-eval-hitl -->
+`;
+
+function makeSourceLoader(): (a: SourceArchetype) => Promise<string> {
+  return async (archetype: SourceArchetype) => {
+    if (archetype === "ceo") return SOURCE_CEO;
+    if (archetype === "chief_of_staff") return SOURCE_COS;
+    return SOURCE_DEFAULT;
+  };
+}
+
+beforeEach(() => {
+  mockLogActivity.mockClear();
+  __resetAgentInstructionRefreshCache();
+});
+
+describe("agentInstructionRefreshService.refreshIfStale", () => {
+  it("returns refreshed=false when bundle is byte-identical to source", async () => {
+    const { db, queueAgent } = makeDb();
+    queueAgent({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Worker",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    // Bundle == source byte-for-byte → fast-path early return.
+    const fake = makeFakeInstructions({ [AGENT_ID]: SOURCE_DEFAULT });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const result = await svc.refreshIfStale(AGENT_ID);
+    expect(result).toEqual({
+      refreshed: false,
+      blocksUpdated: [],
+      blocksAdded: [],
+      blocksRemoved: [],
+    });
+    expect(fake.writes).toHaveLength(0);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("updates a stale block in place and writes a single activity row", async () => {
+    const { db, queueAgent } = makeDb();
+    queueAgent({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Worker",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    const stale = `Worker prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v1 (OLD)
+- old content
+<!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth -->
+## API auth v2
+- new auth content
+<!-- /AgentDash: agent-api-auth -->
+`;
+    const fake = makeFakeInstructions({ [AGENT_ID]: stale });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const result = await svc.refreshIfStale(AGENT_ID);
+    expect(result.refreshed).toBe(true);
+    expect(result.blocksUpdated).toEqual(["goals-eval-hitl"]);
+    expect(result.blocksAdded).toEqual([]);
+    expect(result.blocksRemoved).toEqual([]);
+    expect(fake.writes).toHaveLength(1);
+    expect(fake.writes[0]!.content).toContain("DoD v2 (current)");
+    expect(fake.writes[0]!.content).not.toContain("DoD v1 (OLD)");
+    expect(fake.writes[0]!.content).toContain("Worker prose."); // surrounding prose preserved
+
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+    expect(mockLogActivity.mock.calls[0]![1]).toMatchObject({
+      action: "instructions_refreshed",
+      actorType: "system",
+      actorId: "agent-instruction-refresh-service",
+      entityType: "agent",
+      entityId: AGENT_ID,
+      details: {
+        archetype: "default",
+        blocksUpdated: ["goals-eval-hitl"],
+        blocksAdded: [],
+        blocksRemoved: [],
+      },
+    });
+  });
+
+  it("appends a missing block and reports it as blocksAdded", async () => {
+    const { db, queueAgent } = makeDb();
+    queueAgent({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Worker",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    const missingApiBlock = `Worker prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v2 (current)
+- new content
+<!-- /AgentDash: goals-eval-hitl -->
+`;
+    const fake = makeFakeInstructions({ [AGENT_ID]: missingApiBlock });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const result = await svc.refreshIfStale(AGENT_ID);
+    expect(result.refreshed).toBe(true);
+    expect(result.blocksUpdated).toEqual([]);
+    expect(result.blocksAdded).toEqual(["agent-api-auth"]);
+    expect(fake.writes[0]!.content).toContain("API auth v2");
+  });
+
+  it("leaves a bundle-only block alone and reports it as blocksRemoved", async () => {
+    const { db, queueAgent } = makeDb();
+    queueAgent({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Worker",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    // Bundle has all source blocks AS-IS plus an extra deprecated block.
+    const withExtraBlock = `${SOURCE_DEFAULT}
+
+<!-- AgentDash: old-deprecated-block -->
+## removed feature
+<!-- /AgentDash: old-deprecated-block -->
+`;
+    const fake = makeFakeInstructions({ [AGENT_ID]: withExtraBlock });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const result = await svc.refreshIfStale(AGENT_ID);
+    // No mutation: refreshed=false, blocksRemoved reports the orphan.
+    expect(result.refreshed).toBe(false);
+    expect(result.blocksUpdated).toEqual([]);
+    expect(result.blocksAdded).toEqual([]);
+    expect(result.blocksRemoved).toEqual(["old-deprecated-block"]);
+    expect(fake.writes).toHaveLength(0);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("updates multiple stale blocks in a single activity_log row", async () => {
+    const { db, queueAgent } = makeDb();
+    queueAgent({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Worker",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    const bothStale = `Worker prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v1 (OLD)
+<!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth -->
+## API auth v1 (OLD)
+<!-- /AgentDash: agent-api-auth -->
+`;
+    const fake = makeFakeInstructions({ [AGENT_ID]: bothStale });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const result = await svc.refreshIfStale(AGENT_ID);
+    expect(result.refreshed).toBe(true);
+    expect(new Set(result.blocksUpdated)).toEqual(
+      new Set(["goals-eval-hitl", "agent-api-auth"]),
+    );
+    // Single activity row, combined details.
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+    const details = mockLogActivity.mock.calls[0]![1].details as Record<string, unknown>;
+    expect(new Set(details.blocksUpdated as string[])).toEqual(
+      new Set(["goals-eval-hitl", "agent-api-auth"]),
+    );
+  });
+
+  it("dispatches by archetype: ceo → ceo source, chief_of_staff → cos source, general → default source", async () => {
+    const sourceCalls: SourceArchetype[] = [];
+    const loader = async (a: SourceArchetype) => {
+      sourceCalls.push(a);
+      if (a === "ceo") return SOURCE_CEO;
+      if (a === "chief_of_staff") return SOURCE_COS;
+      return SOURCE_DEFAULT;
+    };
+
+    const { db, queueAgent } = makeDb();
+
+    // worker first
+    queueAgent({
+      id: "w",
+      companyId: COMPANY_ID,
+      name: "W",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+    queueAgent({
+      id: "c",
+      companyId: COMPANY_ID,
+      name: "CEO",
+      role: "ceo",
+      status: "active",
+      adapterConfig: {},
+    });
+    queueAgent({
+      id: "s",
+      companyId: COMPANY_ID,
+      name: "CoS",
+      role: "chief_of_staff",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    const fake = makeFakeInstructions({
+      w: SOURCE_DEFAULT,
+      c: SOURCE_CEO,
+      s: SOURCE_COS,
+    });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: loader,
+      instructions: fake.instructions,
+    });
+
+    await svc.refreshIfStale("w");
+    await svc.refreshIfStale("c");
+    await svc.refreshIfStale("s");
+
+    expect(sourceCalls).toEqual(["default", "ceo", "chief_of_staff"]);
+  });
+
+  it("is idempotent — second refresh after a successful one is a no-op", async () => {
+    const { db, queueAgent } = makeDb();
+    // queue twice — refreshIfStale loads the agent on each call
+    const agent: AgentFixture = {
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Worker",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    };
+    queueAgent(agent);
+    queueAgent(agent);
+
+    const stale = `Worker prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v1 (OLD)
+<!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth -->
+## API auth v2
+- new auth content
+<!-- /AgentDash: agent-api-auth -->
+`;
+    const fake = makeFakeInstructions({ [AGENT_ID]: stale });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const first = await svc.refreshIfStale(AGENT_ID);
+    expect(first.refreshed).toBe(true);
+
+    const second = await svc.refreshIfStale(AGENT_ID);
+    expect(second.refreshed).toBe(false);
+    expect(second.blocksUpdated).toEqual([]);
+    expect(fake.writes).toHaveLength(1); // still only one write
+    expect(mockLogActivity).toHaveBeenCalledTimes(1); // still only one activity row
+  });
+
+  it("preserves role-specific interpolated content (proposal-created agent's ${p.name})", async () => {
+    const { db, queueAgent } = makeDb();
+    queueAgent({
+      id: AGENT_ID,
+      companyId: COMPANY_ID,
+      name: "Sasha",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    // Mimic the renderAgents() output: role-specific content + AgentDash blocks.
+    const proposalAgentBundle = `# AGENTS.md — Sasha
+
+## Role
+Senior Marketing Strategist
+
+## 90-day Goal
+Drive 25% MoM growth in qualified leads
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v1 (OLD)
+- old content
+<!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth -->
+## API auth v2
+- new auth content
+<!-- /AgentDash: agent-api-auth -->
+`;
+    const fake = makeFakeInstructions({ [AGENT_ID]: proposalAgentBundle });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const result = await svc.refreshIfStale(AGENT_ID);
+    expect(result.refreshed).toBe(true);
+    expect(result.blocksUpdated).toEqual(["goals-eval-hitl"]);
+
+    const persisted = fake.writes[0]!.content;
+    // Role-specific content survives the refresh.
+    expect(persisted).toContain("# AGENTS.md — Sasha");
+    expect(persisted).toContain("Senior Marketing Strategist");
+    expect(persisted).toContain("Drive 25% MoM growth in qualified leads");
+    // Stale block was replaced.
+    expect(persisted).toContain("DoD v2 (current)");
+    expect(persisted).not.toContain("DoD v1 (OLD)");
+  });
+});
+
+describe("agentInstructionRefreshService.refreshAllForCompany", () => {
+  it("iterates active agents and returns per-agent results", async () => {
+    const { db, queueCompanyAgents, queueAgent } = makeDb();
+
+    // 1) Listing query returns two agent ids.
+    queueCompanyAgents(["a1", "a2"]);
+    // 2) Per-agent loadAgent queries (in order).
+    queueAgent({
+      id: "a1",
+      companyId: COMPANY_ID,
+      name: "A1",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+    queueAgent({
+      id: "a2",
+      companyId: COMPANY_ID,
+      name: "A2",
+      role: "general",
+      status: "active",
+      adapterConfig: {},
+    });
+
+    const stale = `Worker prose.
+
+<!-- AgentDash: goals-eval-hitl -->
+## DoD v1 (OLD)
+<!-- /AgentDash: goals-eval-hitl -->
+
+<!-- AgentDash: agent-api-auth -->
+## API auth v2
+- new auth content
+<!-- /AgentDash: agent-api-auth -->
+`;
+    const fake = makeFakeInstructions({ a1: stale, a2: SOURCE_DEFAULT });
+
+    const svc = agentInstructionRefreshService({
+      db: db as any,
+      loadSource: makeSourceLoader(),
+      instructions: fake.instructions,
+    });
+
+    const out = await svc.refreshAllForCompany(COMPANY_ID);
+    expect(Object.keys(out).sort()).toEqual(["a1", "a2"]);
+    expect(out.a1!.refreshed).toBe(true);
+    expect(out.a2!.refreshed).toBe(false);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -32,6 +32,7 @@ import {
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
 import {
+  agentInstructionRefreshService,
   agentService,
   agentInstructionsService,
   accessService,
@@ -165,6 +166,7 @@ export function agentRoutes(
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
   const instructions = agentInstructionsService();
+  const instructionRefresh = agentInstructionRefreshService({ db });
   const companySkills = companySkillService(db);
   const workspaceOperations = workspaceOperationService(db);
   const instanceSettings = instanceSettingsService(db);
@@ -2368,6 +2370,35 @@ export function agentRoutes(
 
     res.json(result.bundle);
   });
+
+  // AgentDash: agent-instruction-refresh — manual refresh routes for cases
+  // where the next tick is too far away. The heartbeat hook already refreshes
+  // on every dispatch; these endpoints exist for board-driven force-refresh.
+  router.post(
+    "/companies/:companyId/agents/:agentId/refresh-instructions",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      const agentId = req.params.agentId as string;
+      assertCompanyAccess(req, companyId);
+      const existing = await svc.getById(agentId);
+      if (!existing || existing.companyId !== companyId) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
+      const result = await instructionRefresh.refreshIfStale(agentId);
+      res.json(result);
+    },
+  );
+
+  router.post(
+    "/companies/:companyId/agents/refresh-instructions",
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const results = await instructionRefresh.refreshAllForCompany(companyId);
+      res.json({ companyId, results });
+    },
+  );
 
   router.patch("/agents/:id", validate(updateAgentSchema), async (req, res) => {
     const id = req.params.id as string;

--- a/server/src/services/agent-instruction-refresh.ts
+++ b/server/src/services/agent-instruction-refresh.ts
@@ -1,0 +1,361 @@
+// AgentDash: agent-instruction-refresh
+//
+// Refresh stale `<!-- AgentDash: SLUG -->...<!-- /AgentDash: SLUG -->` blocks
+// inside an agent's bundled AGENTS.md when the underlying source files
+// (server/src/onboarding-assets/{default,ceo,chief_of_staff}/AGENTS.md) have
+// drifted from what was baked into the agent's instructions bundle at create
+// time.
+//
+// Why named-block scope (and NOT whole-file replacement):
+//   1. Proposal-created agents have role-specific content interpolated into
+//      their AGENTS.md (`${p.name}`, `${p.role}`, `${p.oneLineOkr}` —
+//      see agent-creator-from-proposal.ts `renderAgents`). We must preserve
+//      that.
+//   2. Upstream Paperclip prose outside the AgentDash blocks is not ours to
+//      touch.
+//   3. Each `<!-- AgentDash: X -->` block is the cleanest invariant: it must
+//      equal the current source.
+//
+// Cache strategy: the source files (default/ceo/chief_of_staff AGENTS.md) are
+// read-once-per-process. Cache invalidation = process restart, which is what
+// every deploy already does. Hot-path byte-compare against the cached source
+// avoids regex parsing on every heartbeat tick.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Db } from "@paperclipai/db";
+import { agents as agentsTable } from "@paperclipai/db";
+import { and, eq, ne } from "drizzle-orm";
+import { logActivity } from "./activity-log.js";
+import { agentInstructionsService } from "./agent-instructions.js";
+import { logger } from "../middleware/logger.js";
+
+export interface RefreshResult {
+  refreshed: boolean;
+  blocksUpdated: string[];
+  blocksAdded: string[];
+  /** Blocks present in bundle but no longer in source — left alone, audit-only. */
+  blocksRemoved: string[];
+}
+
+export interface AgentInstructionRefreshDeps {
+  db: Db;
+  /**
+   * Optional override for reading source AGENTS.md files. Tests inject their
+   * own; production uses {@link defaultSourceLoader}.
+   */
+  loadSource?: (archetype: SourceArchetype) => Promise<string>;
+  /**
+   * Optional override for the instructions service. Tests inject a stub that
+   * returns the bundle bytes from memory; production uses
+   * agentInstructionsService().
+   */
+  instructions?: ReturnType<typeof agentInstructionsService>;
+}
+
+export type SourceArchetype = "default" | "ceo" | "chief_of_staff";
+
+interface BlockSpan {
+  slug: string;
+  /** Start index of the opening `<!-- AgentDash:` comment. */
+  startIndex: number;
+  /** End index (exclusive) of the closing `<!-- /AgentDash: ... -->` comment. */
+  endIndex: number;
+  /** Full matched text (open marker + body + close marker). */
+  fullText: string;
+}
+
+/**
+ * Regex for `<!-- AgentDash: SLUG (any trailing prose) -->BODY<!-- /AgentDash: SLUG -->`.
+ *
+ * Captures:
+ *   1: slug
+ *   2: body between markers
+ *
+ * The closing marker uses a back-reference to the captured slug to pair the
+ * right open/close.
+ */
+const BLOCK_REGEX = /<!--\s*AgentDash:\s*([\w-]+)[^]*?-->([\s\S]*?)<!--\s*\/AgentDash:\s*\1\s*-->/g;
+
+function parseBlocks(content: string): Map<string, BlockSpan> {
+  const out = new Map<string, BlockSpan>();
+  // Reset lastIndex on the shared regex (it's stateful with /g).
+  BLOCK_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BLOCK_REGEX.exec(content)) !== null) {
+    const slug = match[1]!;
+    out.set(slug, {
+      slug,
+      startIndex: match.index,
+      endIndex: match.index + match[0]!.length,
+      fullText: match[0]!,
+    });
+  }
+  return out;
+}
+
+function bodyEqual(a: BlockSpan, b: BlockSpan): boolean {
+  // Compare the WHOLE marker+body region — if the source rewrites only the
+  // marker (e.g. trailing prose after the slug), we still want to refresh.
+  return a.fullText.trim() === b.fullText.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Source-file cache. Read once per process, then keep in memory. Cache
+// invalidation is "restart the process" — fine because deploys restart.
+// ---------------------------------------------------------------------------
+
+const sourceCache = new Map<SourceArchetype, string>();
+
+function resolveSourcePath(archetype: SourceArchetype): string {
+  // Use import.meta.url so the path resolves correctly whether running from
+  // src/ (vitest) or dist/ (production).
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "onboarding-assets", archetype, "AGENTS.md");
+}
+
+async function defaultSourceLoader(archetype: SourceArchetype): Promise<string> {
+  const cached = sourceCache.get(archetype);
+  if (cached !== undefined) return cached;
+  const filePath = resolveSourcePath(archetype);
+  const content = await fs.readFile(filePath, "utf8");
+  sourceCache.set(archetype, content);
+  return content;
+}
+
+/** Test-only: reset the in-process source cache. */
+export function __resetAgentInstructionRefreshCache(): void {
+  sourceCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Archetype resolution
+// ---------------------------------------------------------------------------
+
+function archetypeForAgent(agent: { role: string }): SourceArchetype {
+  if (agent.role === "ceo") return "ceo";
+  if (agent.role === "chief_of_staff") return "chief_of_staff";
+  return "default";
+}
+
+// ---------------------------------------------------------------------------
+// Block diff + apply
+// ---------------------------------------------------------------------------
+
+interface DiffResult {
+  blocksUpdated: string[];
+  blocksAdded: string[];
+  blocksRemoved: string[];
+  nextContent: string;
+}
+
+function diffAndApply(sourceContent: string, bundleContent: string): DiffResult {
+  const sourceBlocks = parseBlocks(sourceContent);
+  const bundleBlocks = parseBlocks(bundleContent);
+
+  const blocksUpdated: string[] = [];
+  const blocksAdded: string[] = [];
+  const blocksRemoved: string[] = [];
+
+  // Build the next bundle content by replacing matching blocks in place
+  // (highest-index-first, so earlier indices stay valid) and appending new
+  // blocks at the end.
+  let next = bundleContent;
+  const replacements: Array<{ slug: string; span: BlockSpan; replacement: string }> = [];
+
+  for (const [slug, sourceSpan] of sourceBlocks) {
+    const bundleSpan = bundleBlocks.get(slug);
+    if (!bundleSpan) {
+      blocksAdded.push(slug);
+      continue;
+    }
+    if (!bodyEqual(sourceSpan, bundleSpan)) {
+      blocksUpdated.push(slug);
+      replacements.push({ slug, span: bundleSpan, replacement: sourceSpan.fullText });
+    }
+  }
+
+  for (const slug of bundleBlocks.keys()) {
+    if (!sourceBlocks.has(slug)) blocksRemoved.push(slug);
+  }
+
+  // Apply replacements highest-startIndex first to keep earlier offsets valid.
+  replacements.sort((a, b) => b.span.startIndex - a.span.startIndex);
+  for (const { span, replacement } of replacements) {
+    next = next.slice(0, span.startIndex) + replacement + next.slice(span.endIndex);
+  }
+
+  // Append new blocks at the end (current sources put AgentDash blocks at
+  // the tail; appending matches that convention).
+  for (const slug of blocksAdded) {
+    const sourceSpan = sourceBlocks.get(slug)!;
+    if (!next.endsWith("\n")) next += "\n";
+    next += `\n${sourceSpan.fullText}\n`;
+  }
+
+  return { blocksUpdated, blocksAdded, blocksRemoved, nextContent: next };
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+type AgentRow = {
+  id: string;
+  companyId: string;
+  name: string;
+  role: string;
+  status: string;
+  adapterConfig: unknown;
+};
+
+export function agentInstructionRefreshService(deps: AgentInstructionRefreshDeps) {
+  const { db } = deps;
+  const loadSource = deps.loadSource ?? defaultSourceLoader;
+  const instructions = deps.instructions ?? agentInstructionsService();
+
+  async function loadAgent(agentId: string): Promise<AgentRow | null> {
+    const rows = await db
+      .select({
+        id: agentsTable.id,
+        companyId: agentsTable.companyId,
+        name: agentsTable.name,
+        role: agentsTable.role,
+        status: agentsTable.status,
+        adapterConfig: agentsTable.adapterConfig,
+      })
+      .from(agentsTable)
+      .where(eq(agentsTable.id, agentId))
+      .limit(1);
+    return (rows[0] as AgentRow | undefined) ?? null;
+  }
+
+  async function readBundleEntry(agent: AgentRow): Promise<string | null> {
+    try {
+      const file = await instructions.readFile(
+        { id: agent.id, companyId: agent.companyId, name: agent.name, adapterConfig: agent.adapterConfig },
+        "AGENTS.md",
+      );
+      return typeof file?.content === "string" ? file.content : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function writeBundleEntry(agent: AgentRow, content: string): Promise<void> {
+    await instructions.writeFile(
+      { id: agent.id, companyId: agent.companyId, name: agent.name, adapterConfig: agent.adapterConfig },
+      "AGENTS.md",
+      content,
+    );
+  }
+
+  async function refreshIfStale(agentId: string): Promise<RefreshResult> {
+    const noop: RefreshResult = { refreshed: false, blocksUpdated: [], blocksAdded: [], blocksRemoved: [] };
+
+    const agent = await loadAgent(agentId);
+    if (!agent) return noop;
+
+    const archetype = archetypeForAgent(agent);
+    const [sourceContent, bundleContent] = await Promise.all([
+      loadSource(archetype),
+      readBundleEntry(agent),
+    ]);
+
+    if (bundleContent === null) {
+      // No bundle to refresh — nothing to do (could be an external bundle on a
+      // path we don't write; create-time bundling sets this up, so this is
+      // unusual but not an error).
+      return noop;
+    }
+
+    // Hot-path optimization: byte-compare source vs bundle. If they're equal
+    // there can't be drift. Cheap.
+    if (bundleContent === sourceContent) return noop;
+
+    const diff = diffAndApply(sourceContent, bundleContent);
+
+    // Warn (don't act) on bundle blocks that the source no longer carries.
+    if (diff.blocksRemoved.length > 0) {
+      logger.warn(
+        {
+          agentId: agent.id,
+          companyId: agent.companyId,
+          archetype,
+          blocksRemoved: diff.blocksRemoved,
+        },
+        "agent bundle has AgentDash blocks no longer present in source; leaving them in place",
+      );
+    }
+
+    if (diff.blocksUpdated.length === 0 && diff.blocksAdded.length === 0) {
+      return {
+        refreshed: false,
+        blocksUpdated: [],
+        blocksAdded: [],
+        blocksRemoved: diff.blocksRemoved,
+      };
+    }
+
+    await writeBundleEntry(agent, diff.nextContent);
+
+    await logActivity(db, {
+      companyId: agent.companyId,
+      actorType: "system",
+      actorId: "agent-instruction-refresh-service",
+      action: "instructions_refreshed",
+      entityType: "agent",
+      entityId: agent.id,
+      details: {
+        archetype,
+        blocksUpdated: diff.blocksUpdated,
+        blocksAdded: diff.blocksAdded,
+        blocksRemoved: diff.blocksRemoved,
+      },
+    });
+
+    return {
+      refreshed: true,
+      blocksUpdated: diff.blocksUpdated,
+      blocksAdded: diff.blocksAdded,
+      blocksRemoved: diff.blocksRemoved,
+    };
+  }
+
+  async function refreshAllForCompany(companyId: string): Promise<Record<string, RefreshResult>> {
+    const rows = await db
+      .select({ id: agentsTable.id })
+      .from(agentsTable)
+      .where(
+        and(
+          eq(agentsTable.companyId, companyId),
+          ne(agentsTable.status, "terminated"),
+        ),
+      );
+
+    const results: Record<string, RefreshResult> = {};
+    for (const row of rows as Array<{ id: string }>) {
+      try {
+        results[row.id] = await refreshIfStale(row.id);
+      } catch (err) {
+        logger.error(
+          { agentId: row.id, companyId, err },
+          "agent instruction refresh failed",
+        );
+        results[row.id] = {
+          refreshed: false,
+          blocksUpdated: [],
+          blocksAdded: [],
+          blocksRemoved: [],
+        };
+      }
+    }
+    return results;
+  }
+
+  return {
+    refreshIfStale,
+    refreshAllForCompany,
+  };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -73,6 +73,7 @@ import {
   type RunLivenessClassificationInput,
 } from "./run-liveness.js";
 import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
+import { agentInstructionRefreshService } from "./agent-instruction-refresh.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -2170,6 +2171,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     environmentRuntime,
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
+  const instructionRefreshSvc = agentInstructionRefreshService({ db });
   const activeRunExecutions = new Set<string>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
@@ -4918,6 +4920,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const failedRun = await getRun(runId);
       if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
       return;
+    }
+
+    // AgentDash: agent-instruction-refresh — refresh stale named blocks in the
+    // agent's bundled AGENTS.md before this tick's adapter dispatch. Wrapped in
+    // try/catch so a refresh failure never blocks an execution: a stale-but-
+    // working bundle is strictly better than failing the run.
+    try {
+      await instructionRefreshSvc.refreshIfStale(agent.id);
+    } catch (err) {
+      logger.warn(
+        {
+          agentId: agent.id,
+          companyId: agent.companyId,
+          runId: run.id,
+          err,
+        },
+        "agent instruction refresh failed; proceeding with existing bundle",
+      );
     }
 
     const runtime = await ensureRuntimeState(agent);

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -3,6 +3,12 @@ export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
 export { agentInstructionsService, syncInstructionsBundleConfigFromFilePath } from "./agent-instructions.js";
+export {
+  agentInstructionRefreshService,
+  type RefreshResult as AgentInstructionRefreshResult,
+  type AgentInstructionRefreshDeps,
+  type SourceArchetype as AgentInstructionRefreshArchetype,
+} from "./agent-instruction-refresh.js";
 export { assetService } from "./assets.js";
 export { documentService, extractLegacyPlanBody } from "./documents.js";
 export {


### PR DESCRIPTION
## Problem

Worker/CEO/CoS prompt sources keep evolving (#191, #193, #194), but existing agents created before each PR have OLD `AGENTS.md` baked into their managed `instructionsBundle` at create time — they don't pick up the new prompt content automatically. Today the only fix is "delete the embedded DB and bootstrap fresh", which is unacceptable for any non-test deployment.

## Solution

Add a named-block-aware refresh that detects drift between an agent's bundled AGENTS.md and the current source, and refreshes **only AgentDash-owned blocks** in place.

- Diffs each `<!-- AgentDash: SLUG -->...<!-- /AgentDash: SLUG -->` block in the agent's bundled AGENTS.md against the corresponding source block.
- Replaces stale blocks in place. Appends source-only blocks at the end.
- Leaves bundle-only blocks untouched (audit-only warning) — we never delete owned content silently.
- Preserves everything outside named blocks. Proposal-created agents' role-specific `${p.name}` / `${p.role}` / `${p.oneLineOkr}` content survives the refresh untouched.

Why named-block scope and not whole-file replacement:

1. Proposal-created agents have role-specific content interpolated into their AGENTS.md (`renderAgents()` in `agent-creator-from-proposal.ts`). Whole-file refresh would clobber it.
2. We don't own upstream Paperclip prose — touching it risks reintroducing differences after upstream cherry-picks.
3. Block-level diff is the cleanest invariant.

## What runs when

- **Every heartbeat tick** automatically calls `refreshIfStale(agent.id)` right after the agent is loaded, *before* adapter dispatch. Cheap byte-compare fast path; regex parse + replace only fires when source != bundle. Wrapped in try/catch so a refresh failure never blocks execution. (`server/src/services/heartbeat.ts:2174` instantiation, `server/src/services/heartbeat.ts:4923` hook site.)
- **Force-refresh routes** for board-driven manual triggers:
  - `POST /api/companies/:companyId/agents/:agentId/refresh-instructions`
  - `POST /api/companies/:companyId/agents/refresh-instructions` (bulk for all active agents)

## Audit trail

Each successful refresh writes one `instructions_refreshed` `activity_log` row with `actorType=system`, `actorId=agent-instruction-refresh-service`, and details listing `{archetype, blocksUpdated, blocksAdded, blocksRemoved}`. The constant is added to `ACTIVITY_LOG_ACTIONS_GOALS_EVAL_HITL` in `packages/shared/src/constants.ts`.

## Cache strategy

Source files (`onboarding-assets/{default,ceo,chief_of_staff}/AGENTS.md`) are cached in memory after first read. Cache invalidation is process restart, which every deploy already does. A test-only `__resetAgentInstructionRefreshCache()` is exported for unit-test isolation.

## Why bypass is appropriate

This is **infrastructure** — agents don't need to know about the refresh mechanism (it happens *to* them, not *by* them). No new agent-facing endpoints, behaviors, or contracts. The `[no-prompt-update]` flag bypasses `.github/workflows/agents-md-drift-check.yml`, which is the documented escape hatch for non-agent-facing infra. Verified locally:

```sh
node scripts/ci/check-agents-md-drift.mjs --diff <(git diff --name-status origin/main...HEAD) --title "feat(refresh): auto-refresh stale agent instructionsBundles [no-prompt-update]" --body ""
# Agent-facing feature check passed (no trigger files in diff). exit=0
```

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` — exit 0
- [x] `pnpm --filter @paperclipai/shared typecheck` — exit 0
- [x] `pnpm --filter @paperclipai/ui typecheck` — exit 0
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-instruction-refresh.test.ts` — 9 / 9 passing
  - byte-identical bundle → refreshed=false
  - single stale block → updated in place + activity row
  - missing block in bundle → appended + reported as `blocksAdded`
  - bundle-only block → left alone, reported as `blocksRemoved`, refreshed=false
  - multiple stale blocks → single combined activity row
  - archetype dispatch: `ceo` / `chief_of_staff` / `general` route to the right source
  - idempotency: second refresh after first is a no-op
  - role-specific interpolated content (`${p.name}`) preserved across refresh
  - `refreshAllForCompany` iterates active agents and returns per-agent results
- [x] Approvals invariant: `git diff main -- server/src/services/approvals.ts | wc -l` = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)