### PR TITLE
fix(shared): add chief_of_staff to AGENT_ROLES — fixes 400 on wizard hire (#317)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -61,6 +61,14 @@ export const AGENT_ROLES = [
   "devops",
   "researcher",
   "general",
+  // Closes #317: chief_of_staff is the role the onboarding-wizard
+  // creates for the founding-user CoS agent (per OnboardingWizard.tsx
+  // line 469) AND the role the deep-interview flow looks for (see
+  // server/src/routes/conversations.ts:28 and friends). Was missing
+  // from this allowlist → the wizard's POST /agent-hires payload
+  // failed the Zod enum check with a silent 400, blocking real users
+  // AND the e2e wizard spec from completing step 2.
+  "chief_of_staff",
 ] as const;
 export type AgentRole = (typeof AGENT_ROLES)[number];
 
@@ -77,6 +85,8 @@ export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   devops: "DevOps",
   researcher: "Researcher",
   general: "General",
+  // Closes #317: see AGENT_ROLES note above.
+  chief_of_staff: "Chief of Staff",
 };
 
 export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 20;


### PR DESCRIPTION
## Summary

Closes #317. Found the root cause of the last e2e blocker — and it's actually a real production bug.

The OnboardingWizard creates the founding-user agent with \`role: \"chief_of_staff\"\` (\`OnboardingWizard.tsx:469\`), but \`\"chief_of_staff\"\` was NOT in \`AGENT_ROLES\`. The Zod enum validator on \`createAgentSchema.role\` rejected the request with a silent 400 — the CI logs only showed the request body, no response body, so the failure mode was \"wizard never advances to step 3.\"

This affects production too: any founding user going through the legacy wizard path (\`/onboarding\`) hits the same 400. The deep-interview /cos path apparently escapes because it goes through \`onboarding-orchestrator\` which bypasses \`createAgentHireSchema\`.

## Fix

Two-line patch:
1. \`AGENT_ROLES\` gets \`\"chief_of_staff\"\` appended
2. \`AGENT_ROLE_LABELS\` gets \"Chief of Staff\" entry

The role is already used throughout the codebase as a recognized concept (conversations.ts, cos-replier.ts, agent-instruction-refresh.ts, all the onboarding tests). Just needed to be declared in the canonical allowlist.

## Test plan

- [x] \`pnpm -r typecheck\` clean (no exhaustive-switch breaks; AgentRole is used as a type only)
- [ ] CI e2e: wizard spec passes
- [ ] After merge: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)