### PR TITLE
fix(digest): real email body — greeting + grouped section + CTA (#225)

### DIFF
--- a/server/src/__tests__/heartbeat-digest.test.ts
+++ b/server/src/__tests__/heartbeat-digest.test.ts
@@ -34,4 +34,119 @@ describe("heartbeatDigest.run", () => {
     await heartbeatDigest({ email, activity, users } as any).run();
     expect(email.send).not.toHaveBeenCalled();
   });
+
+  // Closes #225: renderBody now produces a real email — greeting, context
+  // line, per-agent bullet list, and a "Open in AgentDash" CTA. The old
+  // body collapsed everything into one-line slop.
+  describe("body rendering (#225)", () => {
+    async function runWith(opts: {
+      user: { id: string; email: string; name?: string | null };
+      activity: Array<{ agentName: string; summary: string }>;
+      publicBaseUrl?: string;
+    }) {
+      const captured: Array<{ to: string; subject: string; body: string }> = [];
+      const email = {
+        send: vi.fn(async (msg: { to: string; subject: string; body: string }) => {
+          captured.push(msg);
+        }),
+      };
+      const activity = { listSince: vi.fn(async () => opts.activity) };
+      const users = { listForDigest: vi.fn().mockResolvedValue([opts.user]) };
+      await heartbeatDigest({
+        email,
+        activity,
+        users,
+        publicBaseUrl: opts.publicBaseUrl,
+      } as any).run();
+      return captured[0]!;
+    }
+
+    it("greets by first name when authUsers.name is set", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada Lovelace" },
+        activity: [{ agentName: "Reese", summary: "sent 14 drafts" }],
+      });
+      expect(msg.body).toContain("Hi Ada,");
+    });
+
+    it("falls back to capitalized email local-part when name is missing", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada.lovelace@acme.com" },
+        activity: [{ agentName: "Reese", summary: "sent 14 drafts" }],
+      });
+      expect(msg.body).toContain("Hi Ada,");
+    });
+
+    it("falls back to \"there\" when email is empty", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "" },
+        activity: [{ agentName: "Reese", summary: "sent 14 drafts" }],
+      });
+      expect(msg.body).toContain("Hi there,");
+    });
+
+    it("reports the activity count in the context line", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada" },
+        activity: [
+          { agentName: "Reese", summary: "drafted email" },
+          { agentName: "Mira", summary: "triaged 3 items" },
+        ],
+      });
+      expect(msg.body).toContain("your team did 2 things");
+    });
+
+    it("uses singular \"thing\" when the activity count is 1", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada" },
+        activity: [{ agentName: "Reese", summary: "drafted email" }],
+      });
+      expect(msg.body).toContain("your team did 1 thing:");
+    });
+
+    it("renders one bullet per agent activity", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada" },
+        activity: [
+          { agentName: "Reese", summary: "drafted email" },
+          { agentName: "Mira", summary: "triaged 3 items" },
+        ],
+      });
+      expect(msg.body).toContain("• Reese: drafted email");
+      expect(msg.body).toContain("• Mira: triaged 3 items");
+    });
+
+    it("includes the \"Open in AgentDash\" CTA with absolute URL when publicBaseUrl set", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada" },
+        activity: [{ agentName: "Reese", summary: "drafted email" }],
+        publicBaseUrl: "https://agentdash.example.com",
+      });
+      expect(msg.body).toContain("Open in AgentDash → https://agentdash.example.com/cos");
+    });
+
+    it("falls back to a relative /cos CTA when publicBaseUrl is unset", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada" },
+        activity: [{ agentName: "Reese", summary: "drafted email" }],
+      });
+      expect(msg.body).toContain("Open in AgentDash → /cos");
+    });
+
+    it("does NOT render the body as one-line slop (regression guard)", async () => {
+      const msg = await runWith({
+        user: { id: "u1", email: "ada@acme.com", name: "Ada" },
+        activity: [
+          { agentName: "Reese", summary: "drafted email" },
+          { agentName: "Mira", summary: "triaged 3 items" },
+        ],
+      });
+      // The OLD body was `Reese: drafted email\nMira: triaged 3 items` —
+      // no greeting, no CTA. Assert all three new pieces are present so
+      // a regression to the old renderer would fail at least one of these.
+      expect(msg.body).toContain("Hi ");
+      expect(msg.body).toContain("your team did");
+      expect(msg.body).toContain("Open in AgentDash");
+    });
+  });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -964,6 +964,11 @@ export async function startServer(): Promise<StartedServer> {
       email: digestEmailAdapter(),
       activity: digestActivityAdapter(db as any),
       users: digestUserAdapter(db as any),
+      // Closes #225: publicBaseUrl threads into the "Open in AgentDash"
+      // CTA. Falls back to "" when unset (CTA renders /cos as a
+      // relative path; mail clients typically resolve against the
+      // sender domain, but absolute is preferred).
+      publicBaseUrl: config.authPublicBaseUrl,
     });
     logger.info({ intervalMs: digestIntervalMs }, "[digest] heartbeatDigest schedule enabled");
     heartbeatDigestHandle = setInterval(() => {

--- a/server/src/services/heartbeat-digest-adapters.ts
+++ b/server/src/services/heartbeat-digest-adapters.ts
@@ -23,6 +23,9 @@ interface Activity {
 interface DigestUser {
   id: string;
   email: string;
+  // Closes #225: thread display name through to the renderer for the
+  // "Hi {firstName}" greeting. Pulled from authUsers.name below.
+  name?: string | null;
   timezone?: string;
 }
 
@@ -42,6 +45,10 @@ export function digestUserAdapter(db: Db) {
         .selectDistinct({
           id: authUsers.id,
           email: authUsers.email,
+          // Closes #225: pull authUsers.name so renderBody can greet
+          // the user by first name instead of falling back to the
+          // email local-part.
+          name: authUsers.name,
         })
         .from(authUsers)
         .innerJoin(
@@ -53,7 +60,7 @@ export function digestUserAdapter(db: Db) {
           ),
         )
         .where(eq(authUsers.emailVerified, true));
-      return rows.map((row) => ({ id: row.id, email: row.email }));
+      return rows.map((row) => ({ id: row.id, email: row.email, name: row.name }));
     },
   };
 }

--- a/server/src/services/heartbeat-digest.ts
+++ b/server/src/services/heartbeat-digest.ts
@@ -1,3 +1,9 @@
+// Closes #225: heartbeatDigest now renders a proper email body — greeting,
+// context line ("While you were away, your team did N things"), grouped
+// per-agent section, and an "Open in AgentDash" CTA. The old renderer
+// collapsed everything into one-line `agentName: summary` slop, which
+// gave no clear next action and failed the spec's value-prop test.
+
 interface Activity {
   agentName: string;
   summary: string;
@@ -6,6 +12,9 @@ interface Activity {
 interface DigestUser {
   id: string;
   email: string;
+  // Closes #225: optional display name for the greeting. Adapter pulls
+  // this from authUsers.name; falls back to the email local-part below.
+  name?: string | null;
   timezone?: string;
 }
 
@@ -13,6 +22,12 @@ interface Deps {
   email: { send: (msg: { to: string; subject: string; body: string }) => Promise<void> };
   activity: { listSince: (userId: string, sinceHours: number) => Promise<Activity[]> };
   users: { listForDigest: () => Promise<DigestUser[]> };
+  // Closes #225: public origin used to build the "Open in AgentDash"
+  // deep link. When omitted, the CTA renders as a plain "/cos" path —
+  // most mail clients still resolve relative paths against the originating
+  // domain in HTML emails, but absolute is preferred. Wire from
+  // process.env.AGENTDASH_PUBLIC_BASE_URL at the caller.
+  publicBaseUrl?: string;
 }
 
 export function heartbeatDigest(deps: Deps) {
@@ -23,7 +38,7 @@ export function heartbeatDigest(deps: Deps) {
         const activity = await deps.activity.listSince(user.id, 24);
         if (activity.length === 0) continue;
         const subject = renderSubject(activity);
-        const body = renderBody(activity);
+        const body = renderBody(user, activity, deps.publicBaseUrl);
         await deps.email.send({ to: user.email, subject, body });
       }
     },
@@ -40,6 +55,48 @@ function renderSubject(activity: Activity[]): string {
   return `${first.agentName}: ${first.summary}${more}`;
 }
 
-function renderBody(activity: Activity[]): string {
-  return activity.map((a) => `${a.agentName}: ${a.summary}`).join("\n");
+// Closes #225: per onboarding spec §5 the digest body should feel
+// person-written, point at the most useful next click, and never leave
+// the reader wondering what to do. Structure:
+//
+//   Hi {firstName},
+//
+//   While you were away, your team did {N} thing{s}:
+//
+//     • {agentName}: {summary}
+//     • ...
+//
+//   Open in AgentDash → {publicBaseUrl}/cos
+//
+// `firstName` falls back to the email local-part (before "@") when no
+// authUsers.name is available, so we never address a digest as "Hi ,".
+function renderBody(user: DigestUser, activity: Activity[], publicBaseUrl?: string): string {
+  const firstName = pickFirstName(user);
+  const count = activity.length;
+  const ctaUrl = `${publicBaseUrl ?? ""}/cos`;
+  const lines: string[] = [];
+  lines.push(`Hi ${firstName},`);
+  lines.push("");
+  lines.push(
+    `While you were away, your team did ${count} thing${count === 1 ? "" : "s"}:`,
+  );
+  lines.push("");
+  for (const a of activity) {
+    lines.push(`  • ${a.agentName}: ${a.summary}`);
+  }
+  lines.push("");
+  lines.push(`Open in AgentDash → ${ctaUrl}`);
+  return lines.join("\n");
+}
+
+function pickFirstName(user: DigestUser): string {
+  const name = (user.name ?? "").trim();
+  if (name) return name.split(/\s+/)[0]!;
+  const local = (user.email ?? "").split("@")[0] ?? "";
+  if (local) {
+    // "ada.lovelace" → "Ada", "ada_lovelace" → "Ada", "ada-lovelace" → "Ada"
+    const first = local.split(/[._-]/)[0] ?? local;
+    return first.charAt(0).toUpperCase() + first.slice(1);
+  }
+  return "there";
 }


### PR DESCRIPTION
## Summary

Closes #225. The heartbeatDigest renderer previously produced one-line \`agentName: summary\` slop — no greeting, no link, no clear next action. Spec §5 calls for a proper email with subject preview, context line, and an \"Open in AgentDash\" CTA.

## New body shape

\`\`\`
Hi {firstName},

While you were away, your team did {N} thing{s}:

  • {agentName}: {summary}
  • ...

Open in AgentDash → {publicBaseUrl}/cos
\`\`\`

## Implementation

- \`heartbeat-digest.ts\` — \`renderBody\` now takes \`(user, activity, publicBaseUrl)\`. \`firstName\` falls back to capitalized email local-part when \`authUsers.name\` is missing, then to \"there\" when the email is also empty.
- \`heartbeat-digest-adapters.ts\` — \`digestUserAdapter\` selects \`authUsers.name\` and threads it into \`DigestUser\`.
- \`index.ts\` — wires \`config.authPublicBaseUrl\` into the digester so the CTA renders as an absolute URL when configured. Falls back to \`/cos\` as a relative path otherwise.

## Test plan

- [x] 9 new unit tests in \`heartbeat-digest.test.ts\` covering: name fallbacks (3 cases), activity-count pluralization, bullet rendering, absolute and relative CTA paths, plus a regression-guard against returning to the one-line renderer
- [x] \`pnpm -r typecheck\` clean
- [x] All 11 digest tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)