### PR TITLE
test(run-healer): integration coverage + backfill missing migration (#297)

### DIFF
--- a/packages/db/src/migrations/0082_heal_attempts_and_events.sql
+++ b/packages/db/src/migrations/0082_heal_attempts_and_events.sql
@@ -1,0 +1,41 @@
+-- AgentDash (#297): backfill the missing migration for `heal_attempts` and
+-- `heal_events`. These tables were defined in
+-- `packages/db/src/schema/heal_attempts.ts` when the run-healer service
+-- shipped, but the corresponding `pnpm db:generate` was never run, so the
+-- tables only existed in TypeScript. The healer would silently no-op (or
+-- crash) in any fresh deployment because the SELECT/INSERTs hit a
+-- non-existent relation. Adding the migration brings prod and the embedded
+-- test database back in sync with the schema source of truth.
+
+CREATE TABLE "heal_attempts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" uuid NOT NULL,
+	"diagnosis" jsonb NOT NULL,
+	"fix_type" text NOT NULL,
+	"action_taken" text,
+	"succeeded" boolean,
+	"cost_usd" real,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "heal_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_type" text NOT NULL,
+	"run_id" uuid,
+	"details" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "heal_attempts" ADD CONSTRAINT "heal_attempts_run_id_heartbeat_runs_id_fk"
+	FOREIGN KEY ("run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "heal_events" ADD CONSTRAINT "heal_events_run_id_heartbeat_runs_id_fk"
+	FOREIGN KEY ("run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "heal_attempts_run_id_idx" ON "heal_attempts" USING btree ("run_id");
+--> statement-breakpoint
+CREATE INDEX "heal_attempts_created_at_idx" ON "heal_attempts" USING btree ("created_at");
+--> statement-breakpoint
+CREATE INDEX "heal_events_event_type_idx" ON "heal_events" USING btree ("event_type");
+--> statement-breakpoint
+CREATE INDEX "heal_events_created_at_idx" ON "heal_events" USING btree ("created_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1778544000000,
       "tag": "0081_cold_signup_reengagement",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1778976000000,
+      "tag": "0082_heal_attempts_and_events",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/run-healer.test.ts
+++ b/server/src/__tests__/run-healer.test.ts
@@ -1,0 +1,227 @@
+// Closes #297: integration coverage for the run-healer eligibility scanner
+// against a real embedded Postgres. The previous unit tests stubbed drizzle
+// chains, which is what let PR #232's `sql\`= ANY(\${tuple})\`` bug ship as
+// a silent no-op (the stub returned []) — exactly the failure mode we now
+// want a guardrail for.
+//
+// We exercise the public `_scanEligibleRunsForTests` hook (added by PR #296)
+// rather than the full `scan()` pipeline because scan() also calls into the
+// LLM diagnoser + fixer, which would require a live model in CI. The piece
+// at risk is the SQL — specifically the `inArray(status, [...])` filter and
+// the grouped heal-attempt count join — and that's what this exercises.
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  agents,
+  companies,
+  createDb,
+  healAttempts,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import { runHealerService } from "../services/run-healer/service.ts";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe
+  : describe.skip;
+
+describeEmbeddedPostgres("run-healer eligibility scan (Postgres integration)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let healer!: ReturnType<typeof runHealerService>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-run-healer-");
+    db = createDb(tempDb.connectionString);
+    // Tighten the windows so we can plant rows with mundane timestamps:
+    //  - minAgeMs: 1ms — anything older than ~now passes the "stabilized" gate
+    //  - lookbackMs: 1h — wide enough that fresh inserts fall inside
+    //  - maxHealsPerRun: 2 — we want to assert the over-cap row is dropped
+    healer = runHealerService(db, {
+      minAgeMs: 1,
+      lookbackMs: 60 * 60 * 1000,
+      maxHealsPerRun: 2,
+    });
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(healAttempts);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Healer Co",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Healer Target",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  it("returns failed runs whose error code looks adapter-related", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const oldEnough = new Date(Date.now() - 60_000);
+
+    const failedRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: failedRunId,
+      companyId,
+      agentId,
+      status: "failed",
+      errorCode: "auth_invalid_token",
+      error: "API key rejected",
+      stderrExcerpt: "auth failed",
+      createdAt: oldEnough,
+    });
+
+    const eligible = await healer._scanEligibleRunsForTests();
+    expect(eligible.map((r) => r.id)).toEqual([failedRunId]);
+    expect(eligible[0]).toMatchObject({
+      id: failedRunId,
+      companyId,
+      agentId,
+      status: "failed",
+      errorCode: "auth_invalid_token",
+      adapterType: "claude_local",
+      agentName: "Healer Target",
+      healAttemptCount: 0,
+    });
+  });
+
+  it("includes 'running' rows even without an error (the stuck-run case)", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const oldEnough = new Date(Date.now() - 60_000);
+
+    const stuckRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: stuckRunId,
+      companyId,
+      agentId,
+      status: "running",
+      createdAt: oldEnough,
+    });
+
+    const eligible = await healer._scanEligibleRunsForTests();
+    expect(eligible.map((r) => r.id)).toContain(stuckRunId);
+  });
+
+  it("excludes runs that have already exceeded maxHealsPerRun", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const oldEnough = new Date(Date.now() - 60_000);
+
+    const underCapId = randomUUID();
+    const overCapId = randomUUID();
+    await db.insert(heartbeatRuns).values([
+      {
+        id: underCapId,
+        companyId,
+        agentId,
+        status: "failed",
+        errorCode: "auth_invalid_token",
+        error: "first attempt",
+        createdAt: oldEnough,
+      },
+      {
+        id: overCapId,
+        companyId,
+        agentId,
+        status: "failed",
+        errorCode: "auth_invalid_token",
+        error: "exhausted attempts",
+        createdAt: oldEnough,
+      },
+    ]);
+
+    // overCapId has 2 prior heal attempts, hitting maxHealsPerRun=2 — must be dropped.
+    await db.insert(healAttempts).values([
+      {
+        runId: overCapId,
+        diagnosis: { category: "auth_failure" },
+        fixType: "retry",
+        actionTaken: "rotate_credentials",
+        succeeded: false,
+      },
+      {
+        runId: overCapId,
+        diagnosis: { category: "auth_failure" },
+        fixType: "retry",
+        actionTaken: "rotate_credentials",
+        succeeded: false,
+      },
+    ]);
+
+    const eligible = await healer._scanEligibleRunsForTests();
+    const ids = eligible.map((r) => r.id);
+    expect(ids).toContain(underCapId);
+    expect(ids).not.toContain(overCapId);
+
+    // And the surviving row reports its real heal count from the grouped query.
+    const underCap = eligible.find((r) => r.id === underCapId);
+    expect(underCap?.healAttemptCount).toBe(0);
+  });
+
+  it("excludes runs created outside the lookback window", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const tooOld = new Date(Date.now() - 6 * 60 * 60 * 1000); // 6h, lookback is 1h
+
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      status: "failed",
+      errorCode: "auth_invalid_token",
+      error: "ancient",
+      createdAt: tooOld,
+    });
+
+    const eligible = await healer._scanEligibleRunsForTests();
+    expect(eligible).toHaveLength(0);
+  });
+
+  it("excludes runs in non-eligible statuses (succeeded/queued)", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const oldEnough = new Date(Date.now() - 60_000);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        companyId,
+        agentId,
+        status: "succeeded",
+        errorCode: "auth_invalid_token", // even with a "scary" error, succeeded runs are out
+        createdAt: oldEnough,
+      },
+      {
+        companyId,
+        agentId,
+        status: "queued",
+        createdAt: oldEnough,
+      },
+    ]);
+
+    const eligible = await healer._scanEligibleRunsForTests();
+    expect(eligible).toHaveLength(0);
+  });
+});

