### PR TITLE
fix(test+script): workspace-runtime tests pass on dev machines with paperclipai installed (#325)

### DIFF
--- a/scripts/provision-worktree.sh
+++ b/scripts/provision-worktree.sh
@@ -335,7 +335,14 @@ EOF
 if [[ -e "$worktree_config_path" && -e "$worktree_env_path" ]]; then
   echo "Reusing existing isolated Paperclip worktree config at $worktree_config_path" >&2
 else
-  if paperclipai_command_available; then
+  # Closes #325: PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT=true skips the
+  # paperclipai-CLI path entirely. Used by integration tests that don't
+  # want a system-installed paperclipai (Homebrew, pnpm-global) to
+  # shadow the fallback path the test is asserting against.
+  if [[ "${PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT:-}" = "true" ]]; then
+    echo "PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT=true; writing isolated fallback config." >&2
+    write_fallback_worktree_config
+  elif paperclipai_command_available; then
     run_isolated_worktree_init
   else
     echo "paperclipai CLI not available in this workspace; writing isolated fallback config without DB seeding." >&2

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -58,6 +58,47 @@ if (!embeddedPostgresSupport.supported) {
 }
 const provisionWorktreeScriptPath = new URL("../../../scripts/provision-worktree.sh", import.meta.url);
 
+// Closes #325: provide a synthetic `paperclipai` shim in fakeBin so the
+// test's PATH-shadow path is deterministic across dev machines.
+//
+// Without this shim:
+//   - On a dev machine with `paperclipai` installed via Homebrew or
+//     pnpm-global, provision-worktree.sh's `paperclipai_command_available`
+//     check returns true (step 3 finds /opt/homebrew/bin/paperclipai),
+//     then `run_isolated_worktree_init` invokes the REAL binary against
+//     the test's fake worktree dir. The real binary fails (no source
+//     config in the test fixture), and with `set -e` the whole script
+//     aborts — but only AFTER the install retry has run. Net effect:
+//     the install-retry stderr assertion passes while .paperclip/
+//     config.json never gets written.
+//   - On CI (no paperclipai), the fallback path runs and writes config.
+//
+// With this shim:
+//   - fakeBin is first on PATH, so `command -v paperclipai` resolves to
+//     OUR shim, not the system binary. The shim writes the minimal
+//     config.json the test asserts on, then exits 0. Same code path
+//     locally and in CI.
+//
+// The shim contents:
+//   - On `worktree init`: writes a minimal `.paperclip/config.json` with
+//     a `"database"` field (matches the assertion at line 1302-ish)
+//     into $PWD/.paperclip and exits 0.
+//   - On anything else: exits 1 (not expected to be called).
+const PAPERCLIPAI_SHIM = [
+  "#!/bin/sh",
+  'if [ "$1" = "worktree" ] && [ "$2" = "init" ]; then',
+  '  mkdir -p "$PWD/.paperclip"',
+  "  cat >\"$PWD/.paperclip/config.json\" <<'JSON'",
+  "{",
+  '  "database": { "mode": "embedded-postgres" }',
+  "}",
+  "JSON",
+  "  exit 0",
+  "fi",
+  "exit 1",
+  "",
+].join("\n");
+
 async function runGit(cwd: string, args: string[]) {
   await execFileAsync("git", args, { cwd });
 }
@@ -1104,6 +1145,15 @@ describe("realizeExecutionWorkspace", () => {
   );
 
   it("provisions successfully when install is needed but there are no symlinked node_modules to move", async () => {
+    // Closes #325: realizeExecutionWorkspace's executeProcess inherits
+    // process.env when no override is passed. On a dev machine that has
+    // `paperclipai` installed via Homebrew, the spawned provision script
+    // finds it on PATH and tries to use the real binary against the test
+    // fixture — which fails (no source config). Force the fallback path
+    // for the duration of this test.
+    const originalForceFallback = process.env.PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT;
+    process.env.PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT = "true";
+    try {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
     await fs.writeFile(
@@ -1174,6 +1224,13 @@ describe("realizeExecutionWorkspace", () => {
     await expect(fs.readFile(path.join(workspace.cwd, ".paperclip", "config.json"), "utf8")).resolves.toContain(
       "\"database\"",
     );
+    } finally {
+      if (originalForceFallback === undefined) {
+        delete process.env.PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT;
+      } else {
+        process.env.PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT = originalForceFallback;
+      }
+    }
   }, 30_000);
 
   it("fails instead of writing an unseeded fallback config when worktree init errors after CLI detection succeeds", async () => {
@@ -1207,6 +1264,16 @@ describe("realizeExecutionWorkspace", () => {
         "utf8",
       );
       await fs.chmod(fakePnpmPath, 0o755);
+
+      // Closes #325: write a paperclipai shim into fakeBin so that
+      // `command -v paperclipai` (called by provision-worktree.sh's
+      // paperclipai_command_available) resolves to OUR shim instead of
+      // whatever the dev machine has globally installed. The shim
+      // handles `worktree init` by writing the minimal config.json the
+      // test asserts on.
+      const fakePaperclipaiPath = path.join(fakeBin, "paperclipai");
+      await fs.writeFile(fakePaperclipaiPath, PAPERCLIPAI_SHIM, "utf8");
+      await fs.chmod(fakePaperclipaiPath, 0o755);
 
       let caught: Error | null = null;
       try {
@@ -1286,6 +1353,16 @@ describe("realizeExecutionWorkspace", () => {
         "utf8",
       );
       await fs.chmod(fakePnpmPath, 0o755);
+
+      // Closes #325: write a paperclipai shim into fakeBin so that
+      // `command -v paperclipai` (called by provision-worktree.sh's
+      // paperclipai_command_available) resolves to OUR shim instead of
+      // whatever the dev machine has globally installed. The shim
+      // handles `worktree init` by writing the minimal config.json the
+      // test asserts on.
+      const fakePaperclipaiPath = path.join(fakeBin, "paperclipai");
+      await fs.writeFile(fakePaperclipaiPath, PAPERCLIPAI_SHIM, "utf8");
+      await fs.chmod(fakePaperclipaiPath, 0o755);
 
       const result = await execFileAsync(scriptPath, [], {
         cwd: worktreeRoot,


### PR DESCRIPTION
Closes #325 — last remaining verify-gate failure batch.

Root cause: developers with system-installed `paperclipai` trigger the script's CLI-detection path, which fails against the test fixture. CI passed because CI has no paperclipai → fallback always ran.

Fixes:
1. `provision-worktree.sh` gains `PAPERCLIP_FORCE_FALLBACK_WORKTREE_INIT=true` env-var bypass
2. Direct-spawn tests write a `paperclipai` shim into fakeBin (shadow on PATH)
3. `realizeExecutionWorkspace` test sets the env-var for its duration

Local: 71/71 workspace-runtime tests pass. CI behavior unchanged.