### PR TITLE
fix(server): replace console.log with logger.info on board-claim notice (#173)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1041,10 +1041,16 @@ export async function startServer(): Promise<StartedServer> {
 
       const boardClaimUrl = getBoardClaimWarningUrl(config.host, listenPort);
       if (boardClaimUrl) {
+        // Closes #173: switched from console.log to logger.info so the
+        // notice flows through the same redaction + level pipeline as
+        // the rest of the startup output (see startup-banner.ts:177 for
+        // the matching pattern). ANSI color codes are kept in the
+        // message; they survive pino's JSON serializer as escaped
+        // string content for interactive TTY runs.
         const red = "\x1b[41m\x1b[30m";
         const yellow = "\x1b[33m";
         const reset = "\x1b[0m";
-        console.log(
+        logger.info(
           [
             `${red}  BOARD CLAIM REQUIRED  ${reset}`,
             `${yellow}This instance was previously local_trusted and still has local-board as the only admin.${reset}`,


### PR DESCRIPTION
Closes #173. The last `console.log` in server/src outside vendored upstream code, switched to `logger.info` to match `startup-banner.ts`'s existing pattern. The `registry.ts` console.logs are intentionally left alone (upstream-managed).