### PR TITLE
fix(run-healer): route diagnose through dispatchLLM (#217)

### DIFF
--- a/server/src/services/run-healer/service.ts
+++ b/server/src/services/run-healer/service.ts
@@ -19,7 +19,7 @@ import { logger } from "../../middleware/logger.js";
 import { redactSensitiveText } from "../../redaction.js";
 import { buildHealDiagnosisPrompt, parseHealDiagnosis, type HealDiagnosis, type DiagnosisCategory } from "./diagnosis.js";
 import { executeHealFix, type HealFixResult } from "./fixer.js";
-import { anthropicLLM } from "../anthropic-llm.js";
+import { dispatchLLM } from "../dispatch-llm.js";
 
 // ---------- config ----------
 
@@ -265,14 +265,22 @@ export function runHealerService(db: Db) {
     });
 
     try {
-      const response = await anthropicLLM({
+      // Closes #217: route diagnosis through dispatchLLM so the run healer
+      // uses the user's configured adapter (AGENTDASH_DEFAULT_ADAPTER) rather
+      // than hard-coding Anthropic. dispatchLLM falls back to the API stub
+      // when no provider is configured, and the parser drops malformed JSON
+      // to UNKNOWN below — both safe for the healer's bounded surface.
+      const response = await dispatchLLM({
         system: "You are a run-healing assistant. Analyze the run context and respond with JSON only.",
         messages: [{ role: "user" as const, content: prompt }],
       });
 
       const diagnosis = parseHealDiagnosis(response);
       if (!diagnosis) {
-        logger.warn({ runId: run.id }, "run_healer: failed to parse LLM diagnosis response");
+        logger.warn(
+          { runId: run.id, rawHead: response.slice(0, 200) },
+          "run_healer: failed to parse LLM diagnosis response — skipping (no fix applied)",
+        );
         return null;
       }
       return diagnosis;


### PR DESCRIPTION
## Summary
- Run healer's \`diagnose()\` was calling \`anthropicLLM\` directly, hard-coding the Anthropic API path
- Switching to \`dispatchLLM\` makes diagnosis respect \`AGENTDASH_DEFAULT_ADAPTER\` so instances on hermes_local / claude_local / etc actually work
- One-line swap (plus a small log improvement). Tsc clean.

Closes #217.

## Why this is safe
- \`dispatchLLM\` falls back to a stub reply when no provider is configured
- The existing \`parseHealDiagnosis\` returns \`null\` on unparseable LLM output
- The healer already treats \`null\` as "skip — no fix applied" (\`service.ts:303\`), so the worst-case path is the same as before: log + skip, no destructive action

## Test plan
- [x] Server tsc clean
- [ ] Manual: trigger a failed run on a Hermes-configured instance → verify \`/api/health\` logs show \`run_healer: diagnose ...\` via dispatchLLM (not the Anthropic path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)