### PR TITLE
fix: #149 Hermes adapter: checkApiKeys missing MINIMAX_API_KEY

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "preflight:workspace-links": "node cli/node_modules/tsx/dist/cli.mjs scripts/ensure-workspace-package-links.ts",
+    "postinstall": "node server/scripts/patch-hermes-adapter.mjs",
     "install-cli": "bash scripts/install-cli.sh",
     "dev": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch",
     "dev:watch": "pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch",


### PR DESCRIPTION
## Thinking Path

Issue #149 reported that the Hermes adapter's `checkApiKeys` function only checks for 4 API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, ZAI_API_KEY), but Hermes itself supports many more providers including MINIMAX_API_KEY, MINIMAX_CN_API_KEY, KIMI_API_KEY, DEEPSEEK_API_KEY, VERTEX_API_KEY, GEMINI_API_KEY, and AZURE_OPENAI_API_KEY.

The fix adds a `postinstall` hook that runs `patch-hermes-adapter.mjs` to patch the installed `hermes-paperclip-adapter` package to include all supported provider API keys in the environment check.

## What Changed

- Added `postinstall` script to `package.json` that runs `node server/scripts/patch-hermes-adapter.mjs` after `pnpm install`
- The patch script modifies `hermes-paperclip-adapter`'s `checkApiKeys` function to:
  1. Add `hasDeepSeek`, `hasVertex`, `hasGemini`, `hasAzureOpenAI`, `hasMiniMaxCN` variables
  2. Update the no-keys condition to include all new providers
  3. Add providers-found reporting for all new providers
  4. Update the hint message to list all supported API keys

## Verification

- [ ] `pnpm install` runs without error and the postinstall hook executes
- [ ] Patch script confirms files are patched (or already patched)
- [ ] Hermès adapter no longer shows false "No LLM API keys" warning for minimax-cn users

## Risks

- Low: Only adds to existing warning message and patch is idempotent (safe to re-run)
- The `patch-hermes-adapter.mjs` patches node_modules copies which may be overwritten on reinstall

## Model Used

None — human-authored

## Checklist

- [x] Code changes follow the project's coding conventions
- [x] Tests pass (or N/A — no new tests needed)
- [x] Documentation updated (N/A — internal tooling only)
- [x] No breaking changes
