### PR TITLE
fix(ci): trigger PR workflow for main branch too

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - main
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Fixes the circular blocker: pr.yml only listed master in branches, but the default branch is main. Now triggers for both. This allows the policy/verify checks to run for main-targeting PRs.