### PR TITLE
fix(e2e): default to PAPERCLIP_E2E_PORT (3199) instead of stale 3105 (#278)

### DIFF
--- a/tests/e2e/goal-metric-flow.spec.ts
+++ b/tests/e2e/goal-metric-flow.spec.ts
@@ -11,7 +11,13 @@
 // `metric_updated` row is written by `setGoalMetricDefinition`.
 import { test, expect, type APIRequestContext } from "@playwright/test";
 
-const BASE = process.env.PAPERCLIP_E2E_BASE_URL ?? "http://127.0.0.1:3105";
+// Closes #278: this suite is part of the default `pnpm test:e2e` config,
+// which boots its own server on PAPERCLIP_E2E_PORT (default 3199). The old
+// hardcoded 3105 fallback meant every CI run hit ECONNREFUSED before the
+// suite even started. Honor PAPERCLIP_E2E_PORT so we talk to the same
+// server playwright.config.ts just brought up.
+const E2E_PORT = process.env.PAPERCLIP_E2E_PORT ?? "3199";
+const BASE = process.env.PAPERCLIP_E2E_BASE_URL ?? `http://127.0.0.1:${E2E_PORT}`;
 
 interface BootstrapInfo {
   ready: boolean;

--- a/tests/e2e/goals-eval-hitl.spec.ts
+++ b/tests/e2e/goals-eval-hitl.spec.ts
@@ -10,7 +10,7 @@
 // closing verdict to land.
 //
 // REQUIREMENTS for the live-pass case (otherwise test.skip is honored):
-//  - server up at PAPERCLIP_E2E_BASE_URL (default http://127.0.0.1:3105),
+//  - server up at PAPERCLIP_E2E_BASE_URL (default http://127.0.0.1:3199),
 //  - bootstrapStatus === 'ready',
 //  - a company id available via /api/me or /api/companies for the
 //    authenticated session.
@@ -20,7 +20,13 @@
 // gracefully when fixtures are absent.
 import { test, expect, type APIRequestContext } from "@playwright/test";
 
-const BASE = process.env.PAPERCLIP_E2E_BASE_URL ?? "http://127.0.0.1:3105";
+// Closes #278: this suite runs under the default `pnpm test:e2e` config,
+// which boots its own server on PAPERCLIP_E2E_PORT (default 3199). The old
+// hardcoded 3105 fallback meant every CI run hit ECONNREFUSED before the
+// suite even started. Honor PAPERCLIP_E2E_PORT so we talk to the same
+// server playwright.config.ts just brought up.
+const E2E_PORT = process.env.PAPERCLIP_E2E_PORT ?? "3199";
+const BASE = process.env.PAPERCLIP_E2E_BASE_URL ?? `http://127.0.0.1:${E2E_PORT}`;
 
 interface BootstrapInfo {
   ready: boolean;


### PR DESCRIPTION
## Summary

Closes #278. Two specs (`goal-metric-flow.spec.ts`, `goals-eval-hitl.spec.ts`) hardcoded `127.0.0.1:3105` as their fallback when `PAPERCLIP_E2E_BASE_URL` was unset. The default `pnpm test:e2e` config (`tests/e2e/playwright.config.ts`) boots its own server on `PAPERCLIP_E2E_PORT` (default **3199**, not 3105), so every CI run under `pr.yml`'s `e2e` job started with ECONNREFUSED on the very first request — exactly the symptom in the issue.

## Root cause

When the specs were authored the e2e port was 3105; the harness later moved to 3199 (see `playwright.config.ts:8`) but these two specs were never updated. The other e2e configs (`onboarding-deep-interview*`, `signoff-policy`) already correctly default to 3199.

## Fix

Honor `PAPERCLIP_E2E_PORT` in the fallback:

```ts
const E2E_PORT = process.env.PAPERCLIP_E2E_PORT ?? "3199";
const BASE = process.env.PAPERCLIP_E2E_BASE_URL ?? `http://127.0.0.1:${E2E_PORT}`;
```

`PAPERCLIP_E2E_BASE_URL` still wins when set explicitly (preserves manual local-runner usage).

## Test plan

- [x] `pnpm -r typecheck` clean
- [ ] CI `e2e` job goes green on this PR — the real verification
- [ ] After merge: re-add `e2e` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)