### PR TITLE
fix(e2e): AGENTDASH_ADAPTER_ENV_BYPASS=true unblocks onboarding wizard test (#315)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -179,6 +179,14 @@ jobs:
           # Disable rate limiting for the e2e run; the per-actor limit
           # is a production-traffic concern, not a test concern.
           AGENTDASH_RATE_LIMIT_DISABLED: "true"
+          # Successor of #311 (round 3) / closes #315: the
+          # onboarding.spec wizard test picks "Claude Code" (claude_local)
+          # and OnboardingWizard.handleStep2Next runs a real adapter
+          # binary probe before advancing. CI runners have no Claude
+          # binary → probe returns failed → step 2 never transitions
+          # to step 3. The bypass returns a synthetic "pass" so the
+          # test can exercise the rest of the wizard.
+          AGENTDASH_ADAPTER_ENV_BYPASS: "true"
         run: pnpm run test:e2e
 
       - name: Upload Playwright report

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1238,6 +1238,33 @@ export function agentRoutes(
       const type = assertKnownAdapterType(req.params.type as string);
       await assertCanReadConfigurations(req, companyId);
 
+      // Closes #315: e2e bypass — when AGENTDASH_ADAPTER_ENV_BYPASS=true
+      // is set, short-circuit the adapter probe and return a synthetic
+      // "pass" result. Lets the OnboardingWizard flow advance past step 2
+      // on a CI runner that has no Claude/Codex/etc. binary installed.
+      // The bypass is OFF by default so production adapter-environment
+      // checks (the real customer-facing functionality) are unaffected.
+      // Same env-var pattern as AGENTDASH_DEEP_INTERVIEW_ASSESS,
+      // AGENTDASH_ALLOW_MULTI_COMPANY, AGENTDASH_RATE_LIMIT_DISABLED.
+      if (process.env.AGENTDASH_ADAPTER_ENV_BYPASS === "true") {
+        res.json({
+          adapterType: type,
+          status: "pass",
+          checks: [
+            {
+              code: "adapter_env_bypass",
+              level: "info",
+              message: "Adapter environment probe bypassed",
+              detail:
+                "AGENTDASH_ADAPTER_ENV_BYPASS=true is set; the real adapter binary check was skipped. Unset this env var to run the actual probe.",
+              hint: null,
+            },
+          ],
+          testedAt: new Date().toISOString(),
+        });
+        return;
+      }
+
       const adapter = requireServerAdapter(type);
 
       const inputAdapterConfig =

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -68,6 +68,13 @@ export default defineConfig({
       // 429 from POST /companies/:id/issues. Disable for e2e runs.
       AGENTDASH_RATE_LIMIT_DISABLED:
         process.env.AGENTDASH_RATE_LIMIT_DISABLED ?? "true",
+      // Closes #315: onboarding.spec.ts picks "Claude Code" and the
+      // wizard runs a real binary probe before advancing. CI runners
+      // (and most dev machines) won't have a Claude binary. The bypass
+      // returns a synthetic "pass" so the test exercises the wizard
+      // shape, not the adapter-environment probe.
+      AGENTDASH_ADAPTER_ENV_BYPASS:
+        process.env.AGENTDASH_ADAPTER_ENV_BYPASS ?? "true",
     },
   },
   outputDir: "./test-results",


### PR DESCRIPTION
## Summary

Closes #315 — the last remaining e2e spec failure.

OnboardingWizard.handleStep2Next runs a real adapter binary probe before advancing to step 3. CI runners have no Claude binary → probe fails → step 2 never transitions → \`onboarding.spec.ts\` times out at the step-3 \"Give it something to do\" heading.

## Fix

Three places:
1. **\`server/src/routes/agents.ts\`** — early return in the test-environment route when \`AGENTDASH_ADAPTER_ENV_BYPASS=true\`. Returns a well-formed synthetic \`AdapterEnvironmentTestResult\` with \`status: \"pass\"\` and an \`adapter_env_bypass\` info check explaining the bypass.
2. **\`.github/workflows/pr.yml\`** — CI env.
3. **\`tests/e2e/playwright.config.ts\` webServer.env** — local runs.

Same pattern as \`AGENTDASH_DEEP_INTERVIEW_ASSESS\`, \`AGENTDASH_ALLOW_MULTI_COMPANY\`, \`AGENTDASH_RATE_LIMIT_DISABLED\`. Off by default — production behavior unchanged.

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [ ] CI \`e2e\` job goes GREEN (every spec passes)
- [ ] After merge: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)