### PR TITLE
feat(onboarding): lift /revise-plan 501 stub, wire inline revision UI (#210)

### DIFF
--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -18,6 +18,8 @@ import { unauthorized, badRequest, notFound } from "../errors.js";
 import { SingleCompanyInstallationError } from "../services/companies.js";
 import { crystallizeAndAdvanceCos } from "../services/deep-interview-crystallize.js";
 import { materializeOnboardingGoals } from "../services/materialize-onboarding-goals.js";
+import { dispatchLLM } from "../services/dispatch-llm.js";
+import { parseTrailer } from "../services/cos-replier.js";
 import { logger } from "../middleware/logger.js";
 import {
   FIXED_QUESTIONS,
@@ -329,16 +331,140 @@ ${kpis || "- (none captured)"}
   });
 
   // POST /api/onboarding/revise-plan
-  // Phase F (revision loop) is deferred — see
-  // docs/superpowers/specs/2026-05-04-cos-onboarding-conversation-design.md.
-  // Stub returns 501 so the UI's "Let me revise" button has a wired target.
+  // Phase 3 of the CoS-onboarding-conversation spec: the user pushes back
+  // on the latest plan; CoS rewrites the plan to incorporate the feedback
+  // and posts a new agent_plan_proposal_v1 card.
+  //
+  // Closes #210. The user's revision text can be free-form ("drop the QA,
+  // swap finance for marketing"); we frame it as a delta on the existing
+  // plan rather than starting from scratch so the LLM preserves the parts
+  // that weren't called out.
   router.post("/revise-plan", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {
       throw unauthorized("Sign-in required");
     }
-    res.status(501).json({
-      error: "not_implemented",
-      message: "Plan revision loop is not implemented yet (Phase F).",
+    const { conversationId, revisionText } = req.body as {
+      conversationId?: string;
+      revisionText?: string;
+    };
+    if (!conversationId || typeof conversationId !== "string") {
+      throw badRequest("conversationId required");
+    }
+    if (!revisionText || typeof revisionText !== "string" || !revisionText.trim()) {
+      throw badRequest("revisionText required");
+    }
+
+    const convoRows = await db
+      .select()
+      .from(assistantConversations)
+      .where(eq(assistantConversations.id, conversationId));
+    const convo = convoRows[0];
+    if (!convo) throw notFound("Conversation not found");
+    const companyId = convo.companyId;
+
+    // Find the latest plan card. Anchoring on the most recent one lets the
+    // user iterate N times — each revision builds on the previous proposal.
+    const planRows = await db
+      .select()
+      .from(assistantMessages)
+      .where(
+        and(
+          eq(assistantMessages.conversationId, conversationId),
+          eq(assistantMessages.cardKind, "agent_plan_proposal_v1"),
+        ),
+      )
+      .orderBy(desc(assistantMessages.createdAt))
+      .limit(1);
+    const planMsg = planRows[0];
+    if (!planMsg) throw notFound("No plan card found to revise");
+    const priorPayload = planMsg.cardPayload as AgentPlanProposalV1Payload | null;
+    if (!priorPayload || !Array.isArray(priorPayload.agents)) {
+      throw badRequest("Latest plan card has no agents payload to revise");
+    }
+
+    // CoS authors all messages here (matches the rest of onboarding-v2).
+    const allAgents = await agents.list(companyId);
+    const cos = allAgents.find((a: any) => a.role === "chief_of_staff") ?? null;
+    if (!cos) throw notFound("No Chief of Staff agent found for this company");
+
+    // Compose the revision prompt. The model gets the prior plan as JSON
+    // plus the user's free-text delta, and is told to emit a new
+    // agent_plan_proposal_v1 payload that integrates the feedback.
+    const priorPlanJson = JSON.stringify(priorPayload, null, 2);
+    const userRevision = revisionText.trim();
+    const system = `You are the Chief of Staff for AgentDash. The user reviewed a plan you proposed and wants to revise it. Apply their feedback as a DELTA on the prior plan — preserve parts they did not call out, change only what they pushed back on.
+
+PRIOR PLAN (as JSON):
+${priorPlanJson}
+
+USER FEEDBACK:
+${userRevision}
+
+In the visible body (before the JSON), give a SHORT one-line preamble like "Updated based on your feedback:" followed by a 1-3 sentence summary of what you changed and why. Then list the revised team in one line per agent. End with "Want me to set them up, or revise again?"
+
+Your reply MUST end with a fenced JSON block emitting an agent_plan_proposal_v1 payload:
+
+\`\`\`json
+{
+  "plan": {
+    "rationale": "...",
+    "agents": [
+      { "role": "engineering_lead", "name": "Ellie", "adapterType": "claude_local", "responsibilities": ["..."], "kpis": ["..."] }
+    ],
+    "alignmentToShortTerm": "...",
+    "alignmentToLongTerm": "..."
+  }
+}
+\`\`\`
+
+Keep the same JSON shape as the prior plan. Use 2-5 agents. Each agent's adapterType must be one of: "claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local".
+
+No greetings. No markdown headings outside the JSON block.`;
+
+    // We don't need conversation history here — the prior plan IS the
+    // context. Pass a single user message with the revision so the model
+    // doesn't have to scan back through chat for it.
+    const text = await dispatchLLM({
+      system,
+      messages: [{ role: "user", content: userRevision }],
+    });
+    const { body, trailer } = parseTrailer(text);
+    const visibleBody = body.length > 0 ? body : "Updated based on your feedback.";
+
+    const newPlan = (trailer as { plan?: unknown })?.plan;
+    if (!isAgentPlanPayload(newPlan)) {
+      logger.warn(
+        { conversationId, raw: text.slice(0, 300) },
+        "[revise-plan] LLM reply missing or malformed plan payload",
+      );
+      throw Object.assign(
+        new Error(
+          "Could not revise the plan; the model returned an unparseable response. Try rephrasing your feedback.",
+        ),
+        { statusCode: 502 },
+      );
+    }
+
+    // Post the visible preamble FIRST, then the new card. Mirrors the
+    // cos-replier plan-emit ordering so the timeline reads naturally.
+    await conversations.postMessage({
+      conversationId,
+      authorKind: "agent",
+      authorId: cos.id,
+      body: visibleBody,
+    });
+    const cardMsg = await conversations.postMessage({
+      conversationId,
+      authorKind: "agent",
+      authorId: cos.id,
+      body: "",
+      cardKind: "agent_plan_proposal_v1",
+      cardPayload: newPlan as unknown as Record<string, unknown>,
+    });
+
+    res.json({
+      cardMessageId: cardMsg?.id ?? null,
+      plan: newPlan,
     });
   });
 
@@ -422,4 +548,19 @@ async function defaultStubProposer(_transcript: InterviewTurn[]) {
     rationale:
       "Stub fallback proposal — wire real LLM when ANTHROPIC_API_KEY is configured.",
   };
+}
+
+// Local type guard for the revise-plan handler. Mirrors the unexported
+// isPlanPayload in cos-replier.ts; kept inline to avoid widening that
+// module's public surface for a single caller.
+function isAgentPlanPayload(value: unknown): value is AgentPlanProposalV1Payload {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.rationale === "string" &&
+    Array.isArray(v.agents) &&
+    v.agents.length > 0 &&
+    typeof v.alignmentToShortTerm === "string" &&
+    typeof v.alignmentToLongTerm === "string"
+  );
 }

