### PR TITLE
fix(assess): surface follow-up generation failures with 502 (#162)

### DIFF
--- a/server/src/services/assess-project.ts
+++ b/server/src/services/assess-project.ts
@@ -448,9 +448,17 @@ Analyze the gaps in the answers above and generate 2-4 targeted follow-up questi
       let parsed: ProjectClarifyResult;
       try {
         parsed = JSON.parse(extractJsonFromText(raw));
-      } catch {
-        logger.warn({ raw }, "Failed to parse follow-up JSON; returning empty");
-        parsed = { rephrased: "", questions: [] };
+      } catch (err) {
+        // Closes #162: fail loud instead of silently returning empty questions.
+        // Unlike the clarify path (~line 144) we have no usable fallback set
+        // for follow-ups — they're contextual to the user's prior answers, so
+        // a static template would be misleading. Bubble a 502 so the UI can
+        // tell the user generation failed and offer a retry.
+        logger.error({ err, raw }, "Failed to parse follow-up JSON");
+        throw Object.assign(
+          new Error("Could not generate follow-up questions; the model returned an unparseable response."),
+          { statusCode: 502 },
+        );
       }
 
       return {


### PR DESCRIPTION
## Summary
- `generateFollowUp` was silently returning empty questions when the LLM produced malformed JSON, hiding the failure from the user
- Now logs at `error` level and throws 502 with a clear message
- UI's `setFollowUpError` already wired to surface `err.message`, so users get an actionable error state with retry

Closes #162.

## Why not the same change to the clarify path
The clarify-path catch block (~line 144) returns hardcoded fallback questions that are still useful to the user. Follow-ups are contextual to prior answers, so a static template would be misleading. Comment in the new catch explains the asymmetry.

## Test plan
- [x] Manual: simulate malformed LLM JSON → verify 502 returned + UI shows error
- [x] Existing happy-path tests for `generateFollowUp` still pass (parse succeeds → returns parsed result unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)