### PR TITLE
feat(ui): mount UpgradePromptCard via global cap-exceeded modal (#224)

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -38,6 +38,24 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   }
   if (!res.ok) {
     const errorBody = await res.json().catch(() => null);
+    // Closes #224: surface 402 cap-exceeded errors via a global event so
+    // <UpgradePromptModal> (mounted in Layout) renders the upgrade card
+    // inline regardless of which call site triggered the error. Avoids
+    // requiring every invite/hire callsite to manually catch + render.
+    if (res.status === 402 && errorBody && typeof errorBody === "object") {
+      const code = (errorBody as { code?: string }).code;
+      if (code === "seat_cap_exceeded" || code === "agent_cap_exceeded") {
+        try {
+          window.dispatchEvent(
+            new CustomEvent("agentdash:cap-exceeded", {
+              detail: { reason: code, companyId: (errorBody as { companyId?: string }).companyId ?? null },
+            }),
+          );
+        } catch {
+          // SSR / non-browser context — swallow; the throw below still surfaces
+        }
+      }
+    }
     throw new ApiError(
       (errorBody as { error?: string } | null)?.error ?? `Request failed: ${res.status}`,
       res.status,

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -20,6 +20,7 @@ import { DevRestartBanner } from "./DevRestartBanner";
 import { SidebarAccountMenu } from "./SidebarAccountMenu";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { TrialBanner } from "./TrialBanner";
+import { UpgradePromptModal } from "./UpgradePromptModal";
 import { useDialogActions } from "../context/DialogContext";
 import { GeneralSettingsProvider } from "../context/GeneralSettingsContext";
 import { usePanel } from "../context/PanelContext";
@@ -437,6 +438,8 @@ export function Layout() {
       <NewGoalDialog />
       <NewAgentDialog />
       <KeyboardShortcutsCheatsheet open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+      {/* Closes #224: opens automatically on 402 cap-exceeded errors. */}
+      <UpgradePromptModal />
       <ToastViewport />
       {/* Fixed connection status indicator — bottom-right, always visible */}
       <div className="fixed bottom-4 right-4 z-50">

--- a/ui/src/components/UpgradePromptModal.tsx
+++ b/ui/src/components/UpgradePromptModal.tsx
@@ -1,0 +1,73 @@
+// Closes #224. Listens for the "agentdash:cap-exceeded" CustomEvent dispatched
+// by ui/src/api/client.ts on 402 responses with code seat_cap_exceeded or
+// agent_cap_exceeded, then renders <UpgradePromptCard> inside a Dialog.
+//
+// Mounted globally in Layout.tsx so any call site that hits a cap surfaces
+// the upgrade CTA without having to wire its own try/catch + UI.
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useCompany } from "../context/CompanyContext";
+import { billingApi } from "../api/billing";
+import { UpgradePromptCard } from "./UpgradePromptCard";
+
+type CapReason = "seat_cap_exceeded" | "agent_cap_exceeded";
+
+interface CapEventDetail {
+  reason: CapReason;
+  companyId: string | null;
+}
+
+export function UpgradePromptModal() {
+  const { selectedCompany } = useCompany();
+  const [reason, setReason] = useState<CapReason | null>(null);
+  const [eventCompanyId, setEventCompanyId] = useState<string | null>(null);
+
+  // Pull billing status so we can suppress if the user is somehow already
+  // on Pro by the time this modal would show (race window after upgrade).
+  const { data: status } = useQuery({
+    queryKey: ["billing-status", eventCompanyId ?? selectedCompany?.id ?? "none"],
+    queryFn: () => billingApi.status(eventCompanyId ?? selectedCompany!.id),
+    enabled: reason !== null && Boolean(eventCompanyId ?? selectedCompany?.id),
+  });
+
+  useEffect(() => {
+    function onCap(e: Event) {
+      const detail = (e as CustomEvent<CapEventDetail>).detail;
+      if (!detail || (detail.reason !== "seat_cap_exceeded" && detail.reason !== "agent_cap_exceeded")) {
+        return;
+      }
+      setReason(detail.reason);
+      setEventCompanyId(detail.companyId);
+    }
+    window.addEventListener("agentdash:cap-exceeded", onCap);
+    return () => window.removeEventListener("agentdash:cap-exceeded", onCap);
+  }, []);
+
+  // If status loaded and the company is already on Pro, suppress (covers the
+  // upgrade-just-landed race where the original 402 was stale). Use effect
+  // (not inline set during render) to avoid React render-loop warnings.
+  useEffect(() => {
+    if (!reason) return;
+    if (status && (status.tier === "pro_trial" || status.tier === "pro_active")) {
+      setReason(null);
+    }
+  }, [reason, status]);
+
+  if (!reason) return null;
+
+  const companyId = eventCompanyId ?? selectedCompany?.id ?? null;
+  if (!companyId) return null;
+
+  return (
+    <Dialog open={reason !== null} onOpenChange={(open) => !open && setReason(null)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Upgrade to Pro</DialogTitle>
+        </DialogHeader>
+        <UpgradePromptCard reason={reason} companyId={companyId} />
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #224. UpgradePromptCard had no callers — hitting a Free-tier cap gave a raw 402. Three pieces:

1. **\`api/client.ts\`**: dispatch a window CustomEvent on 402 with cap codes; throw still happens (additive)
2. **\`UpgradePromptModal.tsx\`** (new): listens, opens a Dialog with the existing card. Self-suppresses if billing.status reports tier already pro_*
3. **\`Layout.tsx\`**: mount globally next to ToastViewport

Why global event vs per-callsite: N invite/hire surfaces all need the same UX; one mount evolves uniformly; future callsites can't forget to handle.

Wave C unblock for path-to-first-paying-customer:
- ✓ #248 sidebar link
- ✓ #208 TrialBanner mounted
- ✓ #224 UpgradePromptCard mounted (this PR)
- → #250 past_due UI next, then #251 callback toast

## Regression suite

typecheck: 0 errors
test:run: skipped (no test surfaces touched)
build: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)