### PR TITLE
hotfix(shared): export isAgentPlanPayload from package root (regression from #294)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -988,6 +988,14 @@ export type {
 
 export * from "./mention-parser.js";
 
+// AgentDash (#234, #231): canonical agent-plan validator. Re-exported
+// here so server-side code can `import { isAgentPlanPayload } from
+// "@paperclipai/shared"` without reaching into the validators subpath.
+// CI's TS build (which doesn't see local symlinks the same way as local
+// `pnpm typecheck`) failed when this was only registered in
+// validators/index.ts — added here to keep both surfaces in sync.
+export { isAgentPlanPayload } from "./validators/agent-plan.js";
+
 // AgentDash: chat substrate card payload types
 export * from "./cards.js";
 


### PR DESCRIPTION
## Summary

Hot-fix for a regression PR #294 introduced into main: \`isAgentPlanPayload\` was added to \`packages/shared/src/validators/index.ts\` but NOT to the package root \`packages/shared/src/index.ts\`. The root re-exports validators piecewise (no \`export *\`), so consumers of \`@paperclipai/shared\` couldn't see the new symbol.

CI's \`verify\` and \`e2e\` lanes have been failing with:
\`\`\`
TS2305: Module '@paperclipai/shared' has no exported member 'isAgentPlanPayload'.
\`\`\`

Both lanes are non-required (excluded pending #286 / #295), which is why the breakage slipped through every PR since #294 was merged.

## Fix

Add the re-export. One-line change.

## Why local typecheck didn't catch this

Local \`pnpm -r typecheck\` resolves \`@paperclipai/shared\` via the workspace symlink and the NodeNext resolver appears to let TS reach into the validators subpath transitively. CI's typecheck runs against a deduped install and fails strictly. Adding the explicit root re-export resolves both.

## Test plan

- [x] \`pnpm -r typecheck\` clean locally
- [ ] CI \`verify\` and \`e2e\` should go green (or at least no longer fail at typecheck/build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)