### PR TITLE
fix(onboarding): wire /api/onboarding/invites to real invite creation [no-prompt-update]

### DIFF
--- a/server/src/__tests__/invites-service.test.ts
+++ b/server/src/__tests__/invites-service.test.ts
@@ -1,0 +1,99 @@
+// Integration coverage for inviteService against an embedded Postgres.
+// Asserts the surface contract the onboarding wizard depends on:
+//   - row is inserted, returned id is real
+//   - the plaintext token starts with the documented prefix
+//   - the persisted token is hashed (never stored verbatim)
+//   - the email is stored in defaults_payload for audit
+//   - expiresAt is in the future (~72h window)
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { companies, createDb, invites } from "@paperclipai/db";
+import { inviteService } from "../services/invites.ts";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe
+  : describe.skip;
+
+describeEmbeddedPostgres("inviteService.createCompanyInvite", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-invites-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(invites);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Invite Co",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  it("inserts a company-join invite and returns a usable plaintext token", async () => {
+    const companyId = await seedCompany();
+    const result = await inviteService(db).createCompanyInvite({
+      companyId,
+      invitedByUserId: "u1",
+      email: "Carol@Example.COM",
+    });
+
+    expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(result.token).toMatch(/^pcp_invite_[a-z0-9]{8}$/);
+    expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now() + 60 * 60 * 1000);
+
+    const [row] = await db.select().from(invites).where(eq(invites.id, result.id));
+    expect(row).toBeDefined();
+    expect(row?.companyId).toBe(companyId);
+    expect(row?.invitedByUserId).toBe("u1");
+    expect(row?.inviteType).toBe("company_join");
+    expect(row?.allowedJoinTypes).toBe("both");
+    // Token is stored hashed; the plaintext is only returned to the caller.
+    const expectedHash = createHash("sha256").update(result.token).digest("hex");
+    expect(row?.tokenHash).toBe(expectedHash);
+    // Email is normalized lowercase + trimmed.
+    expect(row?.defaultsPayload).toEqual({ email: "carol@example.com" });
+  });
+
+  it("omits the email payload when no email is supplied", async () => {
+    const companyId = await seedCompany();
+    const result = await inviteService(db).createCompanyInvite({
+      companyId,
+      invitedByUserId: null,
+    });
+    const [row] = await db.select().from(invites).where(eq(invites.id, result.id));
+    expect(row?.defaultsPayload).toBeNull();
+    expect(row?.invitedByUserId).toBeNull();
+  });
+
+  it("respects an allowedJoinTypes override", async () => {
+    const companyId = await seedCompany();
+    const result = await inviteService(db).createCompanyInvite({
+      companyId,
+      invitedByUserId: "u1",
+      allowedJoinTypes: "agent",
+    });
+    const [row] = await db.select().from(invites).where(eq(invites.id, result.id));
+    expect(row?.allowedJoinTypes).toBe("agent");
+  });
+});

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -287,29 +287,51 @@ describe("POST /api/onboarding/invites", () => {
     mockInvites.createCompanyInvite.mockReset();
   });
 
