### PR TITLE
fix(e2e): set AGENTDASH_ALLOW_MULTI_COMPANY=true so signoff-policy can stand up its own company (#311)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -159,6 +159,16 @@ jobs:
           # tests/e2e/playwright.config.ts forwards process.env, so
           # setting it here makes it visible to the booted server.
           AGENTDASH_DEEP_INTERVIEW_ASSESS: "true"
+          # Successor of #311: specs run alphabetically in one
+          # webServer process, so onboarding-deep-interview's
+          # ensureCompanyExists helper creates a company first, then
+          # signoff-policy's beforeAll tries to POST a SECOND company
+          # and hits the #102 single-company-installation guard (409).
+          # The override here matches what the dev docs already promise
+          # for local_trusted dev (`AGENTDASH_DEV_MODE=true`), but is
+          # set explicitly so the bypass intent is obvious from the CI
+          # config alone.
+          AGENTDASH_ALLOW_MULTI_COMPANY: "true"
         run: pnpm run test:e2e
 
       - name: Upload Playwright report

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -55,6 +55,13 @@ export default defineConfig({
       // need the legacy path can set it to "false" in their shell.
       AGENTDASH_DEEP_INTERVIEW_ASSESS:
         process.env.AGENTDASH_DEEP_INTERVIEW_ASSESS ?? "true",
+      // Successor of #311: onboarding-deep-interview's ensure-company
+      // helper creates the first workspace, then signoff-policy tries
+      // to POST a second one and hits the #102 single-company guard.
+      // Bypass the guard for the duration of the e2e run so all specs
+      // can stand up their own isolated company state.
+      AGENTDASH_ALLOW_MULTI_COMPANY:
+        process.env.AGENTDASH_ALLOW_MULTI_COMPANY ?? "true",
     },
   },
   outputDir: "./test-results",


### PR DESCRIPTION
## Summary

Specs in \`tests/e2e/\` run alphabetically inside ONE webServer process. After #295/#307 added \`ensureCompanyExists\` to onboarding-deep-interview (POSTs the first workspace when local_trusted boots empty), signoff-policy.beforeAll then POSTs a *second* company — which trips the #102 single-company-installation guard (409 \`single_company_installation\`).

That 409 cascades into the 3 spec failures named in #311.

## Fix

Set \`AGENTDASH_ALLOW_MULTI_COMPANY=true\` in two places:
1. \`.github/workflows/pr.yml\` — for the runner's \`pnpm test:e2e\` step
2. \`tests/e2e/playwright.config.ts\` webServer.env — for local runs

The override is the canonical escape hatch already implemented in \`server/src/routes/companies.ts:isSingleCompanyOverrideActive\` — we just hadn't wired it into the CI env.

## Test plan

- [ ] CI e2e job goes green on this PR — combined with #310 (DEEP_INTERVIEW_ASSESS) and #312 (CoS rename), this should be the last piece
- [ ] After merge: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)