### PR TITLE
fix(security): validate LLM output before showing as question (#154)

### DIFF
--- a/server/src/__tests__/deep-interview-engine.test.ts
+++ b/server/src/__tests__/deep-interview-engine.test.ts
@@ -17,6 +17,7 @@ import {
   deepInterviewEngine,
   type EngineLLMDispatch,
 } from "../services/deep-interview-engine.js";
+import { HttpError } from "../errors.js";
 import type {
   DimensionScores,
   OntologySnapshot,
@@ -589,6 +590,98 @@ describe("deepInterviewEngine.nextTurn — malformed trailer", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// LLM output validation
+// ---------------------------------------------------------------------------
+
+const FALLBACK_QUESTION_RE = /Sorry.*trouble.*formulating/i;
+
+function makeNextTurnInput(overrides?: Record<string, unknown>) {
+  return {
+    scope: "cos_onboarding" as const,
+    scopeRefId: "ref-1234",
+    userId: "user-1",
+    companyId: "company-1",
+    initialIdea: "X",
+    adapter: "claude_api" as const,
+    ...overrides,
+  };
+}
+
+describe("deepInterviewEngine.nextTurn — LLM output validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("empty visibleBody + null trailer → fallback question, nothing malformed stored", async () => {
+    const fake = makeFakeDb(makeStateRow());
+    // LLM returns only whitespace (visibleBody will be empty after trim).
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue("   ");
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn(makeNextTurnInput());
+
+    expect(result.kind).toBe("question");
+    if (result.kind === "question") {
+      expect(result.question).toMatch(FALLBACK_QUESTION_RE);
+    }
+    // The persisted transcript should also hold the fallback, not the empty string.
+    const updates = fake.getUpdateCalls();
+    const lastUpdate = updates[updates.length - 1]!;
+    const stored = lastUpdate.transcript as TranscriptTurn[];
+    expect(stored[stored.length - 1]!.question).toMatch(FALLBACK_QUESTION_RE);
+  });
+
+  it("oversized visibleBody (3000 chars) → fallback question", async () => {
+    const fake = makeFakeDb(makeStateRow());
+    const hugeBody = "A".repeat(3000);
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(hugeBody);
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn(makeNextTurnInput());
+
+    expect(result.kind).toBe("question");
+    if (result.kind === "question") {
+      expect(result.question).toMatch(FALLBACK_QUESTION_RE);
+      expect(result.question.length).toBeLessThan(3000);
+    }
+  });
+
+  it("visibleBody containing <script> tag → fallback question", async () => {
+    const fake = makeFakeDb(makeStateRow());
+    const injected = 'What is your goal? <script>alert("xss")</script>';
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(injected);
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn(makeNextTurnInput());
+
+    expect(result.kind).toBe("question");
+    if (result.kind === "question") {
+      expect(result.question).toMatch(FALLBACK_QUESTION_RE);
+      expect(result.question).not.toContain("<script");
+    }
+  });
+
+  it("valid visibleBody flows through unchanged", async () => {
+    const fake = makeFakeDb(makeStateRow());
+    const goodQuestion = "What outcomes matter most to you?";
+    const llm: EngineLLMDispatch = vi.fn().mockResolvedValue(
+      trailerJson({
+        ambiguity_score: 0.7,
+        dimensions: { goal: 0.4, constraints: 0.2, criteria: 0.2, context: 0.1 },
+      }).replace("Here is my next question. What outcomes matter most?", goodQuestion),
+    );
+    const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: llm });
+
+    const result = await engine.nextTurn(makeNextTurnInput());
+
+    expect(result.kind).toBe("question");
+    if (result.kind === "question") {
+      expect(result.question).toBe(goodQuestion);
+    }
+  });
+});
+
 describe("deepInterviewEngine.crystallize", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -656,10 +749,13 @@ describe("deepInterviewEngine.crystallize", () => {
     expect(updates[updates.length - 1]!.status).toBe("crystallized");
   });
 
-  it("throws when state row does not exist", async () => {
+  it("throws HttpError 404 when state row does not exist", async () => {
     const fake = makeFakeDb(null);
     const engine = deepInterviewEngine({ db: fake.db, dispatchLLM: vi.fn() });
-    await expect(engine.crystallize("nope")).rejects.toThrow(/not found/);
+    const err = await engine.crystallize("nope").catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+    expect((err as HttpError).message).toMatch(/not found/i);
   });
 });
 

--- a/server/src/services/deep-interview-engine.ts
+++ b/server/src/services/deep-interview-engine.ts
@@ -38,6 +38,7 @@ import type {
   TranscriptTurn,
 } from "@paperclipai/shared/deep-interview";
 import { logger } from "../middleware/logger.js";
+import { notFound } from "../errors.js";
 import {
   composePrompt,
   type DeepInterviewStateRow as PromptStateRow,
@@ -322,6 +323,48 @@ function toPromptRow(row: DeepInterviewStateRow): PromptStateRow {
 }
 
 // ---------------------------------------------------------------------------
+// LLM output validation
+// ---------------------------------------------------------------------------
+
+const MAX_QUESTION_LENGTH = 2000;
+const INJECTION_PATTERNS = [
+  "<script",
+  "<iframe",
+  "javascript:",
+  "data:text/html",
+];
+
+/**
+ * Validate the visible body of an LLM response before it reaches the UI.
+ *
+ * Returns { valid: true, body } when the text is safe to display, or
+ * { valid: false, reason } when it fails a guard. The caller should substitute
+ * a safe fallback question and log the malformed response — do NOT throw.
+ */
+function validateVisibleBody(
+  raw: string,
+): { valid: true; body: string } | { valid: false; reason: string } {
+  const body = raw.trim();
+  if (body.length === 0) {
+    return { valid: false, reason: "empty" };
+  }
+  if (body.length > MAX_QUESTION_LENGTH) {
+    return { valid: false, reason: `too_long:${body.length}` };
+  }
+  for (const pattern of INJECTION_PATTERNS) {
+    if (body.toLowerCase().includes(pattern)) {
+      return { valid: false, reason: `injection_marker:${pattern}` };
+    }
+  }
+  // Reject anything that looks like raw HTML structure: 3+ '<' characters
+  // anywhere in the body (e.g. stacked tags like "<div><span><p>").
+  if ((body.match(/</g) ?? []).length >= 3) {
+    return { valid: false, reason: "html_structure" };
+  }
+  return { valid: true, body };
+}
+
+// ---------------------------------------------------------------------------
 // Service factory
 // ---------------------------------------------------------------------------
 
@@ -437,7 +480,26 @@ export function deepInterviewEngine(deps: EngineDeps): DeepInterviewEngine {
       messages: composed.messages,
     });
 
-    const { visibleBody, trailer } = parseJsonTrailer(raw);
+    const { visibleBody: rawVisibleBody, trailer } = parseJsonTrailer(raw);
+
+    // Validate visible body before it touches state or the UI.
+    const fallbackQuestion =
+      "Sorry — I had trouble formulating the next question. Could you tell me more about the previous topic?";
+    let visibleBody: string;
+    const validation = validateVisibleBody(rawVisibleBody);
+    if (!validation.valid) {
+      logger.warn(
+        {
+          stateId: row.id,
+          reason: validation.reason,
+          preview: rawVisibleBody.slice(0, 500),
+        },
+        "[deep-interview-engine] malformed LLM output rejected; using fallback question",
+      );
+      visibleBody = fallbackQuestion;
+    } else {
+      visibleBody = validation.body;
+    }
 
     // 3. Update state from trailer (or fall through with previous values).
     const dims: DimensionScores =
@@ -533,7 +595,7 @@ export function deepInterviewEngine(deps: EngineDeps): DeepInterviewEngine {
       .where(eq(deepInterviewStates.id, stateId))
       .limit(1);
     if (rows.length === 0) {
-      throw new Error(`[deep-interview-engine] state ${stateId} not found`);
+      throw notFound(`Deep interview state not found: ${stateId}`);
     }
     const row = rows[0]!;
 


### PR DESCRIPTION
## Summary

- **XSS / injection risk**: `visibleBody` from the LLM was flowing directly into state and the UI with no validation. A malformed, HTML-injected, or attacker-controlled LLM response could have been rendered verbatim as an interview question.
- **Fallback-question approach**: Instead of crashing or propagating bad content, `validateVisibleBody()` rejects empty, oversized (>2000 chars), injection-marker (`<script`, `<iframe`, `javascript:`, `data:text/html`), and HTML-structure outputs. On rejection, the engine logs a `warn` (with a 500-char preview) and substitutes a safe fallback question — the interview continues gracefully.
- **404 fix for crystallize**: `crystallize()` was throwing a plain `Error` for a missing state row, which Express translates to a 500. Changed to `notFound()` (`HttpError` status 404) for a clean error envelope.

## Changes

- `server/src/services/deep-interview-engine.ts`:
  - Added `import { notFound } from "../errors.js"`
  - Added `validateVisibleBody()` guard function (lines ~329–370)
  - Applied validation in `nextTurn()` after `parseJsonTrailer()` (lines ~483–499)
  - Fixed `crystallize()` to use `notFound()` instead of `new Error()`
- `server/src/__tests__/deep-interview-engine.test.ts`:
  - Added `import { HttpError } from "../errors.js"`
  - Added 4 new validation tests: empty body, oversized (3000 chars), `<script>` injection, valid pass-through
  - Updated crystallize 404 test to assert `instanceof HttpError` with `status === 404`

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` — exit 0
- [x] `pnpm test:run` — `deep-interview-engine.test.ts` 33/33 pass (up from 29); 27 pre-existing failures unrelated to this change
- [x] `git diff main -- server/src/services/approvals.ts | wc -l` = 0
- [x] Drift check: `Agent-facing feature check passed (no trigger files in diff)`

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)