### PR TITLE
fix(docker): cover packages/create-agentdash in deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY ui/package.json ui/
 COPY packages/shared/package.json packages/shared/
 COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
+COPY packages/create-agentdash/package.json packages/create-agentdash/
 COPY packages/mcp-server/package.json packages/mcp-server/
 COPY packages/adapters/acpx-local/package.json packages/adapters/acpx-local/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/


### PR DESCRIPTION
## Summary

The \`pr.yml\` \`policy\` job runs \`scripts/check-docker-deps-stage.mjs\` which asserts every workspace package has a matching \`COPY <pkg>/package.json <pkg>/\` line in the Dockerfile's deps stage. The recently-added \`packages/create-agentdash\` (CLI bootstrap helper) was missing — so the policy check fails on every PR, blocking the merge button across the entire repo.

One-line fix. Unblocks #262 and every other open PR.

## Verification

\`\`\`sh
node scripts/check-docker-deps-stage.mjs && echo PASS
# After this fix: PASS (exit 0)
# Before: "Dockerfile deps stage missing package manifest coverage for: packages/create-agentdash/package.json" (exit 1)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)