### PR TITLE
feat(billing): handle ?session=success/cancel callback from Stripe (#251)

### DIFF
--- a/ui/src/pages/BillingPage.tsx
+++ b/ui/src/pages/BillingPage.tsx
@@ -1,12 +1,107 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "@/lib/router";
 import { billingApi, type BillingStatus } from "../api/billing";
+import { useToastActions } from "../context/ToastContext";
+
+const PRO_TIERS: ReadonlyArray<BillingStatus["tier"]> = ["pro_trial", "pro_active"];
+
+// Closes #251: Stripe webhook race window. After checkout redirect, the
+// subscription.created webhook may not have hit our /webhook endpoint by
+// the time the user lands here. Poll status with bounded backoff so the
+// UI catches up to Pro within ~10s instead of forcing a manual reload.
+const WEBHOOK_RACE_POLL_INTERVAL_MS = 2000;
+const WEBHOOK_RACE_POLL_MAX_ATTEMPTS = 5;
 
 export default function BillingPage({ companyId }: { companyId: string }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { pushToast } = useToastActions();
   const [status, setStatus] = useState<BillingStatus | null>(null);
-  useEffect(() => { billingApi.status(companyId).then(setStatus); }, [companyId]);
+  const handledSession = useRef(false);
+
+  // Initial status fetch + manual refetch helper.
+  function loadStatus() {
+    return billingApi.status(companyId).then(setStatus);
+  }
+
+  useEffect(() => {
+    void loadStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [companyId]);
+
+  // Closes #251: handle ?session=success / ?session=cancel callback from Stripe.
+  useEffect(() => {
+    if (handledSession.current) return;
+    const params = new URLSearchParams(location.search);
+    const session = params.get("session");
+    if (!session) return;
+    handledSession.current = true;
+
+    // Strip the param so a refresh doesn't re-trigger.
+    params.delete("session");
+    const cleanedSearch = params.toString();
+    navigate(
+      { pathname: location.pathname, search: cleanedSearch ? `?${cleanedSearch}` : "" },
+      { replace: true },
+    );
+
+    if (session === "cancel") {
+      pushToast({
+        title: "Checkout canceled",
+        body: "No charge was made. You can start again any time.",
+        tone: "info",
+      });
+      return;
+    }
+
+    if (session === "success") {
+      pushToast({
+        title: "Pro trial activating…",
+        body: "Stripe is confirming your subscription. This usually takes a few seconds.",
+        tone: "success",
+      });
+
+      // Poll until tier shows as Pro (webhook race) or attempt budget exhausted.
+      let attempt = 0;
+      let cancelled = false;
+      const poll = async () => {
+        if (cancelled) return;
+        attempt += 1;
+        try {
+          const fresh = await billingApi.status(companyId);
+          setStatus(fresh);
+          if (PRO_TIERS.includes(fresh.tier)) {
+            pushToast({
+              title: "Pro trial active",
+              body: `${fresh.tier === "pro_trial" ? "Your 14-day trial has started." : "Your subscription is active."}`,
+              tone: "success",
+            });
+            return;
+          }
+        } catch {
+          // Network blip; the next poll handles it.
+        }
+        if (attempt >= WEBHOOK_RACE_POLL_MAX_ATTEMPTS) {
+          pushToast({
+            title: "Still confirming with Stripe",
+            body: "Refresh in a moment if your plan doesn't update.",
+            tone: "info",
+          });
+          return;
+        }
+        setTimeout(poll, WEBHOOK_RACE_POLL_INTERVAL_MS);
+      };
+      setTimeout(poll, WEBHOOK_RACE_POLL_INTERVAL_MS);
+
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [companyId, location.pathname, location.search, navigate, pushToast]);
+
   if (!status) return <div className="p-8">Loading…</div>;
 
-  const isPro = status.tier === "pro_trial" || status.tier === "pro_active";
+  const isPro = PRO_TIERS.includes(status.tier);
 
   async function upgrade() {
     const r = await billingApi.startCheckout(companyId);


### PR DESCRIPTION
## Summary

Closes #251. Stripe redirects back to /billing with \`?session=success\` or \`?session=cancel\` after checkout. Previously: silently ignored, user saw stale tier display.

Now:
- **Cancel**: toast "Checkout canceled" + strip param
- **Success**: toast "Pro trial activating…" + poll \`billingApi.status\` (5×2s = 10s budget) until tier flips to pro_*, then toast "Pro trial active". Strips param. If budget exhausts, toast "Still confirming with Stripe — refresh in a moment"

Handles the webhook race window (1-3s typical, can be longer on Stripe retries).

## Implementation
- \`useRef\` guard so React StrictMode double-render doesn't double-fire toasts
- Effect cleanup via cancelled flag so unmount mid-poll doesn't push to unmounted component
- Tone enum check: \`default\` → \`info\` (ToastTone is \`info|success|warn|error\`)

Wave C unblock for path-to-first-paying-customer:
- ✓ #248 sidebar link
- ✓ #208 TrialBanner mounted
- ✓ #224 UpgradePromptCard mounted
- ✓ #251 callback handler (this PR)
- → #250 past_due UI

## Regression suite

typecheck: 0 errors (ui/tsc --noEmit)
test:run: skipped (no test surfaces touched directly)
build: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)