### PR TITLE
fix(ui): ServerUnreachableOverlay no longer flashes on cold mount (#233)

### DIFF
--- a/ui/src/components/ServerUnreachableOverlay.tsx
+++ b/ui/src/components/ServerUnreachableOverlay.tsx
@@ -3,9 +3,19 @@ import { useServerHealth } from "@/hooks/useServerHealth";
 export function ServerUnreachableOverlay() {
   const { reachability, isOnline } = useServerHealth();
 
-  if (reachability === "reachable") return null;
-
+  // Closes #233: previously this only short-circuited on "reachable", so
+  // on first mount react-query was "checking" → the full-screen overlay
+  // flashed for 50ms–2s before the first /api/health response landed,
+  // regressing cold-load UX vs. having no overlay at all. The hook now
+  // only flips to "unreachable" after UNREACHABLE_THRESHOLD consecutive
+  // failures (per #229), so "checking" no longer warrants the full-screen
+  // takeover — at most a quiet indicator (which ConnectionStatus handles).
+  //
+  // The browser-offline branch is independent: if navigator says we have
+  // no network, we still want to surface the overlay regardless of the
+  // health-check state.
   const isBrowserOffline = !isOnline;
+  if (!isBrowserOffline && reachability !== "unreachable") return null;
   const message = isBrowserOffline
     ? "You're offline — check your internet connection."
     : "Unable to reach the server — it may be temporarily unavailable.";


### PR DESCRIPTION
## Summary

Closes #233. The overlay previously short-circuited only on \`reachability === "reachable"\`, so on first mount it covered the entire app for 50ms–2s while react-query's initial \`/api/health\` request was in flight — a clear cold-load UX regression.

## Fix

Render the overlay only when EITHER:
1. The browser is offline (\`navigator.onLine === false\`), OR
2. Reachability is genuinely \`"unreachable"\` — which (per #229) requires \`UNREACHABLE_THRESHOLD\` consecutive failed polls, not just one transient check.

\`"checking"\` no longer triggers the full-screen takeover. The quieter \`ConnectionStatus\` indicator is still free to surface in-flight checks if it wants.

## Acceptance

- [x] Cold mount on healthy server → no overlay flash
- [x] Browser-offline path unaffected (overlay still shows when \`navigator.onLine === false\`)
- [x] Server-going-down mid-session still trips the overlay after the threshold
- [x] \`pnpm -r typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)