### PR TITLE
feat(ui): add delete affordance to GoalDetail (#195)

### DIFF
--- a/ui/src/pages/GoalDetail.delete.test.tsx
+++ b/ui/src/pages/GoalDetail.delete.test.tsx
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GoalDetail } from "./GoalDetail";
+
+// ---- async helpers (same pattern as IssueDetail.test.tsx) ----
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function waitForAssertion(assertion: () => void, attempts = 20): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      assertion();
+      return;
+    } catch {
+      await flushReact();
+    }
+  }
+  assertion();
+}
+
+// ---- hoisted mocks ----
+
+const mockGoalsApi = vi.hoisted(() => ({
+  get: vi.fn(),
+  list: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+  create: vi.fn(),
+}));
+
+const mockProjectsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockAssetsApi = vi.hoisted(() => ({
+  uploadImage: vi.fn(),
+}));
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockOpenPanel = vi.hoisted(() => vi.fn());
+const mockClosePanel = vi.hoisted(() => vi.fn());
+const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
+const mockPushToast = vi.hoisted(() => vi.fn());
+
+vi.mock("../api/goals", () => ({
+  goalsApi: mockGoalsApi,
+}));
+
+vi.mock("../api/projects", () => ({
+  projectsApi: mockProjectsApi,
+}));
+
+vi.mock("../api/assets", () => ({
+  assetsApi: mockAssetsApi,
+}));
+
+vi.mock("@/lib/router", () => ({
+  useParams: () => ({ goalId: "goal-123" }),
+  useNavigate: () => mockNavigate,
+  Link: ({ children, to }: { children?: ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({
+    selectedCompanyId: "company-1",
+    setSelectedCompanyId: vi.fn(),
+  }),
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialogActions: () => ({
+    openNewGoal: vi.fn(),
+  }),
+}));
+
+vi.mock("../context/PanelContext", () => ({
+  usePanel: () => ({
+    openPanel: mockOpenPanel,
+    closePanel: mockClosePanel,
+    panelVisible: false,
+    setPanelVisible: vi.fn(),
+  }),
+}));
+
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({
+    setBreadcrumbs: mockSetBreadcrumbs,
+  }),
+}));
+
+vi.mock("../context/ToastContext", () => ({
+  useToastActions: () => ({
+    pushToast: mockPushToast,
+  }),
+}));
+
+vi.mock("../components/GoalProperties", () => ({
+  GoalProperties: () => null,
+}));
+
+vi.mock("../components/GoalTree", () => ({
+  GoalTree: () => null,
+}));
+
+vi.mock("../components/GoalMetricTile", () => ({
+  GoalMetricTile: () => null,
+}));
+
+vi.mock("../components/StatusBadge", () => ({
+  StatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+vi.mock("../components/InlineEditor", () => ({
+  InlineEditor: ({ value }: { value: string }) => <span>{value}</span>,
+}));
+
+vi.mock("../components/EntityRow", () => ({
+  EntityRow: () => null,
+}));
+
+vi.mock("../components/PageSkeleton", () => ({
+  PageSkeleton: () => <div>loading</div>,
+}));
+
+// ---- sample data ----
+
+const sampleGoal = {
+  id: "goal-123",
+  companyId: "company-1",
+  title: "Increase ARR",
+  description: "Grow revenue",
+  status: "active",
+  level: "company",
+  parentId: null,
+  goalIds: [],
+  goals: [],
+  goalId: null,
+};
+
+// ---- render helper ----
+
+function renderGoalDetail() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <GoalDetail />
+      </QueryClientProvider>,
+    );
+  });
+  return { container, root, queryClient };
+}
+
+// ---- tests ----
+
+describe("GoalDetail delete affordance", () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGoalsApi.get.mockResolvedValue(sampleGoal);
+    mockGoalsApi.list.mockResolvedValue([]);
+    mockProjectsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    document.body.innerHTML = "";
+  });
+
+  it("shows the trash icon button in the goal header after data loads", async () => {
+    ({ container, root } = renderGoalDetail());
+
+    await waitForAssertion(() => {
+      const trashBtn = container.querySelector('[data-testid="delete-goal-button"]');
+      expect(trashBtn).not.toBeNull();
+    });
+  });
+
+  it("clicking trash icon opens the confirm dialog with the goal title", async () => {
+    ({ container, root } = renderGoalDetail());
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="delete-goal-button"]')).not.toBeNull();
+    });
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="delete-goal-button"]')!.click();
+    });
+
+    // Dialog renders via Radix portal into document.body (outside container)
+    await waitForAssertion(() => {
+      expect(document.querySelector('[data-testid="confirm-delete-goal-button"]')).not.toBeNull();
+    });
+    expect(document.body.textContent).toContain("Increase ARR");
+    expect(document.body.textContent).toContain("Delete Goal");
+  });
+
+  it("clicking Cancel closes the dialog without calling goalsApi.remove", async () => {
+    ({ container, root } = renderGoalDetail());
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="delete-goal-button"]')).not.toBeNull();
+    });
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="delete-goal-button"]')!.click();
+    });
+
+    await waitForAssertion(() => {
+      expect(document.querySelector('[data-testid="confirm-delete-goal-button"]')).not.toBeNull();
+    });
+
+    const buttons = Array.from(document.querySelectorAll("button"));
+    const cancelBtn = buttons.find((b) => b.textContent?.trim() === "Cancel");
+    expect(cancelBtn).not.toBeNull();
+
+    act(() => {
+      cancelBtn!.click();
+    });
+
+    await waitForAssertion(() => {
+      expect(document.querySelector('[data-testid="confirm-delete-goal-button"]')).toBeNull();
+    });
+    expect(mockGoalsApi.remove).not.toHaveBeenCalled();
+  });
+
+  it("clicking Delete Goal calls goalsApi.remove with the goal id and navigates to /goals on success", async () => {
+    mockGoalsApi.remove.mockResolvedValue(sampleGoal);
+
+    ({ container, root } = renderGoalDetail());
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="delete-goal-button"]')).not.toBeNull();
+    });
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="delete-goal-button"]')!.click();
+    });
+
+    await waitForAssertion(() => {
+      expect(document.querySelector('[data-testid="confirm-delete-goal-button"]')).not.toBeNull();
+    });
+
+    const confirmBtn = document.querySelector<HTMLButtonElement>(
+      '[data-testid="confirm-delete-goal-button"]',
+    )!;
+
+    await act(async () => {
+      confirmBtn.click();
+      await flushReact();
+    });
+
+    expect(mockGoalsApi.remove).toHaveBeenCalledWith("goal-123");
+    expect(mockNavigate).toHaveBeenCalledWith("/goals");
+  });
+
+  it("shows an error toast when goalsApi.remove fails", async () => {
+    mockGoalsApi.remove.mockRejectedValue(new Error("Server error"));
+
+    ({ container, root } = renderGoalDetail());
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="delete-goal-button"]')).not.toBeNull();
+    });
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="delete-goal-button"]')!.click();
+    });
+
+    await waitForAssertion(() => {
+      expect(document.querySelector('[data-testid="confirm-delete-goal-button"]')).not.toBeNull();
+    });
+
+    const confirmBtn = document.querySelector<HTMLButtonElement>(
+      '[data-testid="confirm-delete-goal-button"]',
+    )!;
+
+    await act(async () => {
+      confirmBtn.click();
+      await flushReact();
+    });
+
+    expect(mockGoalsApi.remove).toHaveBeenCalledWith("goal-123");
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockPushToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Failed to delete goal",
+        body: "Server error",
+        tone: "error",
+      }),
+    );
+  });
+});

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useParams } from "@/lib/router";
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { goalsApi } from "../api/goals";
 import { projectsApi } from "../api/projects";