--- a/server/src/services/run-healer/service.ts
+++ b/server/src/services/run-healer/service.ts
@@ -452,5 +452,13 @@ export function runHealerService(db: Db, configOverride: RunHealerConfig = {}) {
     return { scanned: eligible.length, fixed, skipped };
   }
 
-  return { scan };
+  return {
+    scan,
+    // Closes #297: exposed for integration tests so the scan eligibility
+    // can be exercised against a real heartbeat_runs row without standing
+    // up the full diagnose+fix pipeline (which needs a live LLM and would
+    // make the test environment-dependent). Production callers don't use
+    // this — only the scheduler calls scan() directly.
+    _scanEligibleRunsForTests: scanEligibleRuns,
+  };
 }


### PR DESCRIPTION
## Summary
- Postgres integration test for `runHealerService` eligibility scanner — five cases exercising the real SQL via embedded Postgres (would have caught the silent no-op fixed by #232).
- Exposes `_scanEligibleRunsForTests` from the service so tests can drive the scanner directly without standing up the LLM diagnose+fix pipeline.
- **Backfills missing migration `0082_heal_attempts_and_events.sql`** — the `heal_attempts` / `heal_events` tables existed only in TypeScript; the healer would have crashed on any fresh deployment with `relation "heal_attempts" does not exist`.

## Test plan
- [x] `pnpm exec vitest run run-healer` — 5/5 pass
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm exec vitest run` (server) — 1872 pass / 10 skip / 0 fail
- [ ] CI green (audit, check, drift, policy, e2e, verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)