--- a/ui/src/api/onboarding.ts
+++ b/ui/src/api/onboarding.ts
@@ -58,9 +58,14 @@ export const onboardingApi = {
       "/onboarding/confirm-plan",
       input,
     ),
-  // Phase F (revision loop) is not implemented yet — this returns 501.
+  // #210: Phase F revision loop — server posts the revised plan card via
+  // postMessage (clients receive it over WS) and returns the new card's
+  // payload + message ID for the caller's convenience.
   revisePlan: (input: { conversationId: string; revisionText: string }) =>
-    api.post<{ error: string; message: string }>("/onboarding/revise-plan", input),
+    api.post<{ cardMessageId: string | null; plan: unknown }>(
+      "/onboarding/revise-plan",
+      input,
+    ),
   // AgentDash (Phase F): the SPA calls this when the deep-interview engine
   // emits its `[deep-interview-ready]` marker on `/assess?onboarding=1`. The
   // server crystallizes the spec, advances the CoS phase, and returns the

--- a/ui/src/components/cards/AgentPlanProposal.tsx
+++ b/ui/src/components/cards/AgentPlanProposal.tsx
@@ -1,5 +1,6 @@
-// AgentDash: chat substrate card — CoS plan proposal (Phase C).
+// AgentDash: chat substrate card — CoS plan proposal (Phase C + #210 revision).
 // See docs/superpowers/specs/2026-05-04-cos-onboarding-conversation-design.md.
+import { useState } from "react";
 import type { AgentPlanProposalV1Payload } from "@paperclipai/shared";
 
 export function AgentPlanProposal({
@@ -9,8 +10,27 @@ export function AgentPlanProposal({
 }: {
   payload: AgentPlanProposalV1Payload;
   onConfirm: () => void;
-  onRevise: () => void;
+  // #210: accept a free-text delta so the server can produce a revised plan
+  // instead of just acknowledging "reject". Callers that don't care about
+  // text can still pass a no-op.
+  onRevise: (revisionText: string) => void;
 }) {
+  const [reviseOpen, setReviseOpen] = useState(false);
+  const [revisionText, setRevisionText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const trimmed = revisionText.trim();
+
+  function submit() {
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    onRevise(trimmed);
+    // Optimistic: parent emits a new plan card via WS, so this card stays
+    // visible but the new one will appear. Reset our local state so a
+    // second revise attempt on the SAME card (rare) starts fresh.
+    setReviseOpen(false);
+    setRevisionText("");
+    setSubmitting(false);
+  }
   const agents = Array.isArray(payload?.agents) ? payload.agents : [];
   return (
     <div
@@ -49,20 +69,64 @@ export function AgentPlanProposal({
         </div>
       </div>
 
-      <div className="mt-5 flex gap-2">
-        <button
-          className="bg-accent-500 text-text-inverse px-4 py-2 rounded-md text-sm font-medium hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
-          onClick={onConfirm}
-        >
-          Set it up
-        </button>
-        <button
-          className="border border-border-soft px-4 py-2 rounded-md text-sm font-medium text-text-primary hover:bg-surface-sunken transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
-          onClick={onRevise}
-        >
-          Let me revise
-        </button>
-      </div>
+      {!reviseOpen ? (
+        <div className="mt-5 flex gap-2">
+          <button
+            className="bg-accent-500 text-text-inverse px-4 py-2 rounded-md text-sm font-medium hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
+            onClick={onConfirm}
+          >
+            Set it up
+          </button>
+          <button
+            className="border border-border-soft px-4 py-2 rounded-md text-sm font-medium text-text-primary hover:bg-surface-sunken transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
+            onClick={() => setReviseOpen(true)}
+          >
+            Let me revise
+          </button>
+        </div>
+      ) : (
+        <div className="mt-5 flex flex-col gap-2" data-testid="plan-revise-form">
+          <textarea
+            value={revisionText}
+            onChange={(e) => setRevisionText(e.target.value)}
+            placeholder="Tell me what to change — e.g. 'drop the QA, swap finance for marketing, the eng lead should be Codex'"
+            className="w-full min-h-[88px] border border-border-soft rounded-md px-3 py-2 text-sm bg-surface-base text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:border-accent-500 focus-visible:ring-2 focus-visible:ring-accent-200 resize-y"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                submit();
+              }
+              if (e.key === "Escape") {
+                setReviseOpen(false);
+                setRevisionText("");
+              }
+            }}
+            autoFocus
+          />
+          <div className="flex gap-2 items-center">
+            <button
+              className="bg-accent-500 text-text-inverse px-4 py-2 rounded-md text-sm font-medium hover:bg-accent-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={submit}
+              disabled={!trimmed || submitting}
+            >
+              {submitting ? "Revising…" : "Send revision"}
+            </button>
+            <button
+              className="border border-border-soft px-4 py-2 rounded-md text-sm font-medium text-text-primary hover:bg-surface-sunken transition-colors"
+              onClick={() => {
+                setReviseOpen(false);
+                setRevisionText("");
+              }}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <span className="text-xs text-text-tertiary ml-auto">
+              ⌘/Ctrl + Enter to send
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/cards/index.tsx
+++ b/ui/src/components/cards/index.tsx
@@ -51,7 +51,7 @@ export function CardRenderer({
         <AgentPlanProposal
           payload={payload as any}
           onConfirm={context.onProposalConfirm ?? (() => {})}
-          onRevise={() => context.onProposalReject?.()}
+          onRevise={(text) => context.onProposalReject?.(text)}
         />
       );
     // AgentDash: goals-eval-hitl


### PR DESCRIPTION
## Summary

Phase 3 of the CoS-onboarding-conversation spec. The user reviews a proposed plan card, types free-text feedback ("drop the QA, swap finance for marketing, the eng lead should be Codex"), and CoS posts a revised \`agent_plan_proposal_v1\` card.

Closes #210.

### Server side
- \`POST /api/onboarding/revise-plan\` replaces the 501 stub
- Anchors on the most recent plan card in the conversation (lets the user iterate N times)
- Composes a revision prompt that gives the LLM the prior plan as JSON + the user's delta, and demands the same payload shape back
- Calls \`dispatchLLM\`, parses the fenced JSON via the existing \`parseTrailer\` helper from \`cos-replier\`
- Type-guards the result with \`isAgentPlanPayload\`; throws 502 on malformed LLM output (same shape as #162) so the UI can offer a retry
- Posts the visible preamble first, then the new card — same ordering as \`cos-replier\`'s plan-emit path

### UI side
- \`AgentPlanProposal\` flips to an inline textarea on "Let me revise" instead of firing the callback immediately
- Cmd/Ctrl+Enter to send, Esc to cancel
- \`onRevise\` callback signature changes from \`() => void\` to \`(text: string) => void\`
- \`cards/index.tsx\` plumbs the text through to \`context.onProposalReject\`
- \`onboarding.ts\` API client return type updated from the legacy 501 error shape to \`{ cardMessageId, plan }\`

## Test plan
- [x] Server tsc clean
- [x] UI tsc clean
- [ ] Manual: open a CoS conversation that already has a plan card → click "Let me revise" → type "drop the QA agent" → see a new card appear with QA removed
- [ ] Malformed-LLM path: temporarily stub \`dispatchLLM\` to return unparseable text → verify 502 surfaces in UI

## Out of scope (per #210)
- Versioning / diffing prior proposals (we just append the new card; revision history is implicit in the timeline)
- Inline structured editing of the plan (free-text revision only in v1)
- Cancel-revision-mid-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)