### PR TITLE
feat(ui): mount TrialBanner globally in Layout (#208)

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -19,6 +19,7 @@ import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
 import { SidebarAccountMenu } from "./SidebarAccountMenu";
 import { ConnectionStatus } from "./ConnectionStatus";
+import { TrialBanner } from "./TrialBanner";
 import { useDialogActions } from "../context/DialogContext";
 import { GeneralSettingsProvider } from "../context/GeneralSettingsContext";
 import { usePanel } from "../context/PanelContext";
@@ -395,6 +396,10 @@ export function Layout() {
         )}
 
         <div className={cn("flex min-w-0 flex-col", isMobile ? "w-full" : "h-full flex-1")}>
+          {/* Closes #208: Pro-trial countdown banner. Self-suppresses when
+              tier !== "pro_trial" or session-dismissed, so unconditional
+              mount here is safe and avoids prop drilling. */}
+          {selectedCompany?.id ? <TrialBanner companyId={selectedCompany.id} /> : null}
           <div
             className={cn(
               isMobile && "sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85",


### PR DESCRIPTION
## Summary

Closes #208. TrialBanner component shipped earlier but was never mounted — Pro trial countdown was invisible to every user. Mount globally in Layout.tsx above BreadcrumbBar.

Self-suppresses when \`tier !== \"pro_trial\"\`, status loading, or session-dismissed → unconditional mount is safe.

Wave C unblock for path-to-first-paying-customer (#248 sidebar link, #208 banner, #224 upgrade card next).

## Regression suite

typecheck: 0 errors
test:run: skipped (no test surfaces touched)
build: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)