### PR TITLE
refactor(shared): extract isAgentPlanPayload to @paperclipai/shared (#234)

### DIFF
--- a/packages/shared/src/validators/agent-plan.test.ts
+++ b/packages/shared/src/validators/agent-plan.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isAgentPlanPayload } from "./agent-plan.js";
+
+describe("isAgentPlanPayload", () => {
+  const valid = {
+    rationale: "We need a CoS to coordinate work.",
+    agents: [
+      {
+        role: "general assistant",
+        name: "Sam",
+        adapterType: "claude",
+        responsibilities: ["scheduling"],
+        kpis: ["meeting throughput"],
+      },
+    ],
+    alignmentToShortTerm: "Frees up the founder's time week one.",
+    alignmentToLongTerm: "Scales coordination as headcount grows.",
+  };
+
+  it("accepts a well-formed plan payload", () => {
+    expect(isAgentPlanPayload(valid)).toBe(true);
+  });
+
+  it("rejects null and non-object values", () => {
+    expect(isAgentPlanPayload(null)).toBe(false);
+    expect(isAgentPlanPayload(undefined)).toBe(false);
+    expect(isAgentPlanPayload("plan")).toBe(false);
+    expect(isAgentPlanPayload(42)).toBe(false);
+    expect(isAgentPlanPayload([])).toBe(false);
+  });
+
+  it("rejects missing or non-string rationale", () => {
+    expect(isAgentPlanPayload({ ...valid, rationale: undefined })).toBe(false);
+    expect(isAgentPlanPayload({ ...valid, rationale: 5 })).toBe(false);
+  });
+
+  it("rejects missing or non-array agents", () => {
+    expect(isAgentPlanPayload({ ...valid, agents: undefined })).toBe(false);
+    expect(isAgentPlanPayload({ ...valid, agents: "claude" })).toBe(false);
+  });
+
+  it("rejects empty agents array (a plan must propose at least one hire)", () => {
+    expect(isAgentPlanPayload({ ...valid, agents: [] })).toBe(false);
+  });
+
+  it("rejects missing or non-string alignmentToShortTerm", () => {
+    expect(isAgentPlanPayload({ ...valid, alignmentToShortTerm: undefined })).toBe(false);
+    expect(isAgentPlanPayload({ ...valid, alignmentToShortTerm: 0 })).toBe(false);
+  });
+
+  it("rejects missing or non-string alignmentToLongTerm", () => {
+    expect(isAgentPlanPayload({ ...valid, alignmentToLongTerm: undefined })).toBe(false);
+    expect(isAgentPlanPayload({ ...valid, alignmentToLongTerm: false })).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/agent-plan.ts
+++ b/packages/shared/src/validators/agent-plan.ts
@@ -1,0 +1,21 @@
+// Closes #234: single canonical type guard for AgentPlanProposalV1Payload.
+// Previously duplicated in server/src/services/cos-replier.ts (as
+// isPlanPayload) and server/src/routes/onboarding-v2.ts (as
+// isAgentPlanPayload) — same defect shape as #168. Both copies must grow
+// in lock-step (e.g. when we add adapterType allowlisting per #231), so
+// the only safe place to land it is here, in @paperclipai/shared.
+import type { AgentPlanProposalV1Payload } from "../cards.js";
+
+export function isAgentPlanPayload(
+  value: unknown,
+): value is AgentPlanProposalV1Payload {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.rationale === "string" &&
+    Array.isArray(v.agents) &&
+    v.agents.length > 0 &&
+    typeof v.alignmentToShortTerm === "string" &&
+    typeof v.alignmentToLongTerm === "string"
+  );
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -385,3 +385,7 @@ export {
   type SetPluginState,
   type ListPluginState,
 } from "./plugin.js";
+
+// AgentDash (#234): canonical type guard for AgentPlanProposalV1Payload;
+// replaces the previously-duplicated isPlanPayload + isAgentPlanPayload.
+export { isAgentPlanPayload } from "./agent-plan.js";

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -24,6 +24,7 @@ import { parseTrailer } from "../services/cos-replier.js";
 import { logger } from "../middleware/logger.js";
 import {
   FIXED_QUESTIONS,
+  isAgentPlanPayload,
   type AgentPlanProposalV1Payload,
   type InterviewState,
   type InterviewTurn,
@@ -577,17 +578,6 @@ async function defaultStubProposer(_transcript: InterviewTurn[]) {
   };
 }
 
-// Local type guard for the revise-plan handler. Mirrors the unexported
-// isPlanPayload in cos-replier.ts; kept inline to avoid widening that
-// module's public surface for a single caller.
-function isAgentPlanPayload(value: unknown): value is AgentPlanProposalV1Payload {
-  if (!value || typeof value !== "object") return false;
-  const v = value as Record<string, unknown>;
-  return (
-    typeof v.rationale === "string" &&
-    Array.isArray(v.agents) &&
-    v.agents.length > 0 &&
-    typeof v.alignmentToShortTerm === "string" &&
-    typeof v.alignmentToLongTerm === "string"
-  );
-}
+// AgentDash (#234): isAgentPlanPayload now lives in @paperclipai/shared
+// so the cos-replier service and this route never drift on the validator
+// shape. See packages/shared/src/validators/agent-plan.ts.

--- a/server/src/services/cos-replier.ts
+++ b/server/src/services/cos-replier.ts
@@ -11,7 +11,7 @@
 // transition; the next user turn re-runs the prompt.
 
 import { logger } from "../middleware/logger.js";
-import type { AgentPlanProposalV1Payload } from "@paperclipai/shared";
+import { isAgentPlanPayload, type AgentPlanProposalV1Payload } from "@paperclipai/shared";
 
 interface CosStateRow {
   conversationId: string;
@@ -179,17 +179,6 @@ export function parseTrailer(raw: string): ParsedTrailer {
   }
 }
 
-function isPlanPayload(value: unknown): value is AgentPlanProposalV1Payload {
-  if (!value || typeof value !== "object") return false;
-  const v = value as Record<string, unknown>;
-  return (
-    typeof v.rationale === "string" &&
-    Array.isArray(v.agents) &&
-    typeof v.alignmentToShortTerm === "string" &&
-    typeof v.alignmentToLongTerm === "string"
-  );
-}
-
 function isGoalsPatch(
   value: unknown,
 ): value is { shortTerm?: string; longTerm?: string; constraints?: Record<string, unknown> } {
@@ -290,7 +279,7 @@ export function cosReplier(deps: Deps) {
             }
           } else if (state.phase === "plan" && trailer) {
             // Plan phase: post visible body + a second message carrying the card.
-            if (isPlanPayload(trailer.plan)) {
+            if (isAgentPlanPayload(trailer.plan)) {
               const cardMsg = await deps.conversations.postMessage({
                 conversationId: input.conversationId,
                 authorKind: "agent",


### PR DESCRIPTION
## Summary

Closes #234. The `AgentPlanProposalV1Payload` type-guard was previously duplicated in:
- `server/src/services/cos-replier.ts` (as `isPlanPayload`)
- `server/src/routes/onboarding-v2.ts` (as `isAgentPlanPayload`)

Same defect shape as #168. Canonical home is now `packages/shared/src/validators/agent-plan.ts`, imported by both server-side call sites.

## Behavior

The shared validator is the **stricter** of the two prior copies — it requires `agents.length > 0`, matching the onboarding-v2 version. The old cos-replier copy did not enforce non-empty agents; an LLM trailer with `agents: []` now falls through to the malformed-trailer skip path instead of being mistaken for a real plan. Correctness improvement, not a regression.

## Test plan

- [x] 7 unit tests in `packages/shared/src/validators/agent-plan.test.ts` — happy path + each missing/wrong-type field + null/undefined/non-object
- [x] `pnpm -r typecheck` clean
- [x] `agent-plan.test.ts` 7/7 pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)