@@ -8,6 +8,7 @@ import { usePanel } from "../context/PanelContext";
 import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useToastActions } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { GoalProperties } from "../components/GoalProperties";
 import { GoalTree } from "../components/GoalTree";
@@ -21,7 +22,15 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { cn, projectUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus, SlidersHorizontal } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Plus, SlidersHorizontal, Trash2 } from "lucide-react";
 import type { Goal, Project } from "@paperclipai/shared";
 
 interface GoalPropertiesToggleButtonProps {
@@ -56,6 +65,9 @@ export function GoalDetail() {
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { pushToast } = useToastActions();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const {
     data: goal,
@@ -111,6 +123,26 @@ export function GoalDetail() {
     }
   });
 
+  const deleteGoal = useMutation({
+    mutationFn: () => goalsApi.remove(goalId!),
+    onSuccess: () => {
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.goals.list(resolvedCompanyId),
+        });
+      }
+      navigate("/goals");
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Failed to delete goal",
+        body: error instanceof Error ? error.message : "Could not delete goal.",
+        tone: "error",
+      });
+      setDeleteDialogOpen(false);
+    },
+  });
+
   const childGoals = (allGoals ?? []).filter((g) => g.parentId === goalId);
   const linkedProjects = (allProjects ?? []).filter((p) => {
     if (!goalId) return false;
@@ -150,7 +182,17 @@ export function GoalDetail() {
             {goal.level}
           </span>
           <StatusBadge status={goal.status} />
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="text-muted-foreground hover:text-destructive shrink-0"
+              onClick={() => setDeleteDialogOpen(true)}
+              title="Delete goal"
+              data-testid="delete-goal-button"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
             <GoalPropertiesToggleButton
               panelVisible={panelVisible}
               onShowProperties={() => setPanelVisible(true)}
@@ -237,6 +279,34 @@ export function GoalDetail() {
           )}
         </TabsContent>
       </Tabs>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete goal</DialogTitle>
+            <DialogDescription>
+              Delete goal: <strong>{goal.title}</strong>? This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteDialogOpen(false)}
+              disabled={deleteGoal.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteGoal.mutate()}
+              disabled={deleteGoal.isPending}
+              data-testid="confirm-delete-goal-button"
+            >
+              Delete Goal
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a `Trash2` icon button to the GoalDetail page header (next to the properties toggle)
- Click opens a confirm `Dialog` naming the goal title (e.g. "Delete goal: *Increase ARR*?") to prevent fat-finger deletes
- On confirm: `goalsApi.remove(id)` → invalidates `queryKeys.goals.list(companyId)` → `navigate("/goals")`
- On error: `pushToast({ title: "Failed to delete goal", tone: "error" })` — dialog stays closed

## Convention copied

Patterned after `IssueDetail.tsx` (dialog + useMutation + useToastActions) and `AgentDetail.tsx` (Trash2 icon button in header). No new abstractions introduced.

## Test plan

- [x] `pnpm -r typecheck` — passes clean (0 new errors)
- [x] 5 new jsdom tests in `ui/src/pages/GoalDetail.delete.test.tsx`:
  - Trash button visible after data loads
  - Click trash → dialog opens with goal title
  - Click Cancel → dialog closes, no API call
  - Click Delete Goal → `goalsApi.remove("goal-id")` called, `navigate("/goals")` called
  - Error path → `pushToast` called with error message
- [x] `git diff main -- server/src/services/approvals.ts | wc -l` = 0
- [x] Pre-existing server test failures (assess-retrieval, workspace-runtime) unrelated to this change

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)