### PR TITLE
fix(test): Layout test mocks TrialBanner + UpgradePromptModal (#286 unhandled errors)

### DIFF
--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -71,6 +71,19 @@ vi.mock("./NewAgentDialog", () => ({
   NewAgentDialog: () => null,
 }));
 
+// Closes #286 unhandled-errors: TrialBanner + UpgradePromptModal call
+// billingApi.status / register cap-exceeded listeners at mount. In jsdom
+// `fetch` with a relative path throws "Failed to parse URL", surfacing as
+// an unhandled error after the test finishes. Mock both out — Layout
+// tests only care about Layout structure, not these notification surfaces.
+vi.mock("./TrialBanner", () => ({
+  TrialBanner: () => null,
+}));
+
+vi.mock("./UpgradePromptModal", () => ({
+  UpgradePromptModal: () => null,
+}));
+
 vi.mock("./KeyboardShortcutsCheatsheet", () => ({
   KeyboardShortcutsCheatsheet: () => null,
 }));


### PR DESCRIPTION
Mocks two notification surfaces added during the billing-UI cluster work. Their componentDidMount hooks call `billingApi.status` which uses a relative URL — jsdom throws "Failed to parse URL" → unhandled rejection → suite exit 1.

After this lands the unhandled-error count drops to 0. Remaining failures (16 tests in 3 workspace-runtime files) are a separate flake — temp-dir ENOENT race condition.