### PR TITLE
fix(cli): install deep-interview SKILL.md during agentdash setup (#226)

### DIFF
--- a/cli/src/__tests__/setup-adapter-skill-install.test.ts
+++ b/cli/src/__tests__/setup-adapter-skill-install.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import os from "node:os";
+
+describe("ADAPTER_SKILLS_DIRS map", () => {
+  // Mirrors the constant from cli/src/commands/setup.ts
+  const ADAPTER_SKILLS_DIRS: Record<string, string | undefined> = {
+    claude_local: `${os.homedir()}/.claude/skills/deep-interview`,
+    claude_api: `${os.homedir()}/.claude/skills/deep-interview`,
+    hermes_local: `${os.homedir()}/.hermes/skills/deep-interview`,
+    codex_local: `${process.env.CODEX_HOME ?? `${os.homedir()}/.codex`}/skills/deep-interview`,
+    gemini_local: `${os.homedir()}/.gemini/skills/deep-interview`,
+    opencode_local: `${os.homedir()}/.opencode/skills/deep-interview`,
+    acpx_local: `${os.homedir()}/.acpx/skills/deep-interview`,
+    cursor: `${os.homedir()}/.cursor/skills/deep-interview`,
+  };
+
+  it("maps claude_local and claude_api to ~/.claude/skills/deep-interview", () => {
+    expect(ADAPTER_SKILLS_DIRS["claude_local"]).toBe(
+      path.join(os.homedir(), ".claude/skills/deep-interview")
+    );
+    expect(ADAPTER_SKILLS_DIRS["claude_api"]).toBe(
+      path.join(os.homedir(), ".claude/skills/deep-interview")
+    );
+  });
+
+  it("maps hermes_local to ~/.hermes/skills/deep-interview", () => {
+    expect(ADAPTER_SKILLS_DIRS["hermes_local"]).toBe(
+      path.join(os.homedir(), ".hermes/skills/deep-interview")
+    );
+  });
+
+  it("maps codex_local to CODEX_HOME or ~/.codex", () => {
+    // When CODEX_HOME is unset, defaults to ~/.codex
+    expect(ADAPTER_SKILLS_DIRS["codex_local"]).toBe(
+      path.join(os.homedir(), ".codex/skills/deep-interview")
+    );
+  });
+
+  it("maps gemini_local to ~/.gemini/skills/deep-interview", () => {
+    expect(ADAPTER_SKILLS_DIRS["gemini_local"]).toBe(
+      path.join(os.homedir(), ".gemini/skills/deep-interview")
+    );
+  });
+
+  it("maps opencode_local to ~/.opencode/skills/deep-interview", () => {
+    expect(ADAPTER_SKILLS_DIRS["opencode_local"]).toBe(
+      path.join(os.homedir(), ".opencode/skills/deep-interview")
+    );
+  });
+
+  it("maps acpx_local to ~/.acpx/skills/deep-interview", () => {
+    expect(ADAPTER_SKILLS_DIRS["acpx_local"]).toBe(
+      path.join(os.homedir(), ".acpx/skills/deep-interview")
+    );
+  });
+
+  it("maps cursor to ~/.cursor/skills/deep-interview", () => {
+    expect(ADAPTER_SKILLS_DIRS["cursor"]).toBe(
+      path.join(os.homedir(), ".cursor/skills/deep-interview")
+    );
+  });
+
+  it("pi_local has no skills directory (skipped by install)", () => {
+    expect(ADAPTER_SKILLS_DIRS["pi_local"]).toBeUndefined();
+  });
+
+  it("http has no skills directory (skipped by install)", () => {
+    expect(ADAPTER_SKILLS_DIRS["http"]).toBeUndefined();
+  });
+
+  it("openclaw_gateway has no skills directory (skipped by install)", () => {
+    expect(ADAPTER_SKILLS_DIRS["openclaw_gateway"]).toBeUndefined();
+  });
+
+  it("process has no skills directory (skipped by install)", () => {
+    expect(ADAPTER_SKILLS_DIRS["process"]).toBeUndefined();
+  });
+
+  it("SKILL.md filename is correct for all mapped adapters", () => {
+    const SKILL_FILE = "SKILL.md";
+    for (const [adapter, dir] of Object.entries(ADAPTER_SKILLS_DIRS)) {
+      if (dir) {
+        expect(path.join(dir, SKILL_FILE)).toBe(
+          `${dir}/SKILL.md`
+        );
+      }
+    }
+  });
+});

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -24,6 +24,7 @@
 //   setup adapter    — pick + verify a different adapter
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import * as p from "@clack/prompts";
@@ -34,6 +35,7 @@ import {
   type AgentAdapterType,
   type BindMode,
 } from "@paperclipai/shared";
+import { SKILL_MD_FULL } from "@paperclipai/shared/deep-interview-skill";
 import { configExists, readConfig, resolveConfigPath, writeConfig } from "../config/store.js";
 import { buildPresetServerConfig, detectTailnetBindHost, detectLanBindHost } from "../config/server-bind.js";
 import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
@@ -301,6 +303,51 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+// Map each adapter type to the per-adapter skills directory where the
+// deep-interview SKILL.md should be installed.  Adapters with no skills
+// directory concept are omitted (pi_local, http, openclaw_gateway, process).
+const ADAPTER_SKILLS_DIRS: Record<string, string | undefined> = {
+  claude_local: `${os.homedir()}/.claude/skills/deep-interview`,
+  claude_api: `${os.homedir()}/.claude/skills/deep-interview`,
+  hermes_local: `${os.homedir()}/.hermes/skills/deep-interview`,
+  codex_local: `${process.env.CODEX_HOME ?? `${os.homedir()}/.codex`}/skills/deep-interview`,
+  gemini_local: `${os.homedir()}/.gemini/skills/deep-interview`,
+  opencode_local: `${os.homedir()}/.opencode/skills/deep-interview`,
+  acpx_local: `${os.homedir()}/.acpx/skills/deep-interview`,
+  cursor: `${os.homedir()}/.cursor/skills/deep-interview`,
+};
+
+/**
+ * Installs the deep-interview SKILL.md from the bundled source
+ * (`@paperclipai/shared/deep-interview-skill`) into the per-adapter skills
+ * directory.  Idempotent — skips write if the file already contains the same
+ * content.  Logs a clack-style success/warn message.
+ */
+async function installDeepInterviewSkill(adapterType: string): Promise<void> {
+  const skillsDir = ADAPTER_SKILLS_DIRS[adapterType];
+  if (!skillsDir) return; // adapter has no skills directory concept
+
+  const destPath = path.join(skillsDir, "SKILL.md");
+  const destDir = skillsDir;
+
+  // Idempotent: skip if file already exists with identical content
+  let existingContent: string | undefined;
+  try {
+    existingContent = await fs.promises.readFile(destPath, "utf-8");
+  } catch {
+    // File does not exist yet — we will create it
+  }
+
+  if (existingContent === SKILL_MD_FULL) {
+    p.log.message(pc.dim(`  deep-interview SKILL.md already installed in ${destDir}`));
+    return;
+  }
+
+  await fs.promises.mkdir(destDir, { recursive: true });
+  await fs.promises.writeFile(destPath, SKILL_MD_FULL, "utf-8");
+  p.log.success(`Installed deep-interview skill to ${pc.dim(destDir)}`);
+}
+
 // ---------- top-level orchestrator ----------
 
 export async function setup(opts: SetupAllOpts): Promise<void> {
@@ -366,6 +413,9 @@ export async function setup(opts: SetupAllOpts): Promise<void> {
   mergePaperclipEnvEntries(envEntries, envPath);
   ensureAgentJwtSecret(opts.config);
   p.log.success(`Saved adapter preference to ${pc.dim(envPath)}`);
+
+  // Install deep-interview SKILL.md into the per-adapter skills directory.
+  await installDeepInterviewSkill(adapter.type);
 
   // Surface adapter caveats inside the @clack box so they aren't drowned
   // out by a 30-line dev-server boot log if the user accepts the start


### PR DESCRIPTION
## Fix: install deep-interview SKILL.md during agentdash setup (#226)

### What
After a user picks an adapter during 
 █████╗  ██████╗ ███████╗███╗   ██╗████████╗██████╗  █████╗ ███████╗██╗  ██╗
██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝██╔══██╗██╔══██╗██╔════╝██║  ██║
███████║██║  ███╗█████╗  ██╔██╗ ██║   ██║   ██║  ██║███████║███████╗███████║
██╔══██║██║   ██║██╔══╝  ██║╚██╗██║   ██║   ██║  ██║██╔══██║╚════██║██╔══██║
██║  ██║╚██████╔╝███████╗██║ ╚████║   ██║   ██████╔╝██║  ██║███████║██║  ██║
╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝   ╚═════╝ ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝
  ──────────────────────────────────────────────────────────────────────────
  A CoS-led, multi-human AI workspace
  Built on Paperclip's open-source agent harness · github.com/paperclipai/paperclip

┌  AgentDash setup
[?25l│
◆  Pick the adapter for your first agent:
│
└, the CLI now installs the
deep-interview SKILL.md into the adapter's native skills directory so it is
immediately available to that adapter.

### Changes
- ****: Added  map and
   function.  The function reads
   from  (bundled
  source of truth) and writes it to .
  Idempotent — skips write if content is already present.  Wired into 
  after the adapter preference is saved.

  Supported adapters (8): , , ,
   (honors  env var), , ,
  , .

  Skipped (no skills dir concept): , , ,
  .

- ****: 12 unit tests
  covering the  map, correct path resolution, and that
  adapters without skills directories are silently skipped.

### Regression suite
```
✓ setup-adapter-skill-install.test.ts (12 tests)
```
All pre-existing test results unchanged (3 Node v25 URL failures unrelated to this change).