### PR TITLE
fix(test): final 6 verify failures — onboarding-v2 fixtures + 2 spec drifts (#330)

### DIFF
--- a/server/src/__tests__/assess-routes.test.ts
+++ b/server/src/__tests__/assess-routes.test.ts
@@ -261,8 +261,15 @@ describe("Assess routes", () => {
         .post("/api/companies/company-1/assess")
         .send({ description: "Build a CRM" })
         .expect(200);
-      expect(res.text).toContain("[deep-interview] Ready to crystallize");
-      expect(res.text).toContain("0.180");
+      // Closes #330: marker shape changed from
+      // "[deep-interview] Ready to crystallize" to
+      // "[deep-interview-ready] {stateId, round, ambiguity}" — the
+      // route now emits a parseable JSON envelope (per assess.ts:97
+      // comment "AgentDash (Phase F)"). Test follows the new shape.
+      expect(res.text).toContain("[deep-interview-ready]");
+      expect(res.text).toContain('"stateId":"state-test"');
+      expect(res.text).toContain('"round":12');
+      expect(res.text).toContain('"ambiguity":0.18');
     });
   });
 

--- a/server/src/__tests__/companies-email-domain-route.test.ts
+++ b/server/src/__tests__/companies-email-domain-route.test.ts
@@ -155,7 +155,10 @@ describe("POST /api/companies — FRE Plan B email_domain (AGE-55)", () => {
     const res = await request(app).post("/api/companies").send({ name: "Acme Two" });
 
     expect(res.status).toBe(409);
-    expect(res.body).toEqual({
+    // Closes #330: route now includes a user-facing `message` field on
+    // the 409 response. Use toMatchObject so the test stays robust to
+    // future additive fields.
+    expect(res.body).toMatchObject({
       code: "domain_already_claimed",
       existingCompanyId: "company-existing",
       contactEmail: null,

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -140,7 +140,10 @@ describe("POST /api/onboarding/agent/confirm", () => {
       agentId: "agent-2",
       apiKey: { id: "k", token: "agk_x" },
     });
-    const app = buildApp({ type: "board", userId: "u1", source: "session" });
+    // Closes #330: route asserts companyAccess against body.companyId
+    // (per PR #282 / #230 security fix). Actor must include the
+    // company in its companyIds list or the route returns 403.
+    const app = buildApp({ type: "board", userId: "u1", source: "session", companyIds: ["c1"] });
     const res = await request(app).post("/api/onboarding/agent/confirm").send({
       conversationId: "conv1",
       reportsToAgentId: "cos1",
@@ -193,7 +196,8 @@ describe("POST /api/onboarding/confirm-plan", () => {
       alignmentToLongTerm: "lays groundwork",
     };
     const app = buildApp(
-      { type: "board", userId: "u1", source: "session" },
+      // Closes #330: includes companyIds per PR #282/#230 assertCompanyAccess.
+      { type: "board", userId: "u1", source: "session", companyIds: ["c1"] },
       [
         // 1st db chain: lookup conversation
         [{ id: "conv1", companyId: "c1" }],
@@ -238,7 +242,8 @@ describe("POST /api/onboarding/confirm-plan", () => {
 
   it("returns 404 when the conversation has no plan card", async () => {
     const app = buildApp(
-      { type: "board", userId: "u1", source: "session" },
+      // Closes #330: includes companyIds per PR #282/#230 assertCompanyAccess.
+      { type: "board", userId: "u1", source: "session", companyIds: ["c1"] },
       [
         [{ id: "conv1", companyId: "c1" }], // conversation lookup
         [], // no plan card
@@ -256,12 +261,18 @@ describe("POST /api/onboarding/revise-plan", () => {
     vi.clearAllMocks();
   });
 
-  it("returns 501 (Phase F deferred)", async () => {
-    const app = buildApp({ type: "board", userId: "u1", source: "session" });
+  // Closes #330: route is no longer Phase-F-deferred (#210 / #231
+  // implemented it). With an empty conversation lookup, the route
+  // returns 404 "Conversation not found" — assert that contract.
+  it("returns 404 when the conversation is missing", async () => {
+    const app = buildApp(
+      { type: "board", userId: "u1", source: "session", companyIds: ["c1"] },
+      [[]], // conversation lookup returns no rows
+    );
     const res = await request(app)
       .post("/api/onboarding/revise-plan")
       .send({ conversationId: "conv1", revisionText: "swap qa for marketing" });
-    expect(res.status).toBe(501);
+    expect(res.status).toBe(404);
   });
 });
 


### PR DESCRIPTION
Closes the 6 remaining verify-suite failures named in #330. Each is an isolated mock/spec drift, not the broad pattern of #322/#327.

- **onboarding-v2-routes** (4 fixed): `companyIds: ["c1"]` added to `buildApp` actors so PR #282's `assertCompanyAccess` waves through. Stale 501 test renamed to assert the actual 404 contract.
- **companies-email-domain-route** (1 fixed): `toMatchObject` instead of `toEqual` so the route's added `message` field doesn't break the assertion.
- **assess-routes** (1 fixed): the "ready_to_crystallize" marker shape changed from `[deep-interview] Ready to crystallize` to `[deep-interview-ready] {stateId,round,ambiguity}` JSON envelope.

After this lands the verify suite is fully green and `verify` can be re-added to required branch-protection contexts.