### PR TITLE
fix: #167 check res.writableEnded before res.write in SSE streaming

### DIFF
--- a/server/src/routes/assess.ts
+++ b/server/src/routes/assess.ts
@@ -133,6 +133,7 @@ export function assessRoutes(db: Db) {
               const json = JSON.parse(data);
               if (json.type === "content_block_delta" && json.delta?.text) {
                 fullOutput += json.delta.text;
+                if (res.writableEnded) return;
                 res.write(json.delta.text);
               }
             } catch { /* skip non-JSON lines */ }
@@ -362,6 +363,7 @@ export function assessRoutes(db: Db) {
             const json = JSON.parse(data);
             if (json.type === "content_block_delta" && json.delta?.text) {
               fullOutput += json.delta.text;
+              if (res.writableEnded) return;
               res.write(json.delta.text);
             }
           } catch { /* skip non-JSON lines */ }


### PR DESCRIPTION
## Thinking Path

1. GitHub issue #167 reported that `server/src/routes/assess.ts` writes to `res` in SSE streaming loops without checking if headers were already sent.
2. Two locations were identified: line ~136 (inside `pump()` async function) and line ~365 (inside a `while` loop).
3. Fix: guard each `res.write()` call with `if (res.writableEnded) return;`.

## What Changed

- `server/src/routes/assess.ts`: Added `if (res.writableEnded) return;` before each SSE `res.write()` call in the two streaming loops (lines 136 and 366).

## Verification

- `pnpm test` passes (existing tests).
- Manual review: the guards prevent "write after end" errors when error handling runs mid-stream.

## Risks

- Low: defensive check only, no behavior change when streaming is healthy.

## Model Used

MiniMax-M2.7-highspeed — assisted with diagnosis and fix.

## Checklist

- [x] Behavior matches SPEC-implementation.md
- [x] Typecheck passes
- [x] Tests pass
- [x] PR description follows template