### PR TITLE
fix(server): CoS hires get the full 4-file instructions bundle (#317 follow-up)

### DIFF
--- a/server/src/services/default-agent-instructions.ts
+++ b/server/src/services/default-agent-instructions.ts
@@ -3,6 +3,13 @@ import fs from "node:fs/promises";
 const DEFAULT_AGENT_BUNDLE_FILES = {
   default: ["AGENTS.md"],
   ceo: ["AGENTS.md", "HEARTBEAT.md", "SOUL.md", "TOOLS.md"],
+  // Closes #317 follow-up: the OnboardingWizard creates a
+  // chief_of_staff agent (per #318 which added the role to
+  // AGENT_ROLES). The default-bundle map didn't have a corresponding
+  // entry, so newly-hired CoS agents got only AGENTS.md instead of
+  // the full SOUL/AGENTS/HEARTBEAT/TOOLS kit that
+  // server/src/onboarding-assets/chief_of_staff/ ships.
+  chief_of_staff: ["AGENTS.md", "HEARTBEAT.md", "SOUL.md", "TOOLS.md"],
 } as const;
 
 type DefaultAgentBundleRole = keyof typeof DEFAULT_AGENT_BUNDLE_FILES;
@@ -23,5 +30,7 @@ export async function loadDefaultAgentInstructionsBundle(role: DefaultAgentBundl
 }
 
 export function resolveDefaultAgentInstructionsBundleRole(role: string): DefaultAgentBundleRole {
-  return role === "ceo" ? "ceo" : "default";
+  if (role === "ceo") return "ceo";
+  if (role === "chief_of_staff") return "chief_of_staff";
+  return "default";
 }


### PR DESCRIPTION
## Summary

Second-order fix for the wizard e2e block, and a real production bug:

After PR #318 added \`chief_of_staff\` to AGENT_ROLES (which fixed the hire-validation 400), the wizard test progressed past hire but failed the bundle assertion — a freshly-hired CoS got only \`AGENTS.md\` instead of the full 4-file kit.

\`DEFAULT_AGENT_BUNDLE_FILES\` had entries only for \`\"default\"\` (1 file) and \`\"ceo\"\` (4 files). \`resolveDefaultAgentInstructionsBundleRole\` mapped \"ceo\" → \"ceo\" and everything else → \"default\". So role=\"chief_of_staff\" → 1-file bundle, dropping SOUL/HEARTBEAT/TOOLS.

**This is also a production bug.** Every CoS hire made through the wizard since the CoS rename has shipped with only AGENTS.md, missing the HEARTBEAT contract, the SOUL framing, and the TOOLS reference card. Founding-user agents have been running with incomplete instruction bundles.

## Fix

1. \`DEFAULT_AGENT_BUNDLE_FILES.chief_of_staff = [\"AGENTS.md\", \"HEARTBEAT.md\", \"SOUL.md\", \"TOOLS.md\"]\` (matches the existing \"ceo\" entry and the assets shipped under \`server/src/onboarding-assets/chief_of_staff/\`)
2. \`resolveDefaultAgentInstructionsBundleRole\` maps \"chief_of_staff\" → \"chief_of_staff\"

INTERVIEW.md is loaded separately by cos-interview.ts at prompt-build time, so it stays out of the instructions bundle.

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [ ] CI e2e: wizard spec passes (last assertion to pass)
- [ ] After merge: re-add \`e2e\` to required branch-protection contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)