### PR TITLE
refactor(ui): remove dead ApiError(status=0) branch in ErrorBoundary (#240)

### DIFF
--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import { ApiError } from "@/api/client";
+
+// Closes #240: ApiError(status=0) special-case removed. React error
+// boundaries only catch errors thrown during render or lifecycle —
+// `ApiError` is thrown inside `api/client.ts`'s async `request()` from
+// useQuery/useMutation callbacks, which never reach `componentDidCatch`.
+// The "Unable to reach the server" UX is owned by ServerUnreachableOverlay
+// (via useServerHealth's reachability state). The old branch here was a
+// well-intentioned no-op that gave a false sense of double-coverage.
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -38,47 +45,6 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       if (this.props.fallback) return this.props.fallback;
 
       const error = this.state.error;
-      // PR #220: ApiError(status=0) is the "Unable to reach the server" path
-      // emitted by api/client.ts when fetch itself throws (network unreachable,
-      // CORS, server down). Render a softer spinner state — the server is
-      // probably coming back up, not the code being broken.
-      const isServerUnreachable = error instanceof ApiError && error.status === 0;
-
-      if (isServerUnreachable) {
-        return (
-          <div
-            role="alert"
-            className="flex flex-col items-center justify-center min-h-screen p-8"
-          >
-            <div className="max-w-xl w-full text-center">
-              <div className="mb-6 flex justify-center">
-                <div className="relative size-12">
-                  <div className="absolute inset-0 rounded-full border-4 border-muted" />
-                  <div className="absolute inset-0 rounded-full border-4 border-primary border-t-transparent animate-spin" />
-                </div>
-              </div>
-              <h1 className="text-2xl font-semibold mb-3">Unable to reach the server</h1>
-              <p className="text-muted-foreground mb-6">
-                {error.message || "Check your connection and try again."}
-              </p>
-              <div className="flex gap-2 justify-center">
-                <button
-                  onClick={this.handleReload}
-                  className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                >
-                  Reload
-                </button>
-                <button
-                  onClick={this.handleReset}
-                  className="px-4 py-2 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                >
-                  Try again
-                </button>
-              </div>
-            </div>
-          </div>
-        );
-      }
 
       return (
         <div


### PR DESCRIPTION
## Summary

Closes #240. PR #220's merge added a render-branch in \`ui/src/components/ErrorBoundary.tsx\` that special-cases \`ApiError(status === 0)\`. React error boundaries only catch errors thrown during render or lifecycle — \`ApiError\` is thrown inside \`api/client.ts\`'s async \`request()\` from \`useQuery\` / \`useMutation\` callbacks, so this branch was never hit.

## Verification

\`grep -rn \"throw new ApiError\" ui/src/api/client.ts\` confirmed both throw sites are inside the async \`request()\` function — no synchronous render-path throw. Branch is dead.

## Fix

Removed the branch + the unused \`ApiError\` import. The \"Unable to reach the server\" UX is owned by \`ServerUnreachableOverlay\` (via \`useServerHealth\`).

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [x] No existing test references the removed branch
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)