### PR TITLE
fix(e2e): onboarding wizard test follows CoS-rename (#311)

### DIFF
--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -16,8 +16,15 @@ import { test, expect } from "@playwright/test";
 
 const SKIP_LLM = process.env.PAPERCLIP_E2E_SKIP_LLM !== "false";
 
+// Closes #311: the OnboardingWizard's default agent renamed from "CEO"
+// (role=ceo) to "CoS" (role=chief_of_staff) at the CoS-onboarding refit.
+// Test updated to match the current product shape — see
+// ui/src/components/OnboardingWizard.tsx for the canonical defaults
+// (placeholder="CoS", role="chief_of_staff", DEFAULT_TASK_DESCRIPTION
+// starts with "You are the Chief of Staff (CoS).").
 const COMPANY_NAME = `E2E-Test-${Date.now()}`;
-const AGENT_NAME = "CEO";
+const AGENT_NAME = "CoS";
+const AGENT_ROLE = "chief_of_staff";
 const TASK_TITLE = "E2E test task";
 
 test.describe("Onboarding wizard", () => {
@@ -38,7 +45,7 @@ test.describe("Onboarding wizard", () => {
       page.locator("h3", { hasText: "Create your first agent" })
     ).toBeVisible({ timeout: 30_000 });
 
-    const agentNameInput = page.locator('input[placeholder="CEO"]');
+    const agentNameInput = page.locator('input[placeholder="CoS"]');
     await expect(agentNameInput).toHaveValue(AGENT_NAME);
 
     await expect(
@@ -130,7 +137,7 @@ test.describe("Onboarding wizard", () => {
       (a: { name: string }) => a.name === AGENT_NAME
     );
     expect(ceoAgent).toBeTruthy();
-    expect(ceoAgent.role).toBe("ceo");
+    expect(ceoAgent.role).toBe(AGENT_ROLE);
     expect(ceoAgent.adapterType).not.toBe("process");
 
     const instructionsBundleRes = await page.request.get(
@@ -153,7 +160,7 @@ test.describe("Onboarding wizard", () => {
     expect(task).toBeTruthy();
     expect(task.assigneeAgentId).toBe(ceoAgent.id);
     expect(task.description).toContain(
-      "You are the CEO. You set the direction for the company."
+      "You are the Chief of Staff (CoS)."
     );
     expect(task.description).not.toContain("github.com/paperclipai/companies");
 


### PR DESCRIPTION
## Summary

Closes the **onboarding-wizard portion** of #311.

The OnboardingWizard's default first-agent renamed from \"CEO\" (role=\`ceo\`) to \"CoS\" (role=\`chief_of_staff\`) at the CoS-onboarding refit. The e2e test was never updated — every CI run since the rename failed at the \`input[placeholder=\"CEO\"]\` selector before reaching any of the later assertions.

## Changes (4 lines of meaningful diff)

1. \`AGENT_NAME\`: \"CEO\" → \"CoS\"
2. Step-2 selector: placeholder \"CEO\" → \"CoS\"
3. Role check: \"ceo\" → \"chief_of_staff\"
4. Task description: \"You are the CEO. You set the direction...\" → \"You are the Chief of Staff (CoS).\"

Bundle-paths assertion unchanged — \`onboarding-orchestrator.ts:259\` still loads exactly the four files SOUL.md / AGENTS.md / HEARTBEAT.md / TOOLS.md.

## What's still open

The sibling failures in \`signoff-policy.spec.ts:333,372\` (changes-requested and comment-required flows) are deeper — they appear to be state issues (test ordering or single-company-installation guard interaction) and warrant a separate focused PR.

## Test plan

- [x] Spec changes match the current UI (verified via grep of OnboardingWizard.tsx)
- [ ] CI e2e: this spec progresses past step-2 (signoff failures still expected)
- [ ] Once signoff specs are also green: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)