### PR TITLE
fix(db): add missing journal entry for 0081 cold-signup-reengagement migration

### DIFF
--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -568,6 +568,13 @@
       "when": 1778112000000,
       "tag": "0080_goals_eval_hitl",
       "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1778544000000,
+      "tag": "0081_cold_signup_reengagement",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

PR #228 (cold-signup re-engagement) shipped \`0081_cold_signup_reengagement.sql\` but never updated \`_journal.json\`. Every CI run since has failed at \`packages/db build\` with:

\`\`\`
Migration journal/file count mismatch: journal has 81, files have 82
\`\`\`

Same defect class as PR #270 (Dockerfile + create-agentdash) and PR #271 (stale lockfile): adding a thing without keeping the catalog in sync.

## Fix

Append the journal entry for 0081. Snapshot file is omitted intentionally — neither 0080 nor 0081 had a snapshot, and \`check-migration-numbering.ts\` only validates journal/file count match (not snapshot presence). drizzle-kit will rebuild snapshots when next regenerated from a clean schema.

## Verification

\`\`\`sh
pnpm --filter @paperclipai/db check:migrations  # ✅ exit 0 (was failing)
pnpm --filter @paperclipai/db typecheck         # ✅ exit 0
\`\`\`

Unblocks #262 and every other open PR's verify+e2e jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)