### PR TITLE
feat(ci): Hermes guardrails — PR audit + prompt drift check + branch-protection doc (#257)

### DIFF
--- a/.github/workflows/hermes-pr-audit.yml
+++ b/.github/workflows/hermes-pr-audit.yml
@@ -1,0 +1,43 @@
+name: Hermes PR Audit
+
+# Enforces the directives in docs/agents/hermes-prompt.md on every PR.
+# The audit runs only when at least one commit in the PR is Hermes-authored
+# (commit author email matches Hermes identity, or commit body carries a
+# `Co-Authored-By: Hermes` trailer). Human/manual PRs are a no-op.
+#
+# Failure modes:
+#   D1 — scaffolding text in source / new route not wired into app.ts
+#   D2 — sensitive surface (auth, access, orchestrator, adapters, billing) touched
+#        without a test diff in the same PR
+#   D4 — patches/*.patch with absolute developer-local paths in headers
+#   D5 — PR body missing "## Regression suite" heading with non-empty content
+#
+# Bypass: include `[skip-hermes-audit]` (case-insensitive) in PR title or body.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: hermes-pr-audit-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Hermes PR audit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/ci/check-hermes-pr-audit.mjs

--- a/.github/workflows/hermes-prompt-drift.yml
+++ b/.github/workflows/hermes-prompt-drift.yml
@@ -1,0 +1,35 @@
+name: Hermes Prompt Drift Check
+
+# Asserts that when docs/agents/hermes-prompt.md is edited in a PR, the
+# corresponding runtime surface(s) are also edited (or the PR carries the
+# `[no-runtime-sync]` bypass flag). This closes the Directive-1 self-violation
+# called out in #257: the prompt claims to be synced to runtime surfaces, but
+# nothing enforced the claim.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: hermes-prompt-drift-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Hermes prompt drift check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/ci/check-hermes-prompt-drift.mjs

--- a/doc/BRANCH-PROTECTION.md
+++ b/doc/BRANCH-PROTECTION.md
@@ -1,0 +1,156 @@
+# Branch protection — operator setup
+
+**Status:** Required for full Hermes guardrails (issue #257)
+**Owner:** repo admin
+**Audience:** human operator of `thetangstr/agentdash`
+
+---
+
+## Why
+
+The CI lanes added in this PR (`hermes-pr-audit`, `hermes-prompt-drift`) enforce
+Hermes's directives on PRs, but PR checks **only fire when a PR is opened**.
+Without server-side branch protection, anyone (including Hermes itself) can
+bypass the whole system by pushing directly to `main`. That is exactly the
+pattern #254 / #257 were filed to stop.
+
+This doc is the one-time admin step that turns the policy into a wall.
+
+## What to enable
+
+GitHub branch protection on `main` with:
+
+- ✅ Require a pull request before merging
+- ✅ Require status checks to pass before merging
+  - Required checks (mark them required after they've run at least once):
+    - `Hermes PR Audit / audit`
+    - `Hermes Prompt Drift Check / drift`
+    - `Agents MD Drift Check / check`
+    - The existing `pr` / `e2e` lanes you care about
+- ✅ Require branches to be up to date before merging (catches `main` advancing during review)
+- ✅ Do not allow bypassing the above settings
+- ✅ Restrict who can push to matching branches → empty list (PR-only)
+
+Optional but recommended:
+- ✅ Require linear history (avoids merge commits on main)
+- ✅ Require signed commits (only if you're already on a signed-commit workflow)
+- ❌ Require approvals (1+ reviewer) — set to 0 for now, since Claude/Hermes self-merge after CI green per the autonomous-ship window memo
+
+## How (CLI, two commands)
+
+You need a token with admin rights on the repo (the default `gh` token has
+this if you're signed in as the repo owner).
+
+### 1. Enable protection
+
+```sh
+gh api \
+  -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  repos/thetangstr/agentdash/branches/main/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "audit",
+      "drift",
+      "check"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+EOF
+```
+
+`enforce_admins: true` is the critical line — it stops you (and Hermes) from
+slipping a direct push through admin privilege.
+
+The `contexts` list names the **check JOB names** (not workflow names). The
+Hermes audit workflow's job is named `audit` (see `.github/workflows/hermes-pr-audit.yml`),
+the drift workflow's job is named `drift`, and the existing agents-md drift
+job is named `check`. If you add more required workflows, append their job
+names here.
+
+### 2. Verify
+
+```sh
+gh api repos/thetangstr/agentdash/branches/main/protection | \
+  jq '{
+    required_status_checks: .required_status_checks.contexts,
+    enforce_admins: .enforce_admins.enabled,
+    require_pr: (.required_pull_request_reviews | has("required_approving_review_count")),
+    linear_history: .required_linear_history.enabled
+  }'
+```
+
+Expected:
+
+```json
+{
+  "required_status_checks": ["audit", "drift", "check"],
+  "enforce_admins": true,
+  "require_pr": true,
+  "linear_history": true
+}
+```
+
+### 3. Test (optional, recommended)
+
+In a new branch, push a commit that opens a PR with no `## Regression suite`
+heading in the body. Confirm the merge button is disabled until the
+`audit` check fails out, then close the PR. Then try to `git push origin main`
+directly — the push should be rejected with a branch-protection error.
+
+## Bypass procedure
+
+When you _genuinely_ need to push directly to `main` (e.g. emergency revert
+of a broken merge):
+
+```sh
+# Temporarily disable:
+gh api -X DELETE repos/thetangstr/agentdash/branches/main/protection
+
+# Push your fix:
+git push origin main
+
+# Re-enable:
+gh api -X PUT ... # rerun the command from step 1
+```
+
+Every bypass should be logged in the PR or incident report it relates to.
+If you find yourself bypassing more than once a month, something is wrong
+with the audit lane configuration — file an issue.
+
+## Why these specific settings
+
+| Setting | Why |
+|---|---|
+| `enforce_admins: true` | Without this, the owner (and Hermes via the owner's token) bypasses protection. Defeats the entire point. |
+| `required_linear_history: true` | Squash-merge-only matches existing convention. Forbids merge commits, keeps `main` reviewable. |
+| `allow_force_pushes: false` | Force pushes silently rewrite history; never wanted on a protected default branch. |
+| `allow_deletions: false` | Belt-and-suspenders against accidentally `git push origin :main`. |
+| `dismiss_stale_reviews: false` | Required approvals are 0 anyway, so dismissal behavior is moot. Listed for clarity. |
+| `lock_branch: false` | `lock_branch: true` would block ALL changes including PR merges — not what we want. |
+
+## Related
+
+- [`docs/agents/hermes-prompt.md`](../docs/agents/hermes-prompt.md) — the directives this enforces
+- [`.github/workflows/hermes-pr-audit.yml`](../.github/workflows/hermes-pr-audit.yml) — the audit lane
+- [`.github/workflows/hermes-prompt-drift.yml`](../.github/workflows/hermes-prompt-drift.yml) — the drift check
+- [`scripts/ci/check-hermes-pr-audit.mjs`](../scripts/ci/check-hermes-pr-audit.mjs) — the audit logic
+- [`scripts/ci/check-hermes-prompt-drift.mjs`](../scripts/ci/check-hermes-prompt-drift.mjs) — the drift logic
+- Issue [#254](https://github.com/thetangstr/agentdash/issues/254) — original Hermes self-tune brief
+- Issue [#257](https://github.com/thetangstr/agentdash/issues/257) — the meta gap this closes

--- a/docs/agents/hermes-prompt.md
+++ b/docs/agents/hermes-prompt.md
@@ -112,7 +112,7 @@ All 11 reviewed commits (2026-05-03 to 2026-05-05) were direct pushes to `main`.
 ### Git conventions
 
 - Branch from `origin/main`
-- Worktree path: `/Users/maxiaoer/workspace/agentdash_dev`
+- Worktree path: `${HERMES_WORKSPACE_ROOT}` (resolves to the local checkout; set this env var on the Hermes host once at provisioning time)
 - Commit message format: `<type>(<scope>): <short summary>`
 
   Body: issue link, what changed, why, tail of regression suite output

--- a/scripts/ci/check-hermes-pr-audit.mjs
+++ b/scripts/ci/check-hermes-pr-audit.mjs
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+/**
+ * Hermes PR audit — enforces the directives in docs/agents/hermes-prompt.md.
+ *
+ * Mirrors the agents-md drift-check pattern. Runs on every PR; the audit
+ * rules apply only when at least one commit in the PR is Hermes-authored
+ * (commit author email matches the Hermes identity, or commit body carries
+ * a `Co-Authored-By: Hermes` trailer). Manual / human PRs are a no-op.
+ *
+ * Failure modes enforced (each maps to a Hermes directive):
+ *
+ *   D1 (no dead code):
+ *     - No "Copy this file to:" / "Then register in" / similar scaffolding
+ *       strings in committed source files.
+ *     - When a new file appears under server/src/routes/ matching *.ts (not
+ *       test/spec), grep the diff for an import of its exported route
+ *       function in server/src/app.ts. If absent, fail.
+ *
+ *   D2 (test gate on sensitive surfaces):
+ *     - When the diff touches any sensitive path (access/auth/onboarding-
+ *       orchestrator/adapters/requireTier/billing-cap), require at least
+ *       one test file change in the same PR.
+ *
+ *   D4 (no regex node_modules patches; no absolute paths in patches):
+ *     - Any new file under patches/ must use relative a/ b/ paths (no
+ *       /Users/, /home/, /root/ in header).
+ *
+ *   D5 (PR + regression suite output):
+ *     - PR body must contain a "## Regression suite" heading with non-empty
+ *       content beneath it (mirrors the literal flow in hermes-prompt.md).
+ *
+ * Bypass: include `[skip-hermes-audit]` (case-insensitive) in PR title or body.
+ * Bypass is logged loudly so it can't be used silently.
+ *
+ * Inputs (env):
+ *   BASE_SHA                  base commit SHA   (required for diff mode)
+ *   HEAD_SHA                  head commit SHA   (required for diff mode)
+ *   PR_TITLE                  PR title          (optional)
+ *   PR_BODY                   PR body           (optional)
+ *
+ * Inputs (CLI flags, for self-tests; override env):
+ *   --diff <path>             read newline-separated `<status>\t<path>` from file
+ *   --commits <path>          read newline-separated `<author-email>\t<body>` per commit
+ *   --title <string>          override PR_TITLE
+ *   --body <string>           override PR_BODY
+ *
+ * Exit codes:
+ *   0 — pass (Hermes opt-out / not Hermes-authored / all rules satisfied)
+ *   1 — fail (audit found a violation)
+ *   2 — usage / internal error
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BYPASS_FLAG = "[skip-hermes-audit]";
+
+// Commit signals for "this PR contains Hermes work."
+// Match on either the author email or a Co-Authored-By trailer.
+const HERMES_EMAIL_PATTERNS = [
+  /hermes@/i,
+  /@maxiaoers?-mini\.lan/i, // legacy Hermes hostname before identity fix
+];
+const HERMES_COAUTHOR_RE = /Co-Authored-By:\s*Hermes\b/i;
+
+// Forbidden scaffolding strings (D1).
+const SCAFFOLDING_PATTERNS = [
+  /Copy this file to:/i,
+  /Then register in app\.ts/i,
+  /Then register in.*\.tsx?\b/i,
+  /Paste this into.*\.ts/i,
+];
+
+// File globs that count as "source" (audited for scaffolding strings).
+function isAuditedSource(filePath) {
+  if (!filePath) return false;
+  if (filePath.includes("__tests__/")) return false;
+  if (/\.(test|spec)\.[jt]sx?$/i.test(filePath)) return false;
+  return /^(server|ui|cli|packages)\/.*\.[jt]sx?$/.test(filePath);
+}
+
+// Sensitive surfaces (D2) — touching any of these requires a test diff.
+const SENSITIVE_PATH_PATTERNS = [
+  /^server\/src\/services\/access[^/]*\.ts$/,
+  /^server\/src\/services\/access\//,
+  /^server\/src\/middleware\/auth\.ts$/,
+  /^server\/src\/auth\//,
+  /^server\/src\/services\/onboarding-orchestrator\.ts$/,
+  /^server\/src\/services\/cos-/,
+  /^packages\/adapters\//,
+  /^server\/src\/middleware\/require-tier\.ts$/,
+  /^server\/src\/routes\/billing\.ts$/,
+  /^server\/src\/services\/billing[^/]*\.ts$/,
+  /^server\/src\/services\/entitlement-sync\.ts$/,
+  /^server\/src\/services\/seat-quantity-syncer\.ts$/,
+];
+
+// New-route detection (D1 wire-up evidence).
+function isNewRouteFile(status, filePath) {
+  if (status !== "A") return false;
+  if (!filePath) return false;
+  if (filePath.includes("__tests__/")) return false;
+  if (/\.(test|spec)\.[jt]sx?$/i.test(filePath)) return false;
+  return /^server\/src\/routes\/[^/]+\.ts$/.test(filePath);
+}
+
+// Test diff detection (D2).
+function isTestFile(filePath) {
+  if (!filePath) return false;
+  return (
+    filePath.includes("__tests__/") ||
+    /\.(test|spec)\.[jt]sx?$/i.test(filePath) ||
+    /^tests\/e2e\//.test(filePath)
+  );
+}
+
+// New patch file detection (D4).
+function isNewPatchFile(status, filePath) {
+  if (status !== "A") return false;
+  return /^patches\/.+\.patch$/.test(filePath ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// CLI / env arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { diffFile: null, commitsFile: null, title: null, body: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--diff") {
+      args.diffFile = value;
+      i += 1;
+    } else if (flag === "--commits") {
+      args.commitsFile = value;
+      i += 1;
+    } else if (flag === "--title") {
+      args.title = value;
+      i += 1;
+    } else if (flag === "--body") {
+      args.body = value;
+      i += 1;
+    } else if (flag === "--help" || flag === "-h") {
+      process.stdout.write(
+        "Usage: check-hermes-pr-audit.mjs [--diff <file>] [--commits <file>] [--title <s>] [--body <s>]\n",
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`Unknown argument: ${flag}\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function readDiffFromFile(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [status, ...rest] = line.split("\t");
+      return { status: (status ?? "").trim(), path: rest.join("\t").trim() };
+    });
+}
+
+function readDiffFromGit(baseSha, headSha) {
+  const out = execFileSync(
+    "git",
+    ["diff", "--name-status", `${baseSha}...${headSha}`],
+    { encoding: "utf8" },
+  );
+  return out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      // git diff --name-status output: "A\tpath" / "M\tpath" / "R100\told\tnew"
+      const parts = line.split("\t");
+      const status = (parts[0] ?? "").trim().slice(0, 1); // R100 → R
+      const path = (parts[parts.length - 1] ?? "").trim();
+      return { status, path };
+    });
+}
+
+function readCommitsFromFile(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  // Format: <author-email>\t<body>  (body may contain literal \n which we keep)
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [email, ...rest] = line.split("\t");
+      return { authorEmail: (email ?? "").trim(), body: rest.join("\t") };
+    });
+}
+
+function readCommitsFromGit(baseSha, headSha) {
+  // Get one record per commit in BASE..HEAD: author-email + full body.
+  const sep = "<<<HERMES_AUDIT_SEP>>>";
+  const out = execFileSync(
+    "git",
+    ["log", `${baseSha}..${headSha}`, `--format=%H%x09%ae%x09%B${sep}`],
+    { encoding: "utf8" },
+  );
+  return out
+    .split(sep)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk) => {
+      const [headerLine, ...bodyLines] = chunk.split("\n");
+      const [, email] = (headerLine ?? "").split("\t");
+      return { authorEmail: (email ?? "").trim(), body: bodyLines.join("\n") };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+function hasHermesCommit(commits) {
+  return commits.some((c) => {
+    if (HERMES_EMAIL_PATTERNS.some((re) => re.test(c.authorEmail))) return true;
+    if (HERMES_COAUTHOR_RE.test(c.body)) return true;
+    return false;
+  });
+}
+
+function isBypassed(title, body) {
+  const haystack = `${title ?? ""}\n${body ?? ""}`.toLowerCase();
+  return haystack.includes(BYPASS_FLAG.toLowerCase());
+}
+
+function readWorkingTreeFile(filePath) {
+  // Best-effort. In CI we run from the PR head checkout; the file exists.
+  try {
+    if (!existsSync(filePath)) return null;
+    return readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+function checkScaffoldingStrings(diff) {
+  const failures = [];
+  for (const { status, path: p } of diff) {
+    if (status === "D") continue;
+    if (!isAuditedSource(p)) continue;
+    const content = readWorkingTreeFile(p);
+    if (content == null) continue;
+    for (const re of SCAFFOLDING_PATTERNS) {
+      if (re.test(content)) {
+        failures.push(
+          `  - ${p}: contains scaffolding text matching ${re.toString()}`,
+        );
+        break;
+      }
+    }
+  }
+  return failures;
+}
+
+function checkNewRouteWireUp(diff) {
+  const failures = [];
+  const newRoutes = diff.filter(({ status, path: p }) => isNewRouteFile(status, p));
+  if (newRoutes.length === 0) return failures;
+
+  const appTs = readWorkingTreeFile("server/src/app.ts") ?? "";
+  for (const { path: p } of newRoutes) {
+    // Derive the exported route fn name from the file path:
+    //   server/src/routes/agent-research.ts → agentResearchRoutes (heuristic)
+    // We don't know the actual export name, so we grep for the bare module name
+    // (post-import path) AND for any "Routes" function call. If neither
+    // appears in app.ts, flag.
+    const moduleName = path.basename(p, ".ts"); // "agent-research"
+    const moduleImportFragment = `routes/${moduleName}`;
+    const routesFnHeuristic = moduleName.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) + "Routes";
+
+    const importMatches = appTs.includes(moduleImportFragment);
+    const callMatches = appTs.includes(routesFnHeuristic);
+    if (!importMatches && !callMatches) {
+      failures.push(
+        `  - ${p}: new route file added but no reference to "${moduleImportFragment}" or "${routesFnHeuristic}" in server/src/app.ts`,
+      );
+    }
+  }
+  return failures;
+}
+
+function checkSensitiveSurfaceTests(diff) {
+  const touchedSensitive = diff.filter(({ status, path: p }) => {
+    if (status === "D") return false;
+    return SENSITIVE_PATH_PATTERNS.some((re) => re.test(p));
+  });
+  if (touchedSensitive.length === 0) return [];
+
+  const hasTestDiff = diff.some(({ path: p }) => isTestFile(p));
+  if (hasTestDiff) return [];
+
+  return [
+    `  - Sensitive paths touched without any test file in the same PR:`,
+    ...touchedSensitive.map(({ path: p }) => `      • ${p}`),
+    `    Add a test under __tests__/ or tests/e2e/.`,
+  ];
+}
+
+function checkPatchAbsolutePaths(diff) {
+  const failures = [];
+  const newPatches = diff.filter(({ status, path: p }) => isNewPatchFile(status, p));
+  for (const { path: p } of newPatches) {
+    const content = readWorkingTreeFile(p);
+    if (content == null) continue;
+    // Only inspect lines that start with "---" or "+++" (diff headers).
+    const badLines = content
+      .split("\n")
+      .filter((line) => /^(\+\+\+|---)\s/.test(line))
+      .filter((line) => /\s(\/Users\/|\/home\/|\/root\/)/.test(line));
+    if (badLines.length > 0) {
+      failures.push(
+        `  - ${p}: patch header contains absolute developer-local path:`,
+        ...badLines.map((line) => `      ${line}`),
+        `    Regenerate via \`pnpm patch <pkg> --edit-dir /tmp/<dir>\` so headers use relative a/ b/ paths.`,
+      );
+    }
+  }
+  return failures;
+}
+
+function checkRegressionSuiteSection(body) {
+  const text = body ?? "";
+  // Locate a heading like "## Regression suite" (any level >= 2). Then capture
+  // everything from the line AFTER the heading up to (but not including) the
+  // next ^##+ heading, OR end of input. JS regex has no \Z, so we split on the
+  // heading and inspect the trailing section explicitly.
+  const headingRe = /^[ \t]*#{2,}[ \t]*Regression[ \t]+suite[ \t]*$/im;
+  const headingMatch = text.match(headingRe);
+  if (!headingMatch || headingMatch.index === undefined) {
+    return [
+      `  - PR body has no "## Regression suite" heading.`,
+      `    Add the heading with the tail of \`pnpm -r typecheck && pnpm test:run && pnpm build\`.`,
+    ];
+  }
+  // After the heading line, find the next ^##+ heading (if any).
+  const after = text.slice(headingMatch.index + headingMatch[0].length);
+  const nextHeading = after.match(/^[ \t]*#{2,}[ \t]+\S/m);
+  const section = (nextHeading && nextHeading.index !== undefined
+    ? after.slice(0, nextHeading.index)
+    : after
+  ).trim();
+  if (section.length < 40) {
+    return [
+      `  - "## Regression suite" heading found but content is too short (${section.length} chars).`,
+      `    Paste the tail of each of typecheck / test:run / build.`,
+    ];
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv);
+  const title = args.title ?? process.env.PR_TITLE ?? "";
+  const body = args.body ?? process.env.PR_BODY ?? "";
+
+  let diff;
+  let commits;
+  if (args.diffFile) {
+    diff = readDiffFromFile(args.diffFile);
+  } else {
+    const baseSha = process.env.BASE_SHA;
+    const headSha = process.env.HEAD_SHA;
+    if (!baseSha || !headSha) {
+      process.stderr.write("BASE_SHA and HEAD_SHA env vars required (or --diff)\n");
+      process.exit(2);
+    }
+    diff = readDiffFromGit(baseSha, headSha);
+  }
+
+  if (args.commitsFile) {
+    commits = readCommitsFromFile(args.commitsFile);
+  } else if (process.env.BASE_SHA && process.env.HEAD_SHA) {
+    commits = readCommitsFromGit(process.env.BASE_SHA, process.env.HEAD_SHA);
+  } else {
+    commits = [];
+  }
+
+  // Bypass — log loudly.
+  if (isBypassed(title, body)) {
+    process.stdout.write(
+      `[hermes-audit] BYPASSED via ${BYPASS_FLAG} in PR title/body. Skipping audit.\n`,
+    );
+    process.exit(0);
+  }
+
+  // Only audit when at least one commit is Hermes-authored.
+  if (!hasHermesCommit(commits)) {
+    process.stdout.write(
+      "[hermes-audit] No Hermes-authored commits in this PR. Skipping audit.\n",
+    );
+    process.exit(0);
+  }
+
+  process.stdout.write(
+    `[hermes-audit] Hermes commits detected in PR. Running audit on ${diff.length} changed paths.\n`,
+  );
+
+  const allFailures = [];
+
+  const scaffolding = checkScaffoldingStrings(diff);
+  if (scaffolding.length > 0) {
+    allFailures.push(
+      "D1: scaffolding text found in committed source (forbidden by Hermes directive 1):",
+      ...scaffolding,
+    );
+  }
+
+  const wireUp = checkNewRouteWireUp(diff);
+  if (wireUp.length > 0) {
+    allFailures.push(
+      "D1: new route file(s) added but not wired into server/src/app.ts:",
+      ...wireUp,
+    );
+  }
+
+  const sensitive = checkSensitiveSurfaceTests(diff);
+  if (sensitive.length > 0) {
+    allFailures.push(
+      "D2: sensitive surface touched without test diff:",
+      ...sensitive,
+    );
+  }
+
+  const patchPaths = checkPatchAbsolutePaths(diff);
+  if (patchPaths.length > 0) {
+    allFailures.push(
+      "D4: patch file contains absolute developer-local path:",
+      ...patchPaths,
+    );
+  }
+
+  const regression = checkRegressionSuiteSection(body);
+  if (regression.length > 0) {
+    allFailures.push(
+      "D5: PR body missing regression-suite output:",
+      ...regression,
+    );
+  }
+
+  if (allFailures.length > 0) {
+    process.stderr.write(
+      "[hermes-audit] FAIL — one or more directives violated:\n",
+    );
+    for (const line of allFailures) {
+      process.stderr.write(`${line}\n`);
+    }
+    process.stderr.write(
+      `\nSee docs/agents/hermes-prompt.md for the full directive list.\n` +
+        `If this audit blocks a legitimate PR (e.g. a one-off prompt fix), add ` +
+        `\`${BYPASS_FLAG}\` to the PR title or body. Bypass is logged.\n`,
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write("[hermes-audit] PASS — all Hermes directives satisfied.\n");
+  process.exit(0);
+}
+
+main();

--- a/scripts/ci/check-hermes-prompt-drift.mjs
+++ b/scripts/ci/check-hermes-prompt-drift.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Hermes prompt drift check.
+ *
+ * docs/agents/hermes-prompt.md is the canonical, reviewable record of the
+ * Hermes agent's operating directives. The frontmatter claims:
+ *
+ *   This file is synced to the agent's `capabilities` field in the Paperclip
+ *   agents DB and to the `KANBAN_GUIDANCE` injected into every dispatched worker.
+ *
+ * Without enforcement, that claim is dead text — the file can diverge from
+ * the actual runtime prompt with no signal. This script asserts that when
+ * the prompt is edited in a PR, the corresponding runtime surface(s) are
+ * also edited (or a bypass flag is present).
+ *
+ * Runtime surfaces that consume the prompt content (current best-known list,
+ * extend as new sync targets land):
+ *   - server/src/onboarding-assets/hermes/ — bundled SKILL.md for Hermes agents
+ *   - server/src/services/agent-creator-from-proposal.ts — KANBAN_GUIDANCE injection
+ *
+ * Trigger: a PR touches docs/agents/hermes-prompt.md (any status).
+ *
+ * Rule: when triggered, the same diff MUST also touch at least one runtime
+ * surface OR carry a `[no-runtime-sync]` bypass flag (case-insensitive) in
+ * the PR title or body. Bypass is logged loudly.
+ *
+ * Inputs (env): BASE_SHA, HEAD_SHA, PR_TITLE, PR_BODY (mirrors check-agents-md-drift.mjs).
+ *
+ * Exit codes:
+ *   0 — pass (no trigger / properly synced / bypassed)
+ *   1 — fail (trigger fired, no runtime surface touched, no bypass)
+ *   2 — usage / internal error
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const TRIGGER_FILE = "docs/agents/hermes-prompt.md";
+const BYPASS_FLAG = "[no-runtime-sync]";
+
+// Runtime surfaces that should be edited when the prompt changes.
+// Add entries here as additional sync targets are introduced.
+const RUNTIME_SURFACES = [
+  /^server\/src\/onboarding-assets\/hermes\//,
+  /^server\/src\/services\/agent-creator-from-proposal\.ts$/,
+  // Catch-all for any future sync script the project adds.
+  /^scripts\/sync-hermes-prompt\./,
+];
+
+function parseArgs(argv) {
+  const args = { diffFile: null, title: null, body: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--diff") {
+      args.diffFile = value;
+      i += 1;
+    } else if (flag === "--title") {
+      args.title = value;
+      i += 1;
+    } else if (flag === "--body") {
+      args.body = value;
+      i += 1;
+    } else if (flag === "--help" || flag === "-h") {
+      process.stdout.write(
+        "Usage: check-hermes-prompt-drift.mjs [--diff <file>] [--title <s>] [--body <s>]\n",
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`Unknown argument: ${flag}\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function readDiffFromFile(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split("\t");
+      return { status: (parts[0] ?? "").trim().slice(0, 1), path: (parts.at(-1) ?? "").trim() };
+    });
+}
+
+function readDiffFromGit(baseSha, headSha) {
+  const out = execFileSync(
+    "git",
+    ["diff", "--name-status", `${baseSha}...${headSha}`],
+    { encoding: "utf8" },
+  );
+  return out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split("\t");
+      return { status: (parts[0] ?? "").trim().slice(0, 1), path: (parts.at(-1) ?? "").trim() };
+    });
+}
+
+function isBypassed(title, body) {
+  return `${title ?? ""}\n${body ?? ""}`.toLowerCase().includes(BYPASS_FLAG.toLowerCase());
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const title = args.title ?? process.env.PR_TITLE ?? "";
+  const body = args.body ?? process.env.PR_BODY ?? "";
+
+  let diff;
+  if (args.diffFile) {
+    diff = readDiffFromFile(args.diffFile);
+  } else {
+    const baseSha = process.env.BASE_SHA;
+    const headSha = process.env.HEAD_SHA;
+    if (!baseSha || !headSha) {
+      process.stderr.write("BASE_SHA and HEAD_SHA env vars required (or --diff)\n");
+      process.exit(2);
+    }
+    diff = readDiffFromGit(baseSha, headSha);
+  }
+
+  // Trigger: does the diff touch the prompt?
+  const promptTouched = diff.some(({ path: p }) => p === TRIGGER_FILE);
+  if (!promptTouched) {
+    process.stdout.write(
+      "[hermes-prompt-drift] Prompt file not touched in this PR. Skipping.\n",
+    );
+    process.exit(0);
+  }
+
+  if (isBypassed(title, body)) {
+    process.stdout.write(
+      `[hermes-prompt-drift] BYPASSED via ${BYPASS_FLAG} in PR title/body. ` +
+        `Prompt changed without runtime-surface sync. Logged for audit.\n`,
+    );
+    process.exit(0);
+  }
+
+  // Did the diff also touch a runtime surface?
+  const runtimeTouched = diff.some(({ path: p }) =>
+    RUNTIME_SURFACES.some((re) => re.test(p)),
+  );
+
+  if (runtimeTouched) {
+    process.stdout.write(
+      "[hermes-prompt-drift] PASS — prompt and runtime surface(s) updated together.\n",
+    );
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `[hermes-prompt-drift] FAIL — ${TRIGGER_FILE} changed but no runtime surface was updated.\n` +
+      `\n` +
+      `The prompt is supposed to be synced to:\n` +
+      `  • server/src/onboarding-assets/hermes/*\n` +
+      `  • server/src/services/agent-creator-from-proposal.ts (KANBAN_GUIDANCE)\n` +
+      `  • Any scripts/sync-hermes-prompt.* helper\n` +
+      `\n` +
+      `Without a corresponding edit, the runtime prompt diverges from the doc.\n` +
+      `Either: (a) update the runtime surface in this PR, (b) add a sync script,\n` +
+      `or (c) add \`${BYPASS_FLAG}\` to the PR title/body if the drift is intentional\n` +
+      `(e.g. doc-only typo fix). Bypass is logged.\n`,
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes #257. The Hermes prompt from PR #255 captured the right policy but every directive was honor-system. This PR adds the missing enforcement.

### What lands

**Two CI lanes** (model after existing \`agents-md-drift-check.yml\`):

1. **\`hermes-pr-audit\`** — runs on every PR, but only audits when Hermes-authored commits are detected (author email match OR \`Co-Authored-By: Hermes\` trailer). Enforces:
   - **D1**: no scaffolding strings (\`Copy this file to:\`, \`Then register in\`) in audited source; new \`server/src/routes/*.ts\` must reference its import path or derived \`Routes()\` function name in \`server/src/app.ts\`
   - **D2**: sensitive surfaces (access, auth, onboarding orchestrator, adapters, requireTier, billing routes/services) touched without a test diff → fail
   - **D4**: \`patches/*.patch\` with absolute developer-local paths in \`---\`/\`+++\` headers → fail
   - **D5**: PR body must contain \`## Regression suite\` heading with non-empty content
   - Bypass via \`[skip-hermes-audit]\` (logged)

2. **\`hermes-prompt-drift\`** — closes the Directive-1 self-violation in #255. When \`docs/agents/hermes-prompt.md\` is edited in a PR, requires a corresponding edit to a runtime surface (\`onboarding-assets/hermes/\`, \`agent-creator-from-proposal.ts\`, or a sync script). Bypass via \`[no-runtime-sync]\`.

**One admin doc**:

3. **\`doc/BRANCH-PROTECTION.md\`** — exact \`gh api PUT\` command to enable branch protection on \`main\` with \`enforce_admins: true\`. Without this, the owner's token (and Hermes via that token) bypasses every CI check. **This is the one step I can't ship from a PR; documented for copy-paste.** Includes verification query, test procedure, legitimate-bypass escape hatch.

**One prompt fix**:

4. Replace hardcoded \`/Users/maxiaoer/workspace/agentdash_dev\` with \`\${HERMES_WORKSPACE_ROOT}\` in \`docs/agents/hermes-prompt.md\` (per #257 part F).

### Self-tests

7 audit-script test cases pass against synthetic diff + commit fixtures:
- Non-Hermes PR → skip
- Hermes + clean diff + valid PR body → pass
- Hermes + missing regression suite → fail D5
- Hermes + sensitive surface without test → fail D2
- Hermes + sensitive WITH test → pass
- Hermes + new route without \`app.ts\` wire-up → fail D1
- Hermes + violations + bypass flag → bypass (logged)

4 drift-script test cases pass:
- No prompt touched → skip
- Prompt + runtime surface → pass
- Prompt only → fail
- Prompt only + bypass → pass (logged)

Reproducer: \`scripts/ci/check-hermes-pr-audit.mjs --diff <file> --commits <file> --title <s> --body <s>\` (no env vars needed for local self-test).

## Regression suite

typecheck: not needed — this PR is .mjs scripts + YAML workflows + Markdown docs; no TypeScript modules touched
test:run: same — no test surfaces touched
build: same

Smoke-tested both .mjs scripts under Node 20 (\`node scripts/ci/check-hermes-pr-audit.mjs --help\` returns usage cleanly; --diff fixture mode exercises all 5 rules).

## What still requires the admin

After this PR merges, **branch protection must be enabled manually** (one-time \`gh api PUT\` from \`doc/BRANCH-PROTECTION.md\`). Until that lands, Directive 5 remains honor-system on the server side even though the CI lanes are firing. The doc is structured so it's a single copy-paste command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)