### PR TITLE
fix(billing+cleanup): onInvoicePaid (#169) + partial #171 + partial #173 [no-prompt-update]

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1058,6 +1058,7 @@ export const FEATURE_FLAG_KEYS = {
 export const ACTIVITY_LOG_ACTIONS_BILLING = [
   "stripe.payment_failed",
   "stripe.trial_will_end",
+  "stripe.invoice_paid",
 ] as const;
 export type ActivityLogActionBilling = (typeof ACTIVITY_LOG_ACTIONS_BILLING)[number];
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3476,13 +3476,13 @@ export function issueRoutes(
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;
-    if (resumeRequested === true && !(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
-    if (resumeRequested !== true && reopenRequested === true && req.actor.type === "agent") {
+    if (resumeRequested && !(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
+    if (!resumeRequested && reopenRequested && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     }
     const isClosed = isClosedIssueStatus(issue.status);
     const isBlocked = issue.status === "blocked";
-    const explicitMoveToTodoRequested = reopenRequested || resumeRequested === true;
+    const explicitMoveToTodoRequested = reopenRequested || resumeRequested;
     const effectiveMoveToTodoRequested =
       explicitMoveToTodoRequested ||
       shouldImplicitlyMoveCommentedIssueToTodo({
@@ -3495,7 +3495,7 @@ export function issueRoutes(
       isBlocked && effectiveMoveToTodoRequested
         ? (await svc.getDependencyReadiness(issue.id)).unresolvedBlockerCount > 0
         : false;
-    if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
+    if (resumeRequested && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;
     }
@@ -3529,7 +3529,7 @@ export function issueRoutes(
           reopened: true,
           reopenedFrom: reopenFromStatus,
           source: "comment",
-          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+          ...(resumeRequested ? { resumeIntent: true, followUpRequested: true } : {}),
           identifier: currentIssue.identifier,
         },
       });
@@ -3592,7 +3592,7 @@ export function issueRoutes(
         bodySnippet: comment.body.slice(0, 120),
         identifier: currentIssue.identifier,
         issueTitle: currentIssue.title,
-        ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+        ...(resumeRequested ? { resumeIntent: true, followUpRequested: true } : {}),
         ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, source: "comment" } : {}),
         ...(interruptedRunId ? { interruptedRunId } : {}),
         ...summarizeIssueReferenceActivityDetails({
@@ -3636,7 +3636,7 @@ export function issueRoutes(
               commentId: comment.id,
               reopenedFrom: reopenFromStatus,
               mutation: "comment",
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
             requestedByActorType: actor.actorType,
@@ -3649,7 +3649,7 @@ export function issueRoutes(
               source: "issue.comment.reopen",
               wakeReason: "issue_reopened_via_comment",
               reopenedFrom: reopenFromStatus,
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });
@@ -3662,7 +3662,7 @@ export function issueRoutes(
               issueId: currentIssue.id,
               commentId: comment.id,
               mutation: "comment",
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
             requestedByActorType: actor.actorType,
@@ -3674,7 +3674,7 @@ export function issueRoutes(
               wakeCommentId: comment.id,
               source: "issue.comment",
               wakeReason: "issue_commented",
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });

--- a/server/src/services/entitlement-sync.ts
+++ b/server/src/services/entitlement-sync.ts
@@ -68,7 +68,38 @@ export function entitlementSync(deps: Deps) {
     onSubscriptionCreated: applyFromSubscription,
     onSubscriptionUpdated: applyFromSubscription,
     onSubscriptionDeleted: applyFromSubscription,
-    onInvoicePaid: async (_inv: any) => { /* no-op; subscription.updated follows */ },
+    // AgentDash (#169): no longer a no-op. Stripe doesn't guarantee event
+    // ordering — for manual invoicing flows, invoice.paid may fire without a
+    // follow-up subscription.updated. Refresh local state from the invoice's
+    // line-item period info + audit the event. The next subscription.updated
+    // (if it arrives) will overwrite — that's the source of truth.
+    onInvoicePaid: async (inv: any) => {
+      const company = await findCompanyForInvoice(inv ?? {});
+      if (!company) return;
+      if (deps.activityLog) {
+        await deps.activityLog.record(company.id, "stripe.invoice_paid", {
+          invoiceId: inv?.id ?? null,
+          subscriptionId: inv?.subscription ?? null,
+          amountPaid: inv?.amount_paid ?? null,
+          periodEnd: inv?.period_end ?? null,
+        });
+      }
+      // Best-effort patch from invoice line-item period (covers the
+      // "subscription.updated never fires" failure mode).
+      const line = inv?.lines?.data?.[0];
+      const periodEndTs = line?.period?.end ?? inv?.period_end ?? null;
+      const quantity = line?.quantity ?? null;
+      const patch: Record<string, unknown> = {};
+      if (typeof periodEndTs === "number" && periodEndTs > 0) {
+        patch.planPeriodEnd = new Date(periodEndTs * 1000);
+      }
+      if (typeof quantity === "number" && quantity >= 0) {
+        patch.planSeatsPaid = quantity;
+      }
+      if (Object.keys(patch).length > 0) {
+        await deps.companies.update(company.id, patch);
+      }
+    },
 
     dispatch: async (event: any) => {
       const recorded = await deps.ledger.record(event.id, event.type, event);

--- a/server/src/startup-banner.ts
+++ b/server/src/startup-banner.ts
@@ -3,6 +3,7 @@ import { resolvePaperclipConfigPath, resolvePaperclipEnvPath } from "./paths.js"
 import type { BindMode, DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 
 import { parse as parseEnvFileContents } from "dotenv";
+import { logger } from "./middleware/logger.js";
 
 type UiMode = "none" | "static" | "vite-dev";
 
@@ -173,5 +174,5 @@ export function printStartupBanner(opts: StartupBannerOptions): void {
     "",
   ];
 
-  console.log(lines.filter((line): line is string => line !== null).join("\n"));
+  logger.info(lines.filter((line): line is string => line !== null).join("\n"));
 }


### PR DESCRIPTION
## Summary

Three stranded-WIP items recovered from a previous session and re-applied against current main. Stale items from the same session (#162, #167, #172) were discarded after triage — main already had different fixes for #162/#167, and #172 was closed-by-kanban by the owner.

## #169 (closes) — onInvoicePaid is no longer a no-op

\`\`\`ts
// Before
onInvoicePaid: async (_inv: any) => { /* no-op; subscription.updated follows */ }
\`\`\`

Stripe doesn't guarantee event ordering. For manual invoicing flows, \`invoice.paid\` may fire without a follow-up \`subscription.updated\` — leaving \`planSeatsPaid\` + \`planPeriodEnd\` stale.

**Fix:**
1. Look up the company via \`findCompanyForInvoice(inv)\` (introduced in #157)
2. Write a \`stripe.invoice_paid\` activity_log row (new action enum added to \`ACTIVITY_LOG_ACTIONS_BILLING\`)
3. Best-effort patch \`planPeriodEnd\` + \`planSeatsPaid\` from the invoice's line-item period info. If \`subscription.updated\` arrives later, it overwrites — that's still the source of truth.

The service has no Stripe SDK in scope, so retrieve-by-subscriptionId isn't available; extracting from the invoice payload is the safe fallback for the "subscription.updated never fires" failure mode.

## #171 (partial — staying open) — boolean comparison cleanup

\`server/src/routes/issues.ts\`: 7 instances of \`=== true\` removed where TS already narrowed to \`boolean\`.

Issue #171 cites 14 instances total; this PR only touches issues.ts. \`companies.ts\` / \`projects.ts\` / \`feedback.ts\` sites stay open — they need the same false-y-vs-strict-false scrutiny and weren't in the WIP.

## #173 (partial — staying open) — console.log → logger

\`server/src/startup-banner.ts:177\`: \`console.log\` → \`logger.info\`.

Issue #173 also cites \`server/src/index.ts:919\`, but that's an intentional human-readable terminal banner with ANSI color codes for the board-claim URL — structured logger output would lose the formatting. Left in place.

## Test plan

- [x] \`pnpm --filter @paperclipai/shared typecheck\` → exit 0
- [x] \`pnpm --filter @paperclipai/server typecheck\` → exit 0
- [x] \`git diff origin/main -- server/src/services/approvals.ts | wc -l\` → 0 (caller-only invariant preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)