### PR TITLE
fix(security): add tiered API rate limiting (#160) [no-prompt-update]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^7.5.0
+        version: 7.5.1(express@5.2.1)
       hermes-paperclip-adapter:
         specifier: ^0.3.0
         version: 0.3.0
@@ -4920,6 +4923,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -11493,6 +11502,10 @@ snapshots:
       eventsource-parser: 3.0.6
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -68,6 +68,7 @@
     "drizzle-orm": "^0.38.4",
     "embedded-postgres": "^18.1.0-beta.16",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "hermes-paperclip-adapter": "^0.3.0",
     "jsdom": "^28.1.0",
     "multer": "^2.1.1",

--- a/server/src/__tests__/rate-limit.test.ts
+++ b/server/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * AgentDash (#160): rate-limiter middleware tests.
+ *
+ * Note: NODE_ENV === "test" auto-disables limiters via isDisabled() in the
+ * factory. We override that for these tests by setting AGENTDASH_RATE_LIMIT_*
+ * env vars and re-importing the module via vi.resetModules. Each test sets
+ * its own env state to keep cases isolated.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express, { type Express } from "express";
+import request from "supertest";
+
+const ORIG_ENV = { ...process.env };
+
+afterEach(() => {
+  // Restore env between tests
+  process.env = { ...ORIG_ENV };
+  vi.resetModules();
+});
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+async function loadFactories() {
+  return await import("../middleware/rate-limit.js");
+}
+
+function buildApp(mw: express.RequestHandler): Express {
+  const app = express();
+  app.set("trust proxy", true);
+  app.use(mw);
+  app.get("/", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe("rate-limit middleware (#160)", () => {
+  it("disabled in NODE_ENV=test by default — passes through unlimited", async () => {
+    process.env.NODE_ENV = "test";
+    delete process.env.AGENTDASH_RATE_LIMIT_DISABLED;
+    const { createDefaultApiRateLimiter } = await loadFactories();
+    const app = buildApp(createDefaultApiRateLimiter());
+
+    // Hit it 50 times — would blow any sane limit if active.
+    for (let i = 0; i < 50; i++) {
+      const res = await request(app).get("/");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("auth limiter enforces tighter cap (configurable, set to 3 for test)", async () => {
+    delete process.env.NODE_ENV;
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED = "false";
+    process.env.AGENTDASH_RATE_LIMIT_AUTH_MAX = "3";
+    const { createAuthRateLimiter } = await loadFactories();
+    const app = buildApp(createAuthRateLimiter());
+
+    for (let i = 0; i < 3; i++) {
+      const ok = await request(app).get("/").set("X-Forwarded-For", "10.0.0.1");
+      expect(ok.status).toBe(200);
+    }
+    const blocked = await request(app).get("/").set("X-Forwarded-For", "10.0.0.1");
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toMatchObject({ error: "Rate limited" });
+    expect(blocked.body.retryAfter).toBeGreaterThan(0);
+    expect(blocked.headers["retry-after"]).toBeDefined();
+  });
+
+  it("AGENTDASH_RATE_LIMIT_DISABLED=true bypasses entirely", async () => {
+    delete process.env.NODE_ENV;
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED = "true";
+    process.env.AGENTDASH_RATE_LIMIT_AUTH_MAX = "1";
+    const { createAuthRateLimiter } = await loadFactories();
+    const app = buildApp(createAuthRateLimiter());
+
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app).get("/").set("X-Forwarded-For", "10.0.0.2");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("billing limiter enforces tighter cap (configurable, set to 2)", async () => {
+    delete process.env.NODE_ENV;
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED = "false";
+    process.env.AGENTDASH_RATE_LIMIT_BILLING_MAX = "2";
+    const { createBillingRateLimiter } = await loadFactories();
+    const app = buildApp(createBillingRateLimiter());
+
+    for (let i = 0; i < 2; i++) {
+      const ok = await request(app).get("/").set("X-Forwarded-For", "10.0.0.3");
+      expect(ok.status).toBe(200);
+    }
+    const blocked = await request(app).get("/").set("X-Forwarded-For", "10.0.0.3");
+    expect(blocked.status).toBe(429);
+  });
+
+  it("authenticated requests key on actor.userId, not IP", async () => {
+    delete process.env.NODE_ENV;
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED = "false";
+    process.env.AGENTDASH_RATE_LIMIT_API_MAX = "3";
+    const { createDefaultApiRateLimiter } = await loadFactories();
+
+    const app = express();
+    app.set("trust proxy", true);
+    // Stub actor middleware
+    app.use((req, _res, next) => {
+      const userHeader = req.header("x-test-user");
+      if (userHeader) (req as any).actor = { userId: userHeader };
+      next();
+    });
+    app.use(createDefaultApiRateLimiter());
+    app.get("/", (_req, res) => res.json({ ok: true }));
+
+    // Same IP, two different users — each gets their own quota
+    for (let i = 0; i < 3; i++) {
+      const a = await request(app).get("/").set("X-Forwarded-For", "10.0.0.4").set("X-Test-User", "alice");
+      expect(a.status).toBe(200);
+    }
+    for (let i = 0; i < 3; i++) {
+      const b = await request(app).get("/").set("X-Forwarded-For", "10.0.0.4").set("X-Test-User", "bob");
+      expect(b.status).toBe(200);
+    }
+    // Alice's 4th request blocked
+    const aliceBlocked = await request(app).get("/").set("X-Forwarded-For", "10.0.0.4").set("X-Test-User", "alice");
+    expect(aliceBlocked.status).toBe(429);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,12 @@ import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { corpEmailSignupGuard } from "./middleware/corp-email-signup-guard.js";
+// AgentDash (#160): tiered API rate limiting — auth/billing tighter than default.
+import {
+  createAuthRateLimiter,
+  createBillingRateLimiter,
+  createDefaultApiRateLimiter,
+} from "./middleware/rate-limit.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
@@ -177,13 +183,16 @@ export async function createApp(
       resolveSession: opts.resolveSession,
     }),
   );
-  app.use("/api/auth", authRoutes(db));
+  // AgentDash (#160): tighter rate limit on /api/auth/* (brute-force vector).
+  app.use("/api/auth", createAuthRateLimiter(), authRoutes(db));
   if (opts.betterAuthHandler) {
     // AgentDash (AGE-104 follow-up): block free-mail signups on Pro at the
     // signup endpoint itself, not at company-creation time.
     app.use(
       corpEmailSignupGuard({ enabled: opts.requireCorpEmail ?? false }),
     );
+    // AgentDash (#160): rate-limit better-auth handler too (same /api/auth path).
+    app.use("/api/auth", createAuthRateLimiter());
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
   app.use(llmRoutes(db));
@@ -193,6 +202,9 @@ export async function createApp(
 
   // Mount API routes
   const api = Router();
+  // AgentDash (#160): default-tier rate limit covering everything under /api
+  // (excluding /api/auth which has a tighter limiter mounted on `app` directly).
+  api.use(createDefaultApiRateLimiter());
   api.use(boardMutationGuard());
   api.use(
     "/health",
@@ -264,7 +276,17 @@ export async function createApp(
     const { default: Stripe } = await import("stripe");
     stripeSdk = new Stripe(stripeKey);
   }
-  api.use("/billing", billingRoutes(db, {
+  // AgentDash (#160): tighter rate limit on /billing/* (abuse vector). The
+  // /billing/webhook subpath is hit by Stripe's servers, not users, and must
+  // bypass — Stripe can send bursts during retries / high-traffic events.
+  const billingLimiter = createBillingRateLimiter();
+  api.use(
+    "/billing",
+    (req, res, next) => {
+      if (req.path === "/webhook") return next();
+      return billingLimiter(req, res, next);
+    },
+    billingRoutes(db, {
     stripe: stripeSdk,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET ?? "",
     proPriceId: process.env.STRIPE_PRO_PRICE_ID ?? "",

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,0 +1,83 @@
+/**
+ * AgentDash: tiered API rate limiting (#160)
+ *
+ * Three tiers:
+ *  - Auth  (/api/auth/*): 10 req / 15 min  — brute-force / credential-stuffing vector
+ *  - Billing mutations:   20 req / 15 min  — abuse / billing-fraud vector
+ *  - Default (/api/*):  200 req / 15 min  — generous ceiling for legit usage
+ *
+ * Env-var overrides:
+ *  AGENTDASH_RATE_LIMIT_AUTH_MAX    (default 10)
+ *  AGENTDASH_RATE_LIMIT_BILLING_MAX (default 20)
+ *  AGENTDASH_RATE_LIMIT_API_MAX     (default 200)
+ *  AGENTDASH_RATE_LIMIT_DISABLED=true  — no-op middleware (tests / dev)
+ */
+
+import { rateLimit, type Options as RateLimitOptions } from "express-rate-limit";
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+function isDisabled(): boolean {
+  return (
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED === "true" ||
+    process.env.NODE_ENV === "test"
+  );
+}
+
+function parseEnvInt(key: string, fallback: number): number {
+  const val = process.env[key];
+  if (!val) return fallback;
+  const parsed = parseInt(val, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Key generator: prefer authenticated actor identity over IP address.
+ * This avoids false-positives for users behind NAT / corporate proxies.
+ */
+function keyGenerator(req: Request): string {
+  const actor = (req as any).actor;
+  if (actor?.userId) return `user:${actor.userId}`;
+  if (actor?.agentId) return `agent:${actor.agentId}`;
+  // Fallback to IP — express sets req.ip
+  return `ip:${req.ip ?? "unknown"}`;
+}
+
+function makeHandler(max: number, extraOpts?: Partial<RateLimitOptions>): RequestHandler {
+  return rateLimit({
+    windowMs: WINDOW_MS,
+    max,
+    standardHeaders: "draft-7", // Retry-After + RateLimit-* headers
+    legacyHeaders: false,
+    keyGenerator,
+    handler(_req: Request, res: Response) {
+      const retryAfter = Math.ceil(WINDOW_MS / 1000);
+      res
+        .status(429)
+        .set("Retry-After", String(retryAfter))
+        .json({ error: "Rate limited", retryAfter });
+    },
+    ...extraOpts,
+  });
+}
+
+/** No-op pass-through used when rate limiting is disabled. */
+function noopMiddleware(_req: Request, _res: Response, next: NextFunction): void {
+  next();
+}
+
+export function createAuthRateLimiter(): RequestHandler {
+  if (isDisabled()) return noopMiddleware;
+  return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_AUTH_MAX", 10));
+}
+
+export function createBillingRateLimiter(): RequestHandler {
+  if (isDisabled()) return noopMiddleware;
+  return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_BILLING_MAX", 20));
+}
+
+export function createDefaultApiRateLimiter(): RequestHandler {
+  if (isDisabled()) return noopMiddleware;
+  return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_API_MAX", 200));
+}


### PR DESCRIPTION
## Summary

Adds tiered \`express-rate-limit\` middleware. Closes #160.

| Surface | Limit | Window | Rationale |
|---|---|---|---|
| \`/api/auth/*\` | 10 / IP-or-user | 15 min | Brute-force / credential stuffing |
| \`/api/billing/*\` (excl. \`/webhook\`) | 20 / IP-or-user | 15 min | Billing abuse / fraud |
| \`/api/*\` (default) | 200 / IP-or-user | 15 min | Generous ceiling for legit usage |

## Key design choices

- **Stripe webhook bypass.** \`/api/billing/webhook\` is hit by Stripe's servers (not users) and Stripe sends bursts during retries / high-traffic events. The billing tier is wired with an inline conditional that skips the limiter for that exact subpath.
- **Actor-aware key generator.** \`keyGenerator\` prefers \`req.actor.userId\` / \`req.actor.agentId\` over IP. Users behind NAT or corporate proxies sharing an outbound IP don't false-positive each other.
- **Test/dev bypass.** \`NODE_ENV === \"test\"\` and \`AGENTDASH_RATE_LIMIT_DISABLED=true\` make all factories return a no-op middleware. Existing tests don't need rewriting.
- **Configurable.** Per-tier max via \`AGENTDASH_RATE_LIMIT_{AUTH,BILLING,API}_MAX\` env vars.
- **Standard response.** HTTP 429 with \`{ error: \"Rate limited\", retryAfter }\` body + \`Retry-After\` + draft-7 \`RateLimit-*\` headers.

## Files

- \`server/src/middleware/rate-limit.ts\` (new): 3 factories
- \`server/src/__tests__/rate-limit.test.ts\` (new): 5 cases (disabled-in-test, auth tighter, AGENTDASH_RATE_LIMIT_DISABLED bypass, billing tighter, actor-keyed quotas)
- \`server/src/app.ts\`: wired at 3 points
- \`server/package.json\` + \`pnpm-lock.yaml\`: added \`express-rate-limit ^7.5.0\`

## Test plan

- [x] \`pnpm --filter @paperclipai/server typecheck\` → exit 0
- [x] All 5 new test cases pass
- [x] \`git diff main -- server/src/services/approvals.ts | wc -l\` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)