### PR TITLE
fix(ui-tests): repair 3 stale UI tests broken on main since #218 + #210 (#277)

### DIFF
--- a/ui/src/components/__tests__/AgentPlanProposal.test.tsx
+++ b/ui/src/components/__tests__/AgentPlanProposal.test.tsx
@@ -74,10 +74,38 @@ describe("AgentPlanProposal", () => {
     });
     expect(onConfirm).toHaveBeenCalledOnce();
 
+    // PR #210: "Let me revise" no longer fires onRevise immediately — it opens
+    // an inline textarea + Send / Cancel form. Exercise the full flow:
+    //   1. click "Let me revise" → form opens (textarea + Send button)
+    //   2. type a revision into the textarea
+    //   3. click "Send revision" → onRevise(text) fires
     await act(async () => {
       revise.click();
     });
+    expect(onRevise).not.toHaveBeenCalled();
+    const reviseForm = container.querySelector('[data-testid="plan-revise-form"]');
+    expect(reviseForm).toBeTruthy();
+
+    const textarea = reviseForm!.querySelector("textarea")!;
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      )!.set!;
+      setter.call(textarea, "drop the QA");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const sendBtn = Array.from(reviseForm!.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Send revision"),
+    )!;
+    expect(sendBtn).toBeDefined();
+    await act(async () => {
+      sendBtn.click();
+    });
     expect(onRevise).toHaveBeenCalledOnce();
+    expect(onRevise).toHaveBeenCalledWith("drop the QA");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/CoSConversation.test.tsx
+++ b/ui/src/pages/CoSConversation.test.tsx
@@ -34,6 +34,40 @@ vi.mock("../realtime/useMessages", () => ({
   useMessages: mockUseMessages,
 }));
 
+// CoSConversation now wraps a useQuery for agentsApi.list (added in PR #218 for
+// mention typeahead). Mock @tanstack/react-query so the test doesn't need a
+// QueryClientProvider, and mock agentsApi.list to return an empty directory —
+// the smoke test only cares that the chat panel renders post-bootstrap, not
+// that mention resolution works.
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryFn, enabled }: { queryFn: () => unknown; enabled?: boolean }) => {
+    if (enabled === false) {
+      return { data: undefined, isLoading: false, error: null };
+    }
+    try {
+      const data = queryFn();
+      return { data, isLoading: false, error: null };
+    } catch (err) {
+      return { data: undefined, isLoading: false, error: err };
+    }
+  },
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: {
+    // The useQuery mock above invokes queryFn() synchronously and returns the
+    // raw value as `data`. Returning a Promise would set `data` to the Promise
+    // itself (truthy → bypasses ?? [] → .map fails). Return the array directly.
+    list: vi.fn().mockReturnValue([]),
+  },
+}));
+
+// Mock ChatPanel to a stub so we don't drag in its useQuery / WS / scroll deps.
+// The test only asserts ".chat-panel" is in the DOM after bootstrap resolves.
+vi.mock("./ChatPanel", () => ({
+  default: () => <div className="chat-panel" />,
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/ui/src/pages/CompanyInbox.test.tsx
+++ b/ui/src/pages/CompanyInbox.test.tsx
@@ -35,6 +35,18 @@ vi.mock("../api/conversations", () => ({
   },
 }));
 
+// CompanyInbox added a second useQuery in PR #218 for agentsApi.list (mention
+// typeahead directory). The test's existing useQuery mock blindly invokes the
+// queryFn, so without mocking agentsApi the second call would either throw or
+// return a Promise (fails downstream as `agents.map is not a function`).
+// Stub agentsApi.list to a synchronous empty array so the mention dropdown
+// renders empty without breaking the test.
+vi.mock("../api/agents", () => ({
+  agentsApi: {
+    list: vi.fn().mockReturnValue([]),
+  },
+}));
+
 vi.mock("../context/CompanyContext", () => ({
   useCompany: mockUseCompany,
 }));


### PR DESCRIPTION
## Summary

Closes #277. After PR #262 enabled \`pr.yml\`'s verify gate on main-targeted PRs, three latent test failures became visible.

## Failures fixed

| File | Why broken | Fix |
|---|---|---|
| \`CoSConversation.test.tsx\` | PR #218 added \`useQuery\` for \`agentsApi.list\` (mention typeahead). Test never mocked react-query → "No QueryClient set". | Mock react-query, agentsApi.list returns \`[]\`, ChatPanel stubbed |
| \`CompanyInbox.test.tsx\` | Same useQuery; existing mock invoked queryFn → returned a Promise → \`.map\` failed. | Mock agentsApi.list to return \`[]\` |
| \`AgentPlanProposal.test.tsx\` | PR #210 changed "Let me revise" from firing onRevise immediately to opening a textarea form. Test asserted spy fired on the wrong click. | Exercise full revise flow: click "Let me revise" → form opens → type → click "Send revision" → onRevise(text) fires |

## Verification

\`\`\`sh
pnpm --filter @paperclipai/ui exec vitest run \\
  src/pages/CoSConversation.test.tsx \\
  src/pages/CompanyInbox.test.tsx \\
  src/components/__tests__/AgentPlanProposal.test.tsx

# Test Files  3 passed (3)
# Tests       6 passed (6)
\`\`\`

## After this lands

Re-add \`verify\` to required branch protection contexts (was temporarily removed during the #262 unblock yak-shave). Once #278 (e2e infra) lands, also re-add \`e2e\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)