### PR TITLE
fix(e2e): disable rate limiter — 429 was the real e2e blocker (#311)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -169,6 +169,16 @@ jobs:
           # set explicitly so the bypass intent is obvious from the CI
           # config alone.
           AGENTDASH_ALLOW_MULTI_COMPANY: "true"
+          # Successor of #311 (round 2): the signoff-policy suite alone
+          # creates ~7 issues in one company in rapid succession, plus
+          # the prior specs eat ~50 requests against the same actor key.
+          # The default 200-req / 15-min ceiling (server/src/middleware/
+          # rate-limit.ts) trips inside the suite and returns 429 on
+          # POST /companies/:id/issues — manifests as
+          # \`expect(res.ok()).toBe(true)\` failures in createIssueWithPolicy.
+          # Disable rate limiting for the e2e run; the per-actor limit
+          # is a production-traffic concern, not a test concern.
+          AGENTDASH_RATE_LIMIT_DISABLED: "true"
         run: pnpm run test:e2e
 
       - name: Upload Playwright report

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -62,6 +62,12 @@ export default defineConfig({
       // can stand up their own isolated company state.
       AGENTDASH_ALLOW_MULTI_COMPANY:
         process.env.AGENTDASH_ALLOW_MULTI_COMPANY ?? "true",
+      // Successor of #311 (round 2): the default tiered rate limiter
+      // (200 req / 15 min per actor) trips inside the signoff-policy
+      // suite (7+ rapid issue creates on one board actor) and returns
+      // 429 from POST /companies/:id/issues. Disable for e2e runs.
+      AGENTDASH_RATE_LIMIT_DISABLED:
+        process.env.AGENTDASH_RATE_LIMIT_DISABLED ?? "true",
     },
   },
   outputDir: "./test-results",


### PR DESCRIPTION
## Summary

The 3 remaining e2e failures from #311 are caused by HTTP 429 from the tiered rate limiter (\`server/src/middleware/rate-limit.ts\`, 200 req / 15 min per board actor). The e2e suite — running specs in serial in one webServer — burns through that ceiling inside \`signoff-policy.beforeAll\` (3 agents + 3 keys created), and subsequent \`POST /companies/:id/issues\` calls return 429.

The 429s manifest as:
\`\`\`
expect(res.ok()).toBe(true)
Expected: true
Received: false
\`\`\`
…inside \`createIssueWithPolicy\`.

## Fix

Set \`AGENTDASH_RATE_LIMIT_DISABLED=true\` in:
1. \`.github/workflows/pr.yml\` — CI env
2. \`tests/e2e/playwright.config.ts\` webServer.env — local runs

The product already implements the bypass. Per-actor request caps are a production-traffic concern (#160 brute-force / billing-fraud mitigation), not a test concern.

## Test plan

- [ ] CI e2e job goes GREEN on this PR — should be the last blocker
- [ ] After merge: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)