### PR TITLE
fix(server): missing coldSignupReengagement import broke typecheck on main

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -979,6 +979,7 @@ export async function startServer(): Promise<StartedServer> {
   // the heartbeat digest.
   const coldSignupIntervalMs = 24 * 60 * 60 * 1000; // daily
   if (process.env.AGENTDASH_DIGEST_ENABLED === "true") {
+    const { coldSignupReengagement } = await import("./services/cold-signup-reengagement.js");
     const {
       reengagementUserAdapter,
       reengagementSentAdapter,
@@ -991,7 +992,7 @@ export async function startServer(): Promise<StartedServer> {
     });
     logger.info({ intervalMs: coldSignupIntervalMs }, "[reengagement] cold-signup schedule enabled");
     setInterval(() => {
-      void reengagement.run().catch((err) => {
+      void reengagement.run().catch((err: unknown) => {
         logger.error({ err }, "[reengagement] coldSignupReengagement.run failed");
       });
     }, coldSignupIntervalMs);


### PR DESCRIPTION
## Summary

PR #228 added a call to \`coldSignupReengagement(...)\` at \`server/src/index.ts:987\` but only imported the adapter factories, not the service factory itself. Plus implicit-any on the catch handler. Server typecheck has been failing on every PR since.

## Errors

\`\`\`
src/index.ts(987,26): error TS2304: Cannot find name 'coldSignupReengagement'.
src/index.ts(994,38): error TS7006: Parameter 'err' implicitly has an 'any' type.
\`\`\`

## Fix

- Dynamic-import \`coldSignupReengagement\` from \`./services/cold-signup-reengagement.js\` alongside the adapters
- Annotate catch handler's \`err: unknown\`

## Verification

\`\`\`sh
pnpm --filter @paperclipai/server typecheck  # ✅ exit 0
\`\`\`

Fourth PR in this cluster of "PR #228 didn't validate before merge": #270 Dockerfile, #271 lockfile, #274 journal, this one server typecheck. All to unblock #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)