-  it("creates one invite per email and returns the inviteIds", async () => {
+  it("creates one invite per email and returns ids + URLs", async () => {
+    const expires = new Date("2099-01-01T00:00:00.000Z");
     let n = 0;
-    mockInvites.createCompanyInvite.mockImplementation(async () => ({
-      id: `invite-${++n}`,
-      token: `pcp_invite_token${n}`,
-      expiresAt: new Date(),
-    }));
+    mockInvites.createCompanyInvite.mockImplementation(async () => {
+      n += 1;
+      return {
+        id: `invite-${n}`,
+        token: `pcp_invite_tok${n}`,
+        expiresAt: expires,
+      };
+    });
     const app = buildApp({
       type: "board",
       userId: "u1",
       source: "session",
       companyIds: ["c1"],
     });
-    const res = await request(app).post("/api/onboarding/invites").send({
-      conversationId: "conv1",
-      companyId: "c1",
-      emails: ["bob@acme.com", "carol@acme.com"],
-    });
+    const res = await request(app)
+      .post("/api/onboarding/invites")
+      .set("x-forwarded-proto", "https")
+      .set("x-forwarded-host", "app.example.com")
+      .send({
+        conversationId: "conv1",
+        companyId: "c1",
+        emails: ["bob@acme.com", "carol@acme.com"],
+      });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      inviteIds: ["invite-1", "invite-2"],
-      errors: [],
-    });
+    expect(res.body.inviteIds).toEqual(["invite-1", "invite-2"]);
+    expect(res.body.errors).toEqual([]);
+    expect(res.body.invites).toEqual([
+      {
+        id: "invite-1",
+        email: "bob@acme.com",
+        invitePath: "/invite/pcp_invite_tok1",
+        inviteUrl: "https://app.example.com/invite/pcp_invite_tok1",
+        expiresAt: expires.toISOString(),
+      },
+      {
+        id: "invite-2",
+        email: "carol@acme.com",
+        invitePath: "/invite/pcp_invite_tok2",
+        inviteUrl: "https://app.example.com/invite/pcp_invite_tok2",
+        expiresAt: expires.toISOString(),
+      },
+    ]);
     expect(mockInvites.createCompanyInvite).toHaveBeenCalledTimes(2);
     expect(mockInvites.createCompanyInvite).toHaveBeenNthCalledWith(1, {
       companyId: "c1",
@@ -354,10 +376,12 @@ describe("POST /api/onboarding/invites", () => {
       emails: ["ok@acme.com", "broken@acme.com"],
     });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      inviteIds: ["invite-1"],
-      errors: [{ email: "broken@acme.com", reason: "invite-create-failed" }],
-    });
+    expect(res.body.inviteIds).toEqual(["invite-1"]);
+    expect(res.body.errors).toEqual([
+      { email: "broken@acme.com", reason: "invite-create-failed" },
+    ]);
+    expect(res.body.invites).toHaveLength(1);
+    expect(res.body.invites[0]).toMatchObject({ id: "invite-1", email: "ok@acme.com" });
   });
 
   it("rejects empty emails inline without calling the service", async () => {
@@ -375,6 +399,7 @@ describe("POST /api/onboarding/invites", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       inviteIds: [],
+      invites: [],
       errors: [
         { email: "   ", reason: "empty-email" },
         { email: "", reason: "empty-email" },

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -28,6 +28,10 @@ const mockCosState = {
   advancePhase: vi.fn().mockResolvedValue(undefined),
 };
 
+const mockInvites = {
+  createCompanyInvite: vi.fn(),
+};
+
 vi.mock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
     ISSUE_LIST_DEFAULT_LIMIT: 50,
@@ -41,6 +45,7 @@ vi.mock("../services/index.js", () => ({
   companyService: () => ({}),
   agentInstructionsService: () => mockInstructions,
   cosOnboardingStateService: () => mockCosState,
+  inviteService: () => mockInvites,
 }));
 
 vi.mock("@paperclipai/db", () => ({
@@ -279,19 +284,102 @@ describe("POST /api/onboarding/revise-plan", () => {
 describe("POST /api/onboarding/invites", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockInvites.createCompanyInvite.mockReset();
   });
 
-  it("processes the invite list (returns errors[] when invite service is stubbed)", async () => {
-    const app = buildApp({ type: "board", userId: "u1", source: "session" });
+  it("creates one invite per email and returns the inviteIds", async () => {
+    let n = 0;
+    mockInvites.createCompanyInvite.mockImplementation(async () => ({
+      id: `invite-${++n}`,
+      token: `pcp_invite_token${n}`,
+      expiresAt: new Date(),
+    }));
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["bob@acme.com", "carol@acme.com"],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      inviteIds: ["invite-1", "invite-2"],
+      errors: [],
+    });
+    expect(mockInvites.createCompanyInvite).toHaveBeenCalledTimes(2);
+    expect(mockInvites.createCompanyInvite).toHaveBeenNthCalledWith(1, {
+      companyId: "c1",
+      invitedByUserId: "u1",
+      email: "bob@acme.com",
+    });
+  });
+
+  it("returns 403 for callers without access to companyId", async () => {
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["other-company"],
+    });
     const res = await request(app).post("/api/onboarding/invites").send({
       conversationId: "conv1",
       companyId: "c1",
       emails: ["bob@acme.com"],
     });
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({
-      inviteIds: expect.any(Array),
-      errors: expect.any(Array),
+    expect(res.status).toBe(403);
+    expect(mockInvites.createCompanyInvite).not.toHaveBeenCalled();
+  });
+
+  it("records per-email failures without aborting the batch", async () => {
+    mockInvites.createCompanyInvite
+      .mockResolvedValueOnce({
+        id: "invite-1",
+        token: "tok1",
+        expiresAt: new Date(),
+      })
+      .mockRejectedValueOnce(new Error("db down"));
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
     });
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["ok@acme.com", "broken@acme.com"],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      inviteIds: ["invite-1"],
+      errors: [{ email: "broken@acme.com", reason: "invite-create-failed" }],
+    });
+  });
+
+  it("rejects empty emails inline without calling the service", async () => {
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["   ", ""],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      inviteIds: [],
+      errors: [
+        { email: "   ", reason: "empty-email" },
+        { email: "", reason: "empty-email" },
+      ],
+    });
+    expect(mockInvites.createCompanyInvite).not.toHaveBeenCalled();
   });
 });

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -13,6 +13,7 @@ import {
   companyService,
   agentInstructionsService,
   cosOnboardingStateService,
+  inviteService,
 } from "../services/index.js";
 import { unauthorized, badRequest, notFound } from "../errors.js";
 import { assertCompanyAccess } from "./authz.js";
@@ -503,25 +504,62 @@ No greetings. No markdown headings outside the JSON block.`;
   });
 
   // POST /api/onboarding/invites
+  //
+  // Customer-facing endpoint hit by the CoS onboarding wizard's
+  // InvitePrompt card (`ui/src/pages/CoSConversation.tsx::onInviteSend`).
+  // Previously a stub that returned `invite-service-not-wired-yet` for
+  // every email — silently — so a brand-new customer who typed three
+  // teammate emails saw no errors but also no real invites. Now creates
+  // real `invites` rows via `inviteService` so the tokens persist and
+  // the rest of the join flow (`/invites/:token` resolution, etc.) can
+  // pick them up.
+  //
+  // Note: AgentDash does not yet send invitation emails (no SMTP
+  // service). The plaintext token URL still has to be surfaced to the
+  // inviter — surfacing it from this endpoint is a follow-up.
   router.post("/invites", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {
       throw unauthorized("Sign-in required");
     }
-    const { emails } = req.body as {
+    const { companyId, emails } = req.body as {
       conversationId: string;
       companyId: string;
       emails: string[];
     };
+    if (!companyId || typeof companyId !== "string") {
+      throw badRequest("companyId is required");
+    }
     if (!Array.isArray(emails)) {
       throw badRequest("emails must be an array");
     }
+    assertCompanyAccess(req, companyId);
+
+    const invites = inviteService(db);
     const inviteIds: string[] = [];
     const errors: Array<{ email: string; reason: string }> = [];
-    // TODO: wire upstream invite service when available.
-    // grep -rn "invitation\|invite" server/src/services/ shows no standalone invite service yet.
+
     for (const email of emails) {
-      errors.push({ email, reason: "invite-service-not-wired-yet" });
+      const trimmed = typeof email === "string" ? email.trim() : "";
+      if (!trimmed) {
+        errors.push({ email: String(email), reason: "empty-email" });
+        continue;
+      }
+      try {
+        const created = await invites.createCompanyInvite({
+          companyId,
+          invitedByUserId: req.actor.userId ?? null,
+          email: trimmed,
+        });
+        inviteIds.push(created.id);
+      } catch (err) {
+        logger.warn(
+          { err, companyId, email: trimmed },
+          "onboarding_invite_create_failed",
+        );
+        errors.push({ email: trimmed, reason: "invite-create-failed" });
+      }
     }
+
     res.json({ inviteIds, errors });
   });
 

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -510,13 +510,14 @@ No greetings. No markdown headings outside the JSON block.`;
   // Previously a stub that returned `invite-service-not-wired-yet` for
   // every email — silently — so a brand-new customer who typed three
   // teammate emails saw no errors but also no real invites. Now creates
-  // real `invites` rows via `inviteService` so the tokens persist and
-  // the rest of the join flow (`/invites/:token` resolution, etc.) can
-  // pick them up.
+  // real `invites` rows via `inviteService` and returns the per-email
+  // invite URLs so the wizard can surface them to the inviter.
   //
-  // Note: AgentDash does not yet send invitation emails (no SMTP
-  // service). The plaintext token URL still has to be surfaced to the
-  // inviter — surfacing it from this endpoint is a follow-up.
+  // Email delivery: AgentDash uses Resend (`server/src/auth/email.ts`).
+  // When `RESEND_API_KEY` is unset the helper logs and no-ops, so the
+  // invite URL in the response is the only delivery channel in dev.
+  // Surfacing emailing here is a separate followup; this endpoint
+  // already returns enough for the inviter to share the URL by hand.
   router.post("/invites", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {
       throw unauthorized("Sign-in required");
@@ -534,8 +535,25 @@ No greetings. No markdown headings outside the JSON block.`;
     }
     assertCompanyAccess(req, companyId);
 
+    // Resolve the public base URL from forwarded headers, with a
+    // fallback to the request's own protocol+host. Mirrors
+    // `requestBaseUrl` in access.ts so /invite/<token> URLs stay in
+    // the same shape across endpoints.
+    const forwardedProto = req.header("x-forwarded-proto")?.split(",")[0]?.trim();
+    const forwardedHost = req.header("x-forwarded-host")?.split(",")[0]?.trim();
+    const proto = forwardedProto || req.protocol || "http";
+    const host = forwardedHost || req.header("host") || "";
+    const baseUrl = host ? `${proto}://${host}` : "";
+
     const invites = inviteService(db);
     const inviteIds: string[] = [];
+    const created: Array<{
+      id: string;
+      email: string;
+      invitePath: string;
+      inviteUrl: string;
+      expiresAt: string;
+    }> = [];
     const errors: Array<{ email: string; reason: string }> = [];
 
     for (const email of emails) {
@@ -545,12 +563,20 @@ No greetings. No markdown headings outside the JSON block.`;
         continue;
       }
       try {
-        const created = await invites.createCompanyInvite({
+        const row = await invites.createCompanyInvite({
           companyId,
           invitedByUserId: req.actor.userId ?? null,
           email: trimmed,
         });
-        inviteIds.push(created.id);
+        const invitePath = `/invite/${row.token}`;
+        inviteIds.push(row.id);
+        created.push({
+          id: row.id,
+          email: trimmed,
+          invitePath,
+          inviteUrl: baseUrl ? `${baseUrl}${invitePath}` : invitePath,
+          expiresAt: row.expiresAt.toISOString(),
+        });
       } catch (err) {
         logger.warn(
           { err, companyId, email: trimmed },
@@ -560,7 +586,7 @@ No greetings. No markdown headings outside the JSON block.`;
       }
     }
 
-    res.json({ inviteIds, errors });
+    res.json({ inviteIds, invites: created, errors });
   });
 
   return router;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,4 +1,5 @@
 export { companyService } from "./companies.js";
+export { inviteService } from "./invites.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";

--- a/server/src/services/invites.ts
+++ b/server/src/services/invites.ts
@@ -1,0 +1,109 @@
+// AgentDash (#TBD): minimal invite-creation service.
+//
+// The full invite flow lives in `server/src/routes/access.ts` and
+// includes branding, agent-message rendering, OpenClaw prompt synthesis,
+// and per-actor permission checks. None of that helper code is exported,
+// so other route modules can't reuse it without copy/paste.
+//
+// This service exposes the *minimum* primitive — "create a company-join
+// invite token for company X, attribute it to user Y, optionally tag it
+// with the recipient's email" — so the onboarding wizard and any future
+// programmatic caller can stop reinventing the create-invite loop.
+//
+// Why a service and not a shared helper inside access.ts:
+//   - access.ts is already ~3800 lines; adding another export grows the
+//     "everything is in access.ts" problem.
+//   - The route file mixes auth, validation, branding, and persistence;
+//     this service does only persistence so it's testable in isolation.
+//   - Future cleanup can collapse access.ts's `createCompanyInviteForCompany`
+//     to delegate here, but that's a bigger refactor and not required to
+//     unblock the onboarding-wizard customer-facing fix.
+
+import { createHash, randomBytes } from "node:crypto";
+import type { Db } from "@paperclipai/db";
+import { invites } from "@paperclipai/db";
+
+// Same constants access.ts uses. Kept in sync deliberately — invite tokens
+// are user-visible and the prefix `pcp_invite_` is documented in onboarding
+// emails / CLI prompts. If access.ts evolves these, this file must follow.
+const INVITE_TOKEN_PREFIX = "pcp_invite_";
+const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+const INVITE_TOKEN_SUFFIX_LENGTH = 8;
+const INVITE_TOKEN_MAX_RETRIES = 5;
+const COMPANY_INVITE_TTL_MS = 72 * 60 * 60 * 1000; // 72h, matches access.ts.
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function createInviteToken(): string {
+  const bytes = randomBytes(INVITE_TOKEN_SUFFIX_LENGTH);
+  let suffix = "";
+  for (let idx = 0; idx < INVITE_TOKEN_SUFFIX_LENGTH; idx += 1) {
+    suffix += INVITE_TOKEN_ALPHABET[bytes[idx]! % INVITE_TOKEN_ALPHABET.length];
+  }
+  return `${INVITE_TOKEN_PREFIX}${suffix}`;
+}
+
+function isInviteTokenHashCollisionError(error: unknown): boolean {
+  // Postgres unique-constraint violation. We retry to dodge the (vanishingly
+  // rare) randBytes hash collision rather than surfacing a 5xx.
+  const code = (error as { code?: string } | null)?.code;
+  return code === "23505";
+}
+
+export type CreateCompanyInviteInput = {
+  companyId: string;
+  invitedByUserId: string | null;
+  /** Recipient's email — recorded in defaultsPayload for audit/UX, not enforced. */
+  email?: string | null;
+  /** Defaults to "both" (humans + agents may redeem). */
+  allowedJoinTypes?: "human" | "agent" | "both";
+};
+
+export type CreateCompanyInviteOutput = {
+  id: string;
+  token: string;
+  expiresAt: Date;
+};
+
+export function inviteService(db: Db) {
+  return {
+    /**
+     * Insert a company_join invite row and return its ID + plaintext token.
+     * The plaintext token is only returned here; storage hashes it.
+     */
+    async createCompanyInvite(
+      input: CreateCompanyInviteInput,
+    ): Promise<CreateCompanyInviteOutput> {
+      const expiresAt = new Date(Date.now() + COMPANY_INVITE_TTL_MS);
+      const defaultsPayload =
+        input.email && input.email.trim()
+          ? { email: input.email.trim().toLowerCase() }
+          : null;
+
+      for (let attempt = 0; attempt < INVITE_TOKEN_MAX_RETRIES; attempt += 1) {
+        const token = createInviteToken();
+        try {
+          const [row] = await db
+            .insert(invites)
+            .values({
+              companyId: input.companyId,
+              inviteType: "company_join",
+              allowedJoinTypes: input.allowedJoinTypes ?? "both",
+              defaultsPayload,
+              expiresAt,
+              invitedByUserId: input.invitedByUserId,
+              tokenHash: hashToken(token),
+            })
+            .returning();
+          if (!row) throw new Error("invite_insert_returned_no_row");
+          return { id: row.id, token, expiresAt };
+        } catch (error) {
+          if (!isInviteTokenHashCollisionError(error)) throw error;
+        }
+      }
+      throw new Error("invite_token_collision_retries_exhausted");
+    },
+  };
+}

--- a/ui/src/api/onboarding.ts
+++ b/ui/src/api/onboarding.ts
@@ -23,8 +23,17 @@ export interface ConfirmResponse {
   proposal: ProposalPayload;
 }
 
+export interface CreatedInvite {
+  id: string;
+  email: string;
+  invitePath: string;
+  inviteUrl: string;
+  expiresAt: string;
+}
+
 export interface InvitesResponse {
   inviteIds: string[];
+  invites: CreatedInvite[];
   errors: Array<{ email: string; reason: string }>;
 }
 


### PR DESCRIPTION
## Summary
- The CoS onboarding wizard's InvitePrompt card calls `POST /api/onboarding/invites`, but the route was a stub that returned `{ email, reason: "invite-service-not-wired-yet" }` for every email — and the UI silently swallowed the error. A new customer typing three teammate emails saw no error and **no invite** — a complete black hole.
- Adds `server/src/services/invites.ts` (`inviteService.createCompanyInvite`) — minimum primitive that inserts a real `invites` row with a hashed token, matching the prefix/TTL/alphabet of the existing `access.ts` flow so resolution treats both identically.
- Wires the service into the route; adds `assertCompanyAccess` so a board user can't seed invites into another company. Per-email failures land in `errors[]` without aborting the batch.
- Returns the per-email invite URL (`invitePath`, `inviteUrl`, `expiresAt`) in the response so the wizard has something to surface to the inviter (UI surfacing in a follow-up).

## Followup (not this PR)
The wizard still has no UI affordance to display the URLs and there's no automatic email send. Inviters can copy the URL from the response payload manually for now.

## Test plan
- [x] `pnpm exec vitest run onboarding-v2-routes invites-service` — 13/13 pass
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm exec vitest run` (server) — 1873 pass / 10 skip / 0 fail
- [ ] CI green (audit, check, drift, policy, e2e, verify)

[no-prompt-update] — the new endpoint is board-actor-only (sign-in required), called only from the customer-facing onboarding wizard. Agents do not call `/api/onboarding/invites`, so no agent prompt surface needs to learn it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)