### PR TITLE
fix(run-healer): use inArray instead of raw `= ANY($tuple)` (#232)

### DIFF
--- a/server/src/services/run-healer/service.ts
+++ b/server/src/services/run-healer/service.ts
@@ -7,7 +7,7 @@
  * Design: docs/superpowers/specs/2026-05-11-self-healing-run-fixer-design.md
  */
 
-import { and, desc, eq, gte, isNull, isNotNull, lt, sql, count } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, isNotNull, lt, sql, count } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -173,7 +173,14 @@ export function runHealerService(db: Db) {
       .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
       .where(
         and(
-          sql`${heartbeatRuns.status} = ANY(${HEAL_ELIGIBLE_STATUSES})`,
+          // Closes #232: drizzle's typed `inArray` serializes to
+          // `status IN ($1, $2, ...)` with positional bindings. The
+          // previous `sql\`= ANY(\${tuple})\`` template-literal binding
+          // silently matched zero rows when the tuple wasn't coerced to a
+          // pg array correctly — turning the whole healer into a no-op
+          // while the scan log still read "scan_complete count=0" as if
+          // everything were fine.
+          inArray(heartbeatRuns.status, [...HEAL_ELIGIBLE_STATUSES]),
           gte(heartbeatRuns.createdAt, cutoff),
           lt(heartbeatRuns.createdAt, minAge),
         ),


### PR DESCRIPTION
## Summary

Closes #232. The run-healer's eligibility filter used a Drizzle template-literal binding for an \`= ANY(tuple)\` predicate, which can silently match zero rows when the tuple isn't coerced to a Postgres array literal — turning the entire healer into a no-op while the scan log keeps reading \`scan_complete count=0\`.

## Fix

Swap the raw \`sql\\\`= ANY(\${tuple})\\\`\` for drizzle's typed \`inArray()\` helper. \`inArray\` compiles to \`status IN (\$1, \$2)\` with one positional binding per element — the canonical Drizzle pattern.

The \`as const\` tuple is spread into a mutable array (\`[...HEAL_ELIGIBLE_STATUSES]\`) so \`inArray\`'s signature is satisfied without an unsafe cast.

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [ ] CI green
- Integration test (real heartbeat_runs row per eligible status, scanner returns it) requires a Postgres harness — filing follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)