### PR TITLE
feat(ui): add Billing link to sidebar Company section (#248)

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Repeat,
   GitBranch,
   Settings,
+  CreditCard,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -114,6 +115,7 @@ export function Sidebar() {
           <SidebarNavItem to="/org" label="Org" icon={Network} />
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
+          <SidebarNavItem to="/billing" label="Billing" icon={CreditCard} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
         </SidebarSection>


### PR DESCRIPTION
## Summary

Closes #248. BillingPage at \`/billing\` was orphaned — only reachable by typing the URL. **Wave 1 unblocker** for the entire billing-roadmap path-to-first-customer cluster.

Trivial: single icon import (\`CreditCard\` from lucide) + single \`SidebarNavItem\` entry under the Company section, between Costs and Activity.

After this lands, every other billing UI fix (#208 TrialBanner, #224 UpgradePromptCard, #250 past_due, #251 callback toast) becomes discoverable.

## Regression suite

typecheck: not needed for single import + JSX literal addition
test:run: no test surfaces touched
build: same

🤖 Generated with [Claude Code](https://claude.com/claude-code)