### PR TITLE
feat(billing): pro_past_due UI — banner + BillingPage notice (#250)

### DIFF
--- a/ui/src/components/TrialBanner.tsx
+++ b/ui/src/components/TrialBanner.tsx
@@ -1,27 +1,73 @@
+// Pro-tier billing banner. Despite the historical name "TrialBanner", this
+// component renders one of two states:
+//   - pro_trial    → countdown banner (#208)
+//   - pro_past_due → payment-failed warning (#250)
+// All other tiers self-suppress.
+
 import { useEffect, useState } from "react";
 import { billingApi } from "../api/billing";
 
+interface BillingStatusLite {
+  tier: string;
+  periodEnd: string | null;
+}
+
 export function TrialBanner({ companyId }: { companyId: string }) {
-  const [status, setStatus] = useState<{ tier: string; periodEnd: string | null } | null>(null);
+  const [status, setStatus] = useState<BillingStatusLite | null>(null);
   const [dismissed, setDismissed] = useState(false);
-  useEffect(() => { billingApi.status(companyId).then(setStatus); }, [companyId]);
-  if (!status || status.tier !== "pro_trial" || !status.periodEnd || dismissed) return null;
-  const daysLeft = Math.max(0, Math.round((new Date(status.periodEnd).getTime() - Date.now()) / 86400000));
-  return (
-    <div className="trial-banner bg-accent-100 text-accent-700 border-b border-accent-200 px-4 py-2 flex items-center justify-between text-sm">
-      <div>
-        Pro trial — {daysLeft} day{daysLeft === 1 ? "" : "s"} left.{" "}
-        <a className="underline underline-offset-2 hover:text-accent-600 transition-colors" href="/billing">
-          Add payment method
-        </a>
+  useEffect(() => {
+    billingApi.status(companyId).then(setStatus);
+  }, [companyId]);
+
+  if (!status || dismissed) return null;
+
+  if (status.tier === "pro_trial" && status.periodEnd) {
+    const daysLeft = Math.max(
+      0,
+      Math.round((new Date(status.periodEnd).getTime() - Date.now()) / 86_400_000),
+    );
+    return (
+      <div className="trial-banner bg-accent-100 text-accent-700 border-b border-accent-200 px-4 py-2 flex items-center justify-between text-sm">
+        <div>
+          Pro trial — {daysLeft} day{daysLeft === 1 ? "" : "s"} left.{" "}
+          <a
+            className="underline underline-offset-2 hover:text-accent-600 transition-colors"
+            href="/billing"
+          >
+            Add payment method
+          </a>
+        </div>
+        <button
+          className="text-accent-600 hover:text-accent-700 transition-colors ml-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 rounded"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss trial banner"
+        >
+          ×
+        </button>
       </div>
-      <button
-        className="text-accent-600 hover:text-accent-700 transition-colors ml-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 rounded"
-        onClick={() => setDismissed(true)}
-        aria-label="Dismiss trial banner"
-      >
-        ×
-      </button>
-    </div>
-  );
+    );
+  }
+
+  if (status.tier === "pro_past_due") {
+    // Closes #250: pro_past_due was added to the entitlement model but had
+    // no UI surface — payment-failed users were silently capped on writes
+    // with no visible explanation. Render a prominent (non-dismissible)
+    // banner pointing at the customer portal so they can fix the card.
+    return (
+      <div className="past-due-banner bg-destructive/15 text-destructive border-b border-destructive/30 px-4 py-2 flex items-center justify-between text-sm font-medium">
+        <div>
+          ⚠ Payment failed — your subscription is past due. Inviting teammates
+          and hiring agents are paused until the card is updated.{" "}
+          <a
+            className="underline underline-offset-2 hover:text-destructive/80 transition-colors"
+            href="/billing"
+          >
+            Update payment method
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/ui/src/pages/BillingPage.tsx
+++ b/ui/src/pages/BillingPage.tsx
@@ -102,6 +102,7 @@ export default function BillingPage({ companyId }: { companyId: string }) {
   if (!status) return <div className="p-8">Loading…</div>;
 
   const isPro = PRO_TIERS.includes(status.tier);
+  const isPastDue = status.tier === "pro_past_due";
 
   async function upgrade() {
     const r = await billingApi.startCheckout(companyId);
@@ -115,6 +116,20 @@ export default function BillingPage({ companyId }: { companyId: string }) {
   return (
     <div className="billing-page p-8 max-w-2xl mx-auto">
       <h1 className="text-2xl font-semibold text-text-primary mb-6">Billing</h1>
+      {/* Closes #250: pro_past_due notice with explicit reactivation path. */}
+      {isPastDue ? (
+        <div
+          role="alert"
+          className="mb-4 border border-destructive/30 rounded-lg p-4 bg-destructive/10 text-destructive"
+        >
+          <div className="font-medium mb-1">Payment failed — subscription past due</div>
+          <div className="text-sm text-destructive/90">
+            Stripe couldn't charge your card. Inviting teammates and hiring agents
+            are paused until the card is updated. Click <strong>Manage subscription</strong> below
+            to fix it via the customer portal.
+          </div>
+        </div>
+      ) : null}
       <div className="border border-border-soft rounded-lg p-6 bg-surface-raised shadow-sm">
         <div className="mb-2 text-text-primary">
           Plan: <strong className="text-text-primary">{status.tier}</strong>
@@ -126,7 +141,7 @@ export default function BillingPage({ companyId }: { companyId: string }) {
           </div>
         )}
         <div className="mt-6">
-          {!isPro ? (
+          {!isPro && !isPastDue ? (
             <button
               className="bg-accent-500 text-text-inverse px-4 py-2 rounded-md font-medium hover:bg-accent-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
               onClick={upgrade}
@@ -135,10 +150,14 @@ export default function BillingPage({ companyId }: { companyId: string }) {
             </button>
           ) : (
             <button
-              className="border border-border-soft px-4 py-2 rounded-md font-medium text-text-primary hover:bg-surface-sunken transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
+              className={
+                isPastDue
+                  ? "bg-destructive text-white px-4 py-2 rounded-md font-medium hover:bg-destructive/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30"
+                  : "border border-border-soft px-4 py-2 rounded-md font-medium text-text-primary hover:bg-surface-sunken transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200"
+              }
               onClick={manage}
             >
-              Manage subscription
+              {isPastDue ? "Update payment method" : "Manage subscription"}
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary

Closes #250. \`pro_past_due\` tier was added to the entitlement model + webhook handler but had no UI surface — payment-failed users were silently capped on writes with no visible explanation.

- **TrialBanner**: extends to render destructive-tone banner for past_due tier (non-dismissible — this is action-required, not informational)
- **BillingPage**: prominent past-due notice + swap primary CTA from "Start Pro trial" to "Update payment method" (red button → customer portal)

Wave C complete:
- ✓ #248 sidebar link
- ✓ #208 TrialBanner mounted
- ✓ #224 UpgradePromptCard mounted
- ✓ #251 Stripe callback handler
- ✓ #250 past_due UI (this PR)
- → Wave D: #249, #211, #169

## Regression suite

typecheck: 0 errors
test:run: skipped (no test surfaces touched directly)
build: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)