### PR TITLE
fix(assess): block SSRF + collapse N+1 in listProjectAssessments (#155, #156)

### DIFF
--- a/server/src/__tests__/assess-project.test.ts
+++ b/server/src/__tests__/assess-project.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for assessProjectService — focused on listProjectAssessments N+1 fix.
+ *
+ * The fix collapses per-row companyContext queries into a single batched
+ * inArray query. This test suite verifies:
+ *   1. The return shape is identical to the old implementation
+ *   2. Only ONE additional select on companyContext is issued regardless of assessment count
+ *   3. Missing input rows are handled gracefully (slug used as projectName)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---- DB mock helpers -------------------------------------------------------
+
+type SelectChain = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+};
+
+function makeSelectChain(resolvedValue: unknown[]): SelectChain {
+  const chain: SelectChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.where.mockResolvedValue(resolvedValue);
+  chain.limit.mockResolvedValue(resolvedValue.slice(0, 1));
+  return chain;
+}
+
+// Build a minimal Drizzle-like db mock where each `.select()` call returns a
+// pre-configured chain. We use a queue so successive select() calls resolve to
+// different row sets.
+function makeMockDb(selectResults: unknown[][]) {
+  let callIdx = 0;
+  const selectMock = vi.fn(() => {
+    const rows = selectResults[callIdx] ?? [];
+    callIdx++;
+    return makeSelectChain(rows);
+  });
+
+  return {
+    select: selectMock,
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    onConflictDoUpdate: vi.fn().mockReturnThis(),
+  } as any;
+}
+
+// ---- Subject under test ----------------------------------------------------
+
+import { assessProjectService } from "../services/assess-project.js";
+
+// ---- Tests -----------------------------------------------------------------
+
+describe("assessProjectService.listProjectAssessments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ASSESS_MINIMAX_API_KEY = "test-key";
+  });
+
+  it("returns empty array when no project assessments exist", async () => {
+    const db = makeMockDb([
+      [], // first select: report rows
+      [], // second select: input rows (batched)
+    ]);
+    const svc = assessProjectService(db);
+    const result = await svc.listProjectAssessments("company-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns correct shape for a single assessment", async () => {
+    const reportRows = [
+      {
+        key: "project-assessment:my-project",
+        value: "# Report",
+        updatedAt: new Date("2026-01-15T10:00:00Z"),
+        createdAt: new Date("2026-01-15T09:00:00Z"),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+    ];
+    const inputRows = [
+      {
+        key: "project-assessment-input:my-project",
+        value: JSON.stringify({ projectName: "My Project", intake: { projectName: "My Project" } }),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+    ];
+
+    const db = makeMockDb([reportRows, inputRows]);
+    const svc = assessProjectService(db);
+    const result = await svc.listProjectAssessments("company-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slug: "my-project",
+      projectName: "My Project",
+      createdAt: "2026-01-15T10:00:00.000Z",
+    });
+  });
+
+  it("issues exactly ONE companyContext select for input rows regardless of assessment count", async () => {
+    // 5 assessment report rows
+    const reportRows = Array.from({ length: 5 }, (_, i) => ({
+      key: `project-assessment:project-${i}`,
+      value: `# Report ${i}`,
+      updatedAt: new Date(`2026-01-${String(i + 10).padStart(2, "0")}T10:00:00Z`),
+      createdAt: new Date(`2026-01-${String(i + 10).padStart(2, "0")}T09:00:00Z`),
+      companyId: "company-1",
+      contextType: "agent_research",
+    }));
+    const inputRows = Array.from({ length: 5 }, (_, i) => ({
+      key: `project-assessment-input:project-${i}`,
+      value: JSON.stringify({ projectName: `Project ${i}` }),
+      companyId: "company-1",
+      contextType: "agent_research",
+    }));
+
+    const db = makeMockDb([reportRows, inputRows]);
+    const svc = assessProjectService(db);
+    const result = await svc.listProjectAssessments("company-1");
+
+    // Result shape: 5 items
+    expect(result).toHaveLength(5);
+
+    // select() was called exactly TWICE: once for report rows, once for all input rows
+    // (NOT once per assessment, which would be 6 total)
+    expect(db.select).toHaveBeenCalledTimes(2);
+
+    // Each item has correct shape
+    for (let i = 0; i < 5; i++) {
+      const item = result.find((r) => r.slug === `project-${i}`);
+      expect(item).toBeDefined();
+      expect(item?.projectName).toBe(`Project ${i}`);
+      expect(item?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    }
+  });
+
+  it("falls back to slug as projectName when input row is missing", async () => {
+    const reportRows = [
+      {
+        key: "project-assessment:orphan-slug",
+        value: "# Report",
+        updatedAt: new Date("2026-02-01T00:00:00Z"),
+        createdAt: new Date("2026-02-01T00:00:00Z"),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+    ];
+
+    // No matching input row
+    const db = makeMockDb([reportRows, []]);
+    const svc = assessProjectService(db);
+    const result = await svc.listProjectAssessments("company-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("orphan-slug");
+    expect(result[0].projectName).toBe("orphan-slug");
+  });
+
+  it("falls back to intake.projectName when top-level projectName is absent", async () => {
+    const reportRows = [
+      {
+        key: "project-assessment:deep-name",
+        value: "# Report",
+        updatedAt: new Date("2026-03-01T00:00:00Z"),
+        createdAt: new Date("2026-03-01T00:00:00Z"),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+    ];
+    const inputRows = [
+      {
+        key: "project-assessment-input:deep-name",
+        value: JSON.stringify({ intake: { projectName: "Nested Name" } }),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+    ];
+
+    const db = makeMockDb([reportRows, inputRows]);
+    const svc = assessProjectService(db);
+    const result = await svc.listProjectAssessments("company-1");
+
+    expect(result[0].projectName).toBe("Nested Name");
+  });
+
+  it("returns results sorted newest first", async () => {
+    const reportRows = [
+      {
+        key: "project-assessment:older",
+        value: "# Old",
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+      {
+        key: "project-assessment:newer",
+        value: "# New",
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        companyId: "company-1",
+        contextType: "agent_research",
+      },
+    ];
+
+    const db = makeMockDb([reportRows, []]);
+    const svc = assessProjectService(db);
+    const result = await svc.listProjectAssessments("company-1");
+
+    expect(result[0].slug).toBe("newer");
+    expect(result[1].slug).toBe("older");
+  });
+});

--- a/server/src/__tests__/assess-url-safety.test.ts
+++ b/server/src/__tests__/assess-url-safety.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { isSafeFetchUrl } from "../services/assess.js";
+import { HttpError } from "../errors.js";
+
+function rejectsWithCode(url: string) {
+  try {
+    isSafeFetchUrl(url);
+    return false;
+  } catch (err) {
+    if (err instanceof HttpError) {
+      expect((err.details as { code?: string })?.code).toBe("UNSAFE_FETCH_URL");
+      // Must NOT leak the full URL — only the host is in details
+      expect(JSON.stringify(err.details)).not.toContain("169.254.169.254/latest");
+      expect(JSON.stringify(err.details)).not.toContain("10.0.0.1/secret");
+      return true;
+    }
+    return false;
+  }
+}
+
+describe("isSafeFetchUrl", () => {
+  // --- Allowed: public domains and IPs ---
+  it("allows a plain https domain", () => {
+    const u = isSafeFetchUrl("https://example.com");
+    expect(u.hostname).toBe("example.com");
+  });
+
+  it("allows a bare domain by prepending https://", () => {
+    const u = isSafeFetchUrl("example.com");
+    expect(u.protocol).toBe("https:");
+    expect(u.hostname).toBe("example.com");
+  });
+
+  it("allows http:// (non-https public URL)", () => {
+    const u = isSafeFetchUrl("http://example.com");
+    expect(u.hostname).toBe("example.com");
+  });
+
+  it("allows a public IPv4 address", () => {
+    const u = isSafeFetchUrl("https://8.8.8.8");
+    expect(u.hostname).toBe("8.8.8.8");
+  });
+
+  // --- Blocked: localhost ---
+  it("rejects localhost by name", () => {
+    expect(rejectsWithCode("http://localhost/")).toBe(true);
+  });
+
+  it("rejects 127.0.0.1", () => {
+    expect(rejectsWithCode("http://127.0.0.1/")).toBe(true);
+  });
+
+  it("rejects ::1 (IPv6 loopback)", () => {
+    expect(rejectsWithCode("http://[::1]/")).toBe(true);
+  });
+
+  // --- Blocked: RFC1918 private ranges ---
+  it("rejects 10.x.x.x (RFC1918)", () => {
+    expect(rejectsWithCode("http://10.0.0.1/secret")).toBe(true);
+  });
+
+  it("rejects 172.16.x.x (RFC1918)", () => {
+    expect(rejectsWithCode("https://172.16.0.1/")).toBe(true);
+  });
+
+  it("rejects 172.31.255.255 (RFC1918 upper bound)", () => {
+    expect(rejectsWithCode("https://172.31.255.255/")).toBe(true);
+  });
+
+  it("allows 172.15.x.x (just outside RFC1918)", () => {
+    const u = isSafeFetchUrl("https://172.15.0.1/");
+    expect(u.hostname).toBe("172.15.0.1");
+  });
+
+  it("allows 172.32.x.x (just outside RFC1918)", () => {
+    const u = isSafeFetchUrl("https://172.32.0.1/");
+    expect(u.hostname).toBe("172.32.0.1");
+  });
+
+  it("rejects 192.168.x.x (RFC1918)", () => {
+    expect(rejectsWithCode("http://192.168.1.1/")).toBe(true);
+  });
+
+  // --- Blocked: link-local / cloud metadata ---
+  it("rejects 169.254.169.254 (AWS/Azure IMDS)", () => {
+    expect(rejectsWithCode("http://169.254.169.254/latest/meta-data/")).toBe(true);
+  });
+
+  it("rejects metadata.google.internal (GCP metadata)", () => {
+    expect(rejectsWithCode("http://metadata.google.internal/")).toBe(true);
+  });
+
+  // --- Blocked: IPv6 link-local and ULA ---
+  it("rejects fe80:: (IPv6 link-local)", () => {
+    expect(rejectsWithCode("http://[fe80::1]/")).toBe(true);
+  });
+
+  it("rejects fc00:: (IPv6 ULA)", () => {
+    expect(rejectsWithCode("http://[fc00::1]/")).toBe(true);
+  });
+
+  it("rejects fd00:: (IPv6 ULA fd-range)", () => {
+    expect(rejectsWithCode("http://[fd00::1]/")).toBe(true);
+  });
+
+  // --- Blocked: non-http protocols ---
+  it("rejects ftp:// protocol", () => {
+    expect(rejectsWithCode("ftp://example.com/file")).toBe(true);
+  });
+
+  it("rejects javascript: URI", () => {
+    expect(rejectsWithCode("javascript:alert(1)")).toBe(true);
+  });
+
+  it("rejects file:// URI", () => {
+    expect(rejectsWithCode("file:///etc/passwd")).toBe(true);
+  });
+
+  // --- Blocked: malformed URLs ---
+  it("rejects a completely malformed URL", () => {
+    expect(rejectsWithCode("not a url at all!!!")).toBe(true);
+  });
+
+  // --- Details must not leak full URL path ---
+  it("does not include the URL path in error details", () => {
+    try {
+      isSafeFetchUrl("http://169.254.169.254/latest/meta-data/iam/credentials");
+    } catch (err) {
+      if (err instanceof HttpError) {
+        const detailsStr = JSON.stringify(err.details);
+        expect(detailsStr).not.toContain("/latest/meta-data");
+        expect(detailsStr).toContain("169.254.169.254");
+      } else {
+        throw err;
+      }
+    }
+  });
+});

--- a/server/src/services/assess-project.ts
+++ b/server/src/services/assess-project.ts
@@ -11,7 +11,7 @@
  * Reuses the existing MiniMax wiring (ASSESS_MINIMAX_API_KEY, etc.) — no new
  * env vars or LLM providers.
  */
-import { and, eq, like } from "drizzle-orm";
+import { and, eq, inArray, like } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { companies, companyContext } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
@@ -325,25 +325,36 @@ export function assessProjectService(db: Db) {
           ),
         );
 
+      // AgentDash: batch-fetch all input rows in one query (fixes N+1 — was 1 query per assessment)
+      const slugs = rows.map((r) => r.key.slice(PROJECT_KEY_PREFIX.length)).filter(Boolean);
+      const inputKeys = slugs.map((s) => PROJECT_INPUT_KEY_PREFIX + s);
+      const inputRows = inputKeys.length > 0
+        ? await db
+            .select()
+            .from(companyContext)
+            .where(
+              and(
+                eq(companyContext.companyId, companyId),
+                eq(companyContext.contextType, "agent_research"),
+                inArray(companyContext.key, inputKeys),
+              ),
+            )
+        : [];
+
+      const inputByKey = new Map<string, string>();
+      for (const ir of inputRows) {
+        if (ir.value) inputByKey.set(ir.key, ir.value);
+      }
+
       const out: { slug: string; projectName: string; createdAt: string }[] = [];
       for (const row of rows) {
         const slug = row.key.slice(PROJECT_KEY_PREFIX.length);
         if (!slug) continue;
-        const inputRow = await db
-          .select()
-          .from(companyContext)
-          .where(
-            and(
-              eq(companyContext.companyId, companyId),
-              eq(companyContext.contextType, "agent_research"),
-              eq(companyContext.key, PROJECT_INPUT_KEY_PREFIX + slug),
-            ),
-          )
-          .limit(1);
         let projectName = slug;
-        if (inputRow[0]?.value) {
+        const rawInput = inputByKey.get(PROJECT_INPUT_KEY_PREFIX + slug);
+        if (rawInput) {
           try {
-            const parsed = JSON.parse(inputRow[0].value) as { projectName?: string; intake?: { projectName?: string } };
+            const parsed = JSON.parse(rawInput) as { projectName?: string; intake?: { projectName?: string } };
             projectName = parsed.projectName ?? parsed.intake?.projectName ?? slug;
           } catch {
             // ignore

--- a/server/src/services/assess.ts
+++ b/server/src/services/assess.ts
@@ -6,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { companyContext } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
+import { badRequest } from "../errors.js";
 import { retrieveContext, type AssessmentInput } from "./assess-retrieval.js";
 import {
   serializeContext,
@@ -51,6 +52,76 @@ const INDUSTRY_KEYWORDS: Record<string, string[]> = {
   Agriculture: ["agriculture", "farming", "crop", "livestock"],
 };
 
+/**
+ * AgentDash: SSRF guard — rejects internal/private URLs before any fetch().
+ * Checks protocol, localhost, RFC1918, link-local, and cloud metadata endpoints.
+ * Does NOT perform DNS resolution; static IP/hostname checks only.
+ *
+ * @returns the parsed URL if safe
+ * @throws HttpError 400 with code UNSAFE_FETCH_URL if the URL is dangerous
+ */
+export function isSafeFetchUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    // Try parsing as-is first; if that fails (bare domain with no scheme),
+    // retry with https:// prepended. This ensures non-http schemes like
+    // ftp://, file://, javascript: are caught by the protocol check below
+    // rather than silently being treated as hostnames.
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      parsed = new URL(`https://${rawUrl}`);
+    }
+  } catch {
+    throw badRequest("Invalid URL", { code: "UNSAFE_FETCH_URL", host: rawUrl });
+  }
+
+  // Only allow http and https
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host: parsed.hostname });
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  // Reject localhost variants
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
+    throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+  }
+
+  // Reject GCP metadata endpoint
+  if (host === "metadata.google.internal") {
+    throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+  }
+
+  // Parse IPv4 dotted-decimal addresses
+  const ipv4Parts = host.split(".");
+  if (ipv4Parts.length === 4 && ipv4Parts.every((p) => /^\d+$/.test(p))) {
+    const [a, b] = ipv4Parts.map(Number);
+    // 10.0.0.0/8
+    if (a === 10) throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+    // 172.16.0.0/12
+    if (a === 172 && b >= 16 && b <= 31) throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+    // 192.168.0.0/16
+    if (a === 192 && b === 168) throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+    // 169.254.0.0/16 — AWS/Azure link-local / IMDS
+    if (a === 169 && b === 254) throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+  }
+
+  // Reject IPv6 link-local (fe80::/10), ULA (fc00::/7), and loopback (::1)
+  // Browsers/Node normalise bracket notation: [fe80::1] → fe80::1 in hostname
+  const ipv6 = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (
+    ipv6 === "::1" ||
+    ipv6.startsWith("fe80:") ||
+    ipv6.startsWith("fc") ||
+    ipv6.startsWith("fd")
+  ) {
+    throw badRequest("Unsafe URL", { code: "UNSAFE_FETCH_URL", host });
+  }
+
+  return parsed;
+}
+
 function detectIndustry(text: string): string {
   const lower = text.toLowerCase();
   const scores: { industry: string; count: number }[] = [];
@@ -68,6 +139,8 @@ function extractSummary(text: string): string {
 }
 
 async function fetchWebsite(url: string): Promise<string> {
+  // AgentDash: SSRF guard — throws 400 HttpError for unsafe URLs
+  isSafeFetchUrl(url);
   try {
     const res = await fetch(url, {
       headers: { "User-Agent": "AgentDash-Assess/1.0" },


### PR DESCRIPTION
## Summary

- **#155 (SSRF):** `fetchWebsite()` called `fetch(url)` with raw user-supplied input, allowing attackers to hit cloud metadata endpoints (169.254.169.254), localhost, and RFC1918 private ranges. Added `isSafeFetchUrl()` that validates the URL before every fetch — rejects non-http(s) protocols, localhost variants, RFC1918 (10/8, 172.16-31/12, 192.168/16), link-local 169.254/16 (AWS/Azure IMDS), metadata.google.internal (GCP), and IPv6 ULA/link-local. Rejection leaks only the hostname, not the full URL path.
- **#156 (N+1):** `listProjectAssessments` issued one `db.select()` per assessment row to fetch the matching input record. With 100 assessments → 101 queries. Replaced with a single batched `inArray(key, allKeys)` query + in-memory Map lookup. Return shape is unchanged.

## Files changed

| File | Change |
|------|--------|
| `server/src/services/assess.ts` | Added `isSafeFetchUrl()` helper (exported); wired into `fetchWebsite()` before `fetch()` call |
| `server/src/services/assess-project.ts` | Added `inArray` import; replaced N+1 loop with single batched query + Map |
| `server/src/__tests__/assess-url-safety.test.ts` | **New** — 23 cases: allowed public URLs, all rejection categories, no-path-leak assertion, boundary IPs |
| `server/src/__tests__/assess-project.test.ts` | **New** — 6 cases: return shape, exactly 2 db.select() calls for any N assessments, fallback behaviors |

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` — exit 0
- [x] `vitest run assess-url-safety.test.ts assess-project.test.ts` — 29/29 pass
- [x] CI drift check — "no trigger files in diff" (no AGENTS.md prompt surfaces touched)
- [x] `git diff main -- server/src/services/approvals.ts | wc -l` = 0

Closes #155, Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)