### PR TITLE
fix(e2e): wire AGENTDASH_DEEP_INTERVIEW_ASSESS=true in CI + webServer env

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -151,6 +151,14 @@ jobs:
       - name: Run e2e tests
         env:
           PAPERCLIP_E2E_SKIP_LLM: "true"
+          # Successor of #295: the onboarding-deep-interview spec
+          # requires the /assess endpoint to route through the
+          # deep-interview engine (not the legacy assess path). Without
+          # this flag the engine returns 503 on every turn and the spec
+          # parade fails. The webServer subprocess in
+          # tests/e2e/playwright.config.ts forwards process.env, so
+          # setting it here makes it visible to the booted server.
+          AGENTDASH_DEEP_INTERVIEW_ASSESS: "true"
         run: pnpm run test:e2e
 
       - name: Upload Playwright report

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -48,6 +48,13 @@ export default defineConfig({
       PAPERCLIP_BIND: "loopback",
       PAPERCLIP_DEPLOYMENT_MODE: "local_trusted",
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private",
+      // Successor of #295: the onboarding-deep-interview spec requires
+      // /assess to route through the deep-interview engine; without
+      // this flag the route returns 503 on every turn. Default to true
+      // so local `pnpm test:e2e` runs match CI behavior; callers that
+      // need the legacy path can set it to "false" in their shell.
+      AGENTDASH_DEEP_INTERVIEW_ASSESS:
+        process.env.AGENTDASH_DEEP_INTERVIEW_ASSESS ?? "true",
     },
   },
   outputDir: "./test-results",


### PR DESCRIPTION
## Summary

After PR #307 unblocked the cold-bootstrap-company assertion, the onboarding-deep-interview spec hit a new failure: \`POST /assess\` returned 503 on every turn. The spec's own header comment names the missing env var — \`AGENTDASH_DEEP_INTERVIEW_ASSESS=true\` — which was never wired into pr.yml or playwright.config.ts.

## Fix

Set it in two places:
1. \`.github/workflows/pr.yml\` — so CI's \`pnpm run test:e2e\` step sees it
2. \`tests/e2e/playwright.config.ts\` webServer.env — so local \`pnpm test:e2e\` runs match CI

Local callers that want the legacy path can override with \`AGENTDASH_DEEP_INTERVIEW_ASSESS=false pnpm test:e2e\`.

## Test plan

- [ ] CI e2e job goes green on this PR — the actual verification
- [ ] After merge: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)