### PR TITLE
fix(ci): trigger refresh-lockfile + docker workflows on main (#272)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches:
+      - "main"
       - "master"
     tags:
       - "v*"

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -3,11 +3,12 @@ name: Refresh Lockfile
 on:
   push:
     branches:
+      - main
       - master
   workflow_dispatch:
 
 concurrency:
-  group: refresh-lockfile-master
+  group: refresh-lockfile-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -81,7 +82,7 @@ jobs:
             pr_url="$(gh pr create \
               --head "$BRANCH" \
               --title "chore(lockfile): refresh pnpm-lock.yaml" \
-              --body "Auto-generated lockfile refresh after dependencies changed on master. This PR only updates pnpm-lock.yaml.")"
+              --body "Auto-generated lockfile refresh after dependencies changed on the default branch. This PR only updates pnpm-lock.yaml.")"
             echo "Created new PR: $pr_url"
           else
             echo "PR already exists: $pr_url"


### PR DESCRIPTION
## Summary

Closes #272. Two workflows still had \`branches: [master]\` after the agentdash-main → main cutover and have been silently not firing for ~2 weeks. Add \`main\` to both trigger lists (kept \`master\` defensively).

- \`refresh-lockfile.yml\` — last ran 2026-05-02. PR #271 had to manually regenerate.
- \`docker.yml\` — Docker images haven't published since the cutover.

Same defect class as #262 (pr.yml — already fixed).

## Verification

YAML-only change; CI exercises both on next push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)