### PR TITLE
feat(ui): connection self-healing — proactive health check + offline overlay

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -59,6 +59,7 @@ import { InviteLandingPage } from "./pages/InviteLanding";
 import { JoinRequestQueue } from "./pages/JoinRequestQueue";
 import { NotFoundPage } from "./pages/NotFound";
 import { CoSConversation } from "./pages/CoSConversation";
+import { ServerUnreachableOverlay } from "@/components/ServerUnreachableOverlay";
 // AgentDash: marketing pages — render on cream/light surface, no CloudAccessGate.
 import { Landing as MarketingLanding } from "./marketing/pages/Landing";
 import { Consulting as MarketingConsulting } from "./marketing/pages/Consulting";
@@ -351,6 +352,7 @@ export function App() {
         </Route>
       </Routes>
       <OnboardingWizard />
+      <ServerUnreachableOverlay />
     </>
   );
 }

--- a/ui/src/components/ConnectionStatus.tsx
+++ b/ui/src/components/ConnectionStatus.tsx
@@ -1,0 +1,35 @@
+import { useServerHealth } from "@/hooks/useServerHealth";
+
+export type ConnectionState = "connected" | "degraded" | "offline";
+
+export function ConnectionStatus() {
+  const { reachability, isOnline } = useServerHealth();
+
+  const state: ConnectionState =
+    !isOnline || reachability === "unreachable"
+      ? "offline"
+      : reachability === "checking"
+        ? "degraded"
+        : "connected";
+
+  const color =
+    state === "connected"
+      ? "bg-green-500"
+      : state === "degraded"
+        ? "bg-yellow-500"
+        : "bg-red-500";
+
+  const label =
+    state === "connected"
+      ? "Connected"
+      : state === "degraded"
+        ? "Checking…"
+        : "Offline";
+
+  return (
+    <div className="flex items-center gap-1.5" title={label}>
+      <span className={`size-2 rounded-full ${color} shrink-0`} />
+      <span className="text-xs text-muted-foreground hidden sm:inline">{label}</span>
+    </div>
+  );
+}

--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ApiError } from "@/api/client";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -36,6 +37,49 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback;
 
+      const error = this.state.error;
+      // PR #220: ApiError(status=0) is the "Unable to reach the server" path
+      // emitted by api/client.ts when fetch itself throws (network unreachable,
+      // CORS, server down). Render a softer spinner state — the server is
+      // probably coming back up, not the code being broken.
+      const isServerUnreachable = error instanceof ApiError && error.status === 0;
+
+      if (isServerUnreachable) {
+        return (
+          <div
+            role="alert"
+            className="flex flex-col items-center justify-center min-h-screen p-8"
+          >
+            <div className="max-w-xl w-full text-center">
+              <div className="mb-6 flex justify-center">
+                <div className="relative size-12">
+                  <div className="absolute inset-0 rounded-full border-4 border-muted" />
+                  <div className="absolute inset-0 rounded-full border-4 border-primary border-t-transparent animate-spin" />
+                </div>
+              </div>
+              <h1 className="text-2xl font-semibold mb-3">Unable to reach the server</h1>
+              <p className="text-muted-foreground mb-6">
+                {error.message || "Check your connection and try again."}
+              </p>
+              <div className="flex gap-2 justify-center">
+                <button
+                  onClick={this.handleReload}
+                  className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                >
+                  Reload
+                </button>
+                <button
+                  onClick={this.handleReset}
+                  className="px-4 py-2 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                >
+                  Try again
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div
           role="alert"
@@ -60,15 +104,15 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
                 Try again
               </button>
             </div>
-            {this.state.error && (
+            {error && (
               <details className="mt-8 text-left">
                 <summary className="cursor-pointer text-sm text-muted-foreground">
                   Error details
                 </summary>
                 <pre className="mt-2 p-4 bg-muted rounded-md overflow-auto text-xs text-left">
-                  {this.state.error.message}
+                  {error.message}
                   {"\n"}
-                  {this.state.error.stack}
+                  {error.stack}
                 </pre>
               </details>
             )}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import { MobileBottomNav } from "./MobileBottomNav";
 import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
 import { SidebarAccountMenu } from "./SidebarAccountMenu";
+import { ConnectionStatus } from "./ConnectionStatus";
 import { useDialogActions } from "../context/DialogContext";
 import { GeneralSettingsProvider } from "../context/GeneralSettingsContext";
 import { usePanel } from "../context/PanelContext";
@@ -432,6 +433,10 @@ export function Layout() {
       <NewAgentDialog />
       <KeyboardShortcutsCheatsheet open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
       <ToastViewport />
+      {/* Fixed connection status indicator — bottom-right, always visible */}
+      <div className="fixed bottom-4 right-4 z-50">
+        <ConnectionStatus />
+      </div>
       </div>
     </GeneralSettingsProvider>
   );

--- a/ui/src/components/ServerUnreachableOverlay.tsx
+++ b/ui/src/components/ServerUnreachableOverlay.tsx
@@ -1,0 +1,62 @@
+import { useServerHealth } from "@/hooks/useServerHealth";
+
+export function ServerUnreachableOverlay() {
+  const { reachability, isOnline } = useServerHealth();
+
+  if (reachability === "reachable") return null;
+
+  const isBrowserOffline = !isOnline;
+  const message = isBrowserOffline
+    ? "You're offline — check your internet connection."
+    : "Unable to reach the server — it may be temporarily unavailable.";
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="flex flex-col items-center gap-6 max-w-sm text-center px-6">
+        {/* Animated reconnecting spinner */}
+        <div className="relative size-12">
+          <div className="absolute inset-0 rounded-full border-4 border-muted" />
+          <div className="absolute inset-0 rounded-full border-4 border-primary border-t-transparent animate-spin" />
+          {reachability === "unreachable" && (
+            <div className="absolute inset-2 rounded-full bg-red-500/10 flex items-center justify-center">
+              <span className="size-2 rounded-full bg-red-500 animate-pulse" />
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">
+            {isBrowserOffline ? "You're Offline" : "Connection Lost"}
+          </h2>
+          <p className="text-sm text-muted-foreground">{message}</p>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-sm font-medium"
+          >
+            Reload page
+          </button>
+          {reachability === "unreachable" && (
+            <button
+              onClick={() => {
+                // Force refetch all queries to trigger a retry
+                window.location.reload();
+              }}
+              className="px-4 py-2 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors text-sm"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+
+        {reachability === "unreachable" && (
+          <p className="text-xs text-muted-foreground">
+            If this persists, the server may be restarting. Try again in a moment.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/hooks/useServerHealth.ts
+++ b/ui/src/hooks/useServerHealth.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+const HEALTH_POLL_INTERVAL_MS = 30_000;
+
+export type ServerReachability = "reachable" | "unreachable" | "checking";
+
+interface ServerHealth {
+  reachability: ServerReachability;
+  lastCheck: Date | null;
+  isOnline: boolean; // browser navigator.onLine
+}
+
+async function checkHealth(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch("/api/health", {
+      signal: controller.signal,
+      credentials: "include",
+    });
+    clearTimeout(timeout);
+    return res.ok;
+  } catch {
+    clearTimeout(timeout);
+    return false;
+  }
+}
+
+export function useServerHealth(): ServerHealth {
+  const [isOnline, setIsOnline] = useState(typeof navigator !== "undefined" ? navigator.onLine : true);
+  const unreachableConsecutiveRef = useRef(0);
+
+  const { data: isReachable, isFetching } = useQuery({
+    queryKey: ["serverHealth"],
+    queryFn: checkHealth,
+    refetchInterval: HEALTH_POLL_INTERVAL_MS,
+    retry: false,
+    staleTime: HEALTH_POLL_INTERVAL_MS - 1_000,
+  });
+
+  // Track consecutive unreachable results to avoid flapping on transient failures
+  const reachability: ServerReachability =
+    isFetching || unreachableConsecutiveRef.current > 0
+      ? "checking"
+      : isReachable
+        ? "reachable"
+        : "unreachable";
+
+  // Update consecutive counter
+  const wasChecking = useRef(false);
+  if (wasChecking.current && !isFetching) {
+    if (isReachable) {
+      unreachableConsecutiveRef.current = 0;
+    } else {
+      unreachableConsecutiveRef.current++;
+    }
+  }
+  wasChecking.current = isFetching;
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return {
+    reachability,
+    lastCheck: isReachable !== undefined ? new Date() : null,
+    isOnline,
+  };
+}


### PR DESCRIPTION
## Summary

Three-layer self-healing system that prevents "Failed to fetch" from ever reaching users:

1. **`useServerHealth` hook** — polls `/api/health` every 30s via `useQuery` + listens to browser `navigator.onLine/offline` events. Tracks consecutive unreachable results to avoid flapping.

2. **`ConnectionStatus` indicator** — fixed bottom-right badge (green/amber/red) always visible on every page so users always know connection state.

3. **`ServerUnreachableOverlay`** — full-screen overlay when server is unreachable or browser is offline. Shows animated spinner + friendly message + Reload/Retry buttons. Covers all routes, including unauthenticated pages.

4. **`ErrorBoundary` improvement** — special-cases `ApiError(status=0)` (the "Unable to reach the server" error from `api/client.ts`) to render the animated spinner path instead of the generic "Something went wrong" fallback.

## Test plan

- [x] `pnpm --filter @paperclipai/ui typecheck` — passes
- [ ] Verify ConnectionStatus badge shows "Connected" when server is reachable
- [ ] Verify overlay appears when server is down (stop dev server)
- [ ] Verify ErrorBoundary renders friendly message for ApiError status=0
- [ ] Verify browser offline mode triggers the overlay

## Related

Fixes the "Failed to fetch" UX issue surfaced during v2 development. The backend fix (ApiError conversion) was in #214; this completes the UI layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)