### PR TITLE
fix(digest): coalesce null latestAction so digest never renders "null" (#238)

### DIFF
--- a/server/src/services/heartbeat-digest-adapters.ts
+++ b/server/src/services/heartbeat-digest-adapters.ts
@@ -93,7 +93,13 @@ export function digestActivityAdapter(db: Db) {
           agentId: activityLog.agentId,
           agentName: agents.name,
           count: sql<number>`count(*)::int`,
-          latestAction: sql<string>`(array_agg(${activityLog.action} ORDER BY ${activityLog.createdAt} DESC))[1]`,
+          // Closes #238: coalesce in SQL so the most-recent action is never
+          // null on the wire. activity_log.action is nullable, and the
+          // downstream renderer used to interpolate the literal string
+          // "null" into the digest body when the latest row's action was
+          // missing. The TS-side fallback below is a belt-and-suspenders
+          // guard in case the coalesce is ever bypassed.
+          latestAction: sql<string>`coalesce((array_agg(${activityLog.action} ORDER BY ${activityLog.createdAt} DESC))[1], 'activity')`,
           latestAt: sql<Date>`max(${activityLog.createdAt})`,
         })
         .from(activityLog)
@@ -110,13 +116,20 @@ export function digestActivityAdapter(db: Db) {
 
       return rows
         .filter((row) => !!row.agentName)
-        .map((row) => ({
-          agentName: row.agentName,
-          summary:
-            row.count > 1
-              ? `${row.count} updates (latest: ${row.latestAction})`
-              : row.latestAction,
-        }));
+        .map((row) => {
+          // Closes #238: defense-in-depth fallback. The SQL coalesce above
+          // already substitutes "activity" when the aggregated action is
+          // null, but if a future refactor removes that, we still never
+          // ship a literal "null" into the rendered digest body.
+          const action = row.latestAction ?? "activity";
+          return {
+            agentName: row.agentName,
+            summary:
+              row.count > 1
+                ? `${row.count} updates (latest: ${action})`
+                : action,
+          };
+        });
     },
   };
 }


### PR DESCRIPTION
## Summary

Closes #238. \`activity_log.action\` is nullable. The most-recent-action aggregation in the heartbeat-digest used \`(array_agg(action ORDER BY createdAt DESC))[1]\`, which returns \`null\` when the latest row has a null action. The renderer interpolated that null into the email body, producing literal strings like \`\"3 updates (latest: null)\"\` (or just the bare word \`null\` for the single-row case).

## Fix

Defense in depth:
1. **SQL** — wrap the aggregation in \`coalesce(..., 'activity')\`. Query result is never null on the wire.
2. **TypeScript** — keep a \`row.latestAction ?? \"activity\"\` fallback in the render loop. Survives any future refactor that strips the SQL coalesce.

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [ ] CI green
- Integration: insert \`activity_log\` row with NULL action → digest body falls back to \"activity\" (manual; the file has no unit tests yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)