### PR TITLE
feat(digest): wire heartbeatDigest scheduler with DB-backed adapters (#207)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -927,6 +927,52 @@ export async function startServer(): Promise<StartedServer> {
     }, reconcileIntervalMs);
   }
 
+  // AgentDash (#207): heartbeatDigest scheduler — daily re-engagement email
+  // per onboarding spec §5. Mirrors the billingReconcile pattern above:
+  // - Disabled by default in dev (opt-in via AGENTDASH_DIGEST_ENABLED=true)
+  // - Skipped if RESEND_API_KEY is unset (sendEmail no-ops anyway, but
+  //   skipping avoids the daily log spam from each user iteration)
+  // - Default cadence: 24h. Override with AGENTDASH_DIGEST_INTERVAL_MS for
+  //   tests / manual exercise.
+  // - Per-user timezone targeting is a follow-up; v1 ticks once per UTC day.
+  let heartbeatDigestHandle: ReturnType<typeof setInterval> | null = null;
+  const digestEnabled =
+    process.env.AGENTDASH_DIGEST_ENABLED === "true" && !!process.env.RESEND_API_KEY?.trim();
+  if (!digestEnabled) {
+    logger.info(
+      {
+        reason: !process.env.RESEND_API_KEY?.trim()
+          ? "no RESEND_API_KEY"
+          : "AGENTDASH_DIGEST_ENABLED not set",
+      },
+      "[digest] heartbeatDigest schedule skipped",
+    );
+  } else {
+    const digestIntervalMs = (() => {
+      const raw = process.env.AGENTDASH_DIGEST_INTERVAL_MS;
+      if (!raw) return 86_400_000; // 24h
+      const parsed = Number.parseInt(raw, 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 86_400_000;
+    })();
+    const { heartbeatDigest } = await import("./services/index.js");
+    const {
+      digestUserAdapter,
+      digestActivityAdapter,
+      digestEmailAdapter,
+    } = await import("./services/heartbeat-digest-adapters.js");
+    const digester = heartbeatDigest({
+      email: digestEmailAdapter(),
+      activity: digestActivityAdapter(db as any),
+      users: digestUserAdapter(db as any),
+    });
+    logger.info({ intervalMs: digestIntervalMs }, "[digest] heartbeatDigest schedule enabled");
+    heartbeatDigestHandle = setInterval(() => {
+      void digester.run().catch((err) => {
+        logger.error({ err }, "[digest] heartbeatDigest.run failed");
+      });
+    }, digestIntervalMs);
+  }
+
   await new Promise<void>((resolveListen, rejectListen) => {
     const onError = (err: Error) => {
       server.off("error", onError);
@@ -1003,6 +1049,15 @@ export async function startServer(): Promise<StartedServer> {
           clearInterval(billingReconcileHandle);
         } catch (err) {
           logger.error({ err }, "failed to clear billingReconcile interval");
+        }
+      }
+
+      // AgentDash (#207): heartbeat digest scheduler
+      if (heartbeatDigestHandle) {
+        try {
+          clearInterval(heartbeatDigestHandle);
+        } catch (err) {
+          logger.error({ err }, "failed to clear heartbeatDigest interval");
         }
       }
 

--- a/server/src/services/heartbeat-digest-adapters.ts
+++ b/server/src/services/heartbeat-digest-adapters.ts
@@ -1,0 +1,156 @@
+// AgentDash (#207): adapters that satisfy heartbeatDigest's Deps interface so
+// the dailyDigest scheduler in server/src/index.ts can wire it up against the
+// real DB + Resend transport. Kept separate from heartbeat-digest.ts so that
+// service stays a pure orchestrator (testable with mocks) and these adapters
+// own the persistence concerns.
+
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import {
+  activityLog,
+  agents,
+  authUsers,
+  companyMemberships,
+  type Db,
+} from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+import { sendEmail } from "../auth/email.js";
+
+interface Activity {
+  agentName: string;
+  summary: string;
+}
+
+interface DigestUser {
+  id: string;
+  email: string;
+  timezone?: string;
+}
+
+/**
+ * Lists every authenticated user with a verified email AND at least one active
+ * "user" company membership. Per onboarding spec §5 the digest goes to all
+ * conversation participants — we approximate "participant" as "active member
+ * of any company" until we wire per-conversation participant lookup.
+ *
+ * Timezone is left undefined; v1 ticks once per UTC day. Per-user timezone is
+ * a follow-up (#207 acceptance criteria explicitly defer it).
+ */
+export function digestUserAdapter(db: Db) {
+  return {
+    listForDigest: async (): Promise<DigestUser[]> => {
+      const rows = await db
+        .selectDistinct({
+          id: authUsers.id,
+          email: authUsers.email,
+        })
+        .from(authUsers)
+        .innerJoin(
+          companyMemberships,
+          and(
+            eq(companyMemberships.principalType, "user"),
+            eq(companyMemberships.principalId, authUsers.id),
+            eq(companyMemberships.status, "active"),
+          ),
+        )
+        .where(eq(authUsers.emailVerified, true));
+      return rows.map((row) => ({ id: row.id, email: row.email }));
+    },
+  };
+}
+
+/**
+ * For a given user, returns chat-worthy agent activity from the last `hours`
+ * hours, scoped to companies the user is an active member of. One row per
+ * agent — multiple updates from the same agent are summarised into a single
+ * line ("Reese: 14 outreach drafts overnight + 2 more updates").
+ *
+ * Filters to actorType="agent" so system events and human edits don't leak
+ * into the digest. Per the chat-substrate spec the digest mirrors the
+ * agent_status_v1 cards, which are also agent-authored.
+ */
+export function digestActivityAdapter(db: Db) {
+  return {
+    listSince: async (userId: string, sinceHours: number): Promise<Activity[]> => {
+      const since = new Date(Date.now() - sinceHours * 60 * 60 * 1000);
+
+      // Companies the user can see.
+      const memberships = await db
+        .select({ companyId: companyMemberships.companyId })
+        .from(companyMemberships)
+        .where(
+          and(
+            eq(companyMemberships.principalType, "user"),
+            eq(companyMemberships.principalId, userId),
+            eq(companyMemberships.status, "active"),
+          ),
+        );
+      const companyIds = memberships.map((m) => m.companyId);
+      if (companyIds.length === 0) return [];
+
+      // One row per agent — count + most recent action serve as the summary.
+      const rows = await db
+        .select({
+          agentId: activityLog.agentId,
+          agentName: agents.name,
+          count: sql<number>`count(*)::int`,
+          latestAction: sql<string>`(array_agg(${activityLog.action} ORDER BY ${activityLog.createdAt} DESC))[1]`,
+          latestAt: sql<Date>`max(${activityLog.createdAt})`,
+        })
+        .from(activityLog)
+        .innerJoin(agents, eq(agents.id, activityLog.agentId))
+        .where(
+          and(
+            inArray(activityLog.companyId, companyIds),
+            eq(activityLog.actorType, "agent"),
+            gte(activityLog.createdAt, since),
+          ),
+        )
+        .groupBy(activityLog.agentId, agents.name)
+        .orderBy(desc(sql`max(${activityLog.createdAt})`));
+
+      return rows
+        .filter((row) => !!row.agentName)
+        .map((row) => ({
+          agentName: row.agentName,
+          summary:
+            row.count > 1
+              ? `${row.count} updates (latest: ${row.latestAction})`
+              : row.latestAction,
+        }));
+    },
+  };
+}
+
+/**
+ * Wraps the existing Resend wrapper. Failures are caught + logged inside
+ * sendEmail (it never throws), but we still surface here so callers can
+ * react if needed; today the heartbeatDigest service ignores per-message
+ * failures and continues with the next user.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function digestEmailAdapter() {
+  return {
+    send: async (msg: { to: string; subject: string; body: string }): Promise<void> => {
+      const result = await sendEmail({
+        to: msg.to,
+        subject: msg.subject,
+        text: msg.body,
+        html: `<pre style="font-family: -apple-system, system-ui, sans-serif; white-space: pre-wrap;">${escapeHtml(msg.body)}</pre>`,
+      });
+      if (result.status !== "sent") {
+        logger.warn(
+          { to: msg.to, status: result.status, error: result.error },
+          "[digest] heartbeat digest email not sent",
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Wires the never-invoked `heartbeatDigest` service into the daily scheduler in `server/src/index.ts`
- Adds three thin DB/email adapters that satisfy the service's `Deps` interface
- Mirrors the `billingReconcile` (#152) pattern verbatim — same dynamic import, same error swallowing, same SIGTERM cleanup

Closes #207.

## Behavior

| Env | Effect |
|---|---|
| `AGENTDASH_DIGEST_ENABLED=true` + `RESEND_API_KEY=…` | Scheduler runs every 24h |
| `AGENTDASH_DIGEST_ENABLED` unset | Skipped, logs reason |
| `RESEND_API_KEY` unset | Skipped (avoids per-user log spam from no-op email sends) |
| `AGENTDASH_DIGEST_INTERVAL_MS=N` | Override cadence (for tests / manual exercise) |

## Adapters
- **`digestUserAdapter`** — verified-email board users with at least one active company membership
- **`digestActivityAdapter`** — last-24h `actorType="agent"` activity from `activity_log` scoped to companies the user belongs to, grouped per-agent (count + latest action)
- **`digestEmailAdapter`** — wraps existing `sendEmail()` (Resend); failures logged, never rethrown

## Test plan
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` clean (after `pnpm --filter @paperclipai/plugin-sdk build`)
- [x] Existing `heartbeat-digest.test.ts` still passes (service untouched)
- [x] Scheduler skips correctly when env unset (visible in logs)
- [ ] Manual smoke: set both env vars locally, generate fake activity row, observe email firing

## Out of scope (per #207)
- Per-user timezone targeting (`authUsers` has no timezone column yet — v1 ticks once per UTC day)
- HTML email template polish (uses `<pre>` wrapper of the plain-text body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)