### PR TITLE
feat(onboarding): send invite emails via Resend + harden invite endpoint [no-prompt-update]

### DIFF
--- a/server/src/__tests__/email-templates.test.ts
+++ b/server/src/__tests__/email-templates.test.ts
@@ -1,0 +1,104 @@
+// Pure unit tests for the email template helpers — no Resend, no DB.
+//
+// The phishing-payload assertions exist because `inviterName` is read
+// from `authUsers.name`, which the user controls at signup. Without
+// sanitization an attacker could set their name to
+// "Microsoft Security <security@microsoft.com>" and the resulting subject
+// + plaintext body would impersonate a trusted brand using AgentDash's
+// verified-domain DKIM/SPF as cover.
+import { describe, it, expect } from "vitest";
+import { sanitizeDisplayName, inviteEmailTemplate } from "../auth/email.ts";
+
+describe("sanitizeDisplayName", () => {
+  it("returns null for null/undefined/empty", () => {
+    expect(sanitizeDisplayName(null)).toBe(null);
+    expect(sanitizeDisplayName(undefined)).toBe(null);
+    expect(sanitizeDisplayName("")).toBe(null);
+    expect(sanitizeDisplayName("   ")).toBe(null);
+  });
+
+  it("strips control characters and quote / angle / @ glyphs", () => {
+    // CR/LF/quotes/angles/@ are removed (not replaced) — that's the
+    // safest default for an attribute the user controls. Adjacent
+    // surviving whitespace is collapsed by the second pass.
+    expect(sanitizeDisplayName("Carol\r\nBcc: spam@x.com")).toBe("CarolBcc: spamx.com");
+    expect(sanitizeDisplayName('Microsoft Security <security@microsoft.com>')).toBe(
+      "Microsoft Security securitymicrosoft.com",
+    );
+    expect(sanitizeDisplayName('Carol "the boss"')).toBe("Carol the boss");
+    expect(sanitizeDisplayName("Carol's team")).toBe("Carols team");
+  });
+
+  it("collapses whitespace and trims", () => {
+    expect(sanitizeDisplayName("  Carol   Q.   Smith  ")).toBe("Carol Q. Smith");
+  });
+
+  it("caps at 60 chars", () => {
+    const long = "a".repeat(120);
+    expect(sanitizeDisplayName(long)).toHaveLength(60);
+  });
+
+  it("returns null when sanitization eats the whole string", () => {
+    expect(sanitizeDisplayName('<<<>>>"""')).toBe(null);
+    expect(sanitizeDisplayName("\r\n\r\n")).toBe(null);
+  });
+});
+
+describe("inviteEmailTemplate", () => {
+  it("falls back to neutral copy when names are null", () => {
+    const t = inviteEmailTemplate({
+      inviteUrl: "https://app.example.com/invite/tok",
+      companyName: null,
+      inviterName: null,
+    });
+    expect(t.subject).toBe("your teammate invited you to AgentDash on AgentDash");
+    expect(t.text).toContain("your teammate invited you to join AgentDash");
+    expect(t.html).toContain("your teammate");
+    expect(t.html).toContain("https://app.example.com/invite/tok");
+  });
+
+  it("escapes HTML in the rendered body when names contain special chars", () => {
+    // Even after sanitization, HTML special chars like & should still
+    // round-trip through escapeHtml in the HTML part.
+    const t = inviteEmailTemplate({
+      inviteUrl: "https://app.example.com/invite/tok",
+      companyName: "Bob & Co",
+      inviterName: "Carol",
+    });
+    expect(t.html).toContain("Bob &amp; Co");
+    expect(t.html).not.toContain("Bob & Co"); // raw & must be escaped
+  });
+
+  it("strips phishing payloads from the inviter name (subject + plaintext + html)", () => {
+    const t = inviteEmailTemplate({
+      inviteUrl: "https://app.example.com/invite/tok",
+      companyName: null,
+      inviterName: 'Microsoft Security <security@microsoft.com>',
+    });
+    // The hostile substring must not appear anywhere in the body — not
+    // in subject, not in plaintext, not in HTML (escaped or otherwise).
+    for (const part of [t.subject, t.text, t.html]) {
+      expect(part).not.toContain("<security");
+      expect(part).not.toContain("@microsoft.com");
+      expect(part).not.toContain("security@");
+    }
+    expect(t.subject).toContain("Microsoft Security");
+    expect(t.subject).toContain("securitymicrosoft.com");
+  });
+
+  it("strips CRLF from display names so they can't break the subject or smuggle headers", () => {
+    const t = inviteEmailTemplate({
+      inviteUrl: "https://app.example.com/invite/tok",
+      companyName: "Acme\r\nBcc: leak@x.com",
+      inviterName: "Carol\nFwd: spam",
+    });
+    // Subject lives in a real mail header — no CRLF allowed.
+    expect(t.subject).not.toMatch(/[\r\n]/);
+    // The plaintext body has its own newlines (from the template), so we
+    // can't blanket-reject \n there. What we DO reject is the inviter
+    // string smuggling its OWN newline into the subject, which would
+    // create a second header line in some MTAs. The CRLF-free subject
+    // assertion above covers that case.
+    expect(t.text).toContain("CarolFwd: spam invited"); // CR/LF dropped, words remain plaintext
+  });
+});

--- a/server/src/__tests__/invites-service.test.ts
+++ b/server/src/__tests__/invites-service.test.ts
@@ -59,7 +59,7 @@ describeEmbeddedPostgres("inviteService.createCompanyInvite", () => {
     });
 
     expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
-    expect(result.token).toMatch(/^pcp_invite_[a-z0-9]{8}$/);
+    expect(result.token).toMatch(/^pcp_invite_[a-z0-9]{16}$/);
     expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now() + 60 * 60 * 1000);
 
     const [row] = await db.select().from(invites).where(eq(invites.id, result.id));

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -31,6 +31,25 @@ const mockCosState = {
 const mockInvites = {
   createCompanyInvite: vi.fn(),
 };
+const mockSendEmail = vi.fn().mockResolvedValue({ status: "skipped" });
+
+vi.mock("../auth/email.js", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+  inviteEmailTemplate: ({
+    inviteUrl,
+    companyName,
+    inviterName,
+  }: {
+    inviteUrl: string;
+    companyName: string | null;
+    inviterName: string | null;
+  }) => ({
+    subject: `${inviterName ?? "x"}→${companyName ?? "y"}: ${inviteUrl}`,
+    html: `<a>${inviteUrl}</a>`,
+    text: `Invite ${inviteUrl}`,
+  }),
+  sanitizeDisplayName: (s: string | null) => s,
+}));
 
 vi.mock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
@@ -287,7 +306,7 @@ describe("POST /api/onboarding/invites", () => {
     mockInvites.createCompanyInvite.mockReset();
   });
 
-  it("creates one invite per email and returns ids + URLs", async () => {
+  it("creates one invite per email, sends an email per invite, and returns URLs + emailStatus", async () => {
     const expires = new Date("2099-01-01T00:00:00.000Z");
     let n = 0;
     mockInvites.createCompanyInvite.mockImplementation(async () => {
@@ -298,6 +317,7 @@ describe("POST /api/onboarding/invites", () => {
         expiresAt: expires,
       };
     });
+    mockSendEmail.mockResolvedValue({ status: "skipped" });
     const app = buildApp({
       type: "board",
       userId: "u1",
@@ -323,6 +343,7 @@ describe("POST /api/onboarding/invites", () => {
         invitePath: "/invite/pcp_invite_tok1",
         inviteUrl: "https://app.example.com/invite/pcp_invite_tok1",
         expiresAt: expires.toISOString(),
+        emailStatus: "skipped",
       },
       {
         id: "invite-2",
@@ -330,6 +351,7 @@ describe("POST /api/onboarding/invites", () => {
         invitePath: "/invite/pcp_invite_tok2",
         inviteUrl: "https://app.example.com/invite/pcp_invite_tok2",
         expiresAt: expires.toISOString(),
+        emailStatus: "skipped",
       },
     ]);
     expect(mockInvites.createCompanyInvite).toHaveBeenCalledTimes(2);
@@ -338,6 +360,100 @@ describe("POST /api/onboarding/invites", () => {
       invitedByUserId: "u1",
       email: "bob@acme.com",
     });
+    // sendEmail invoked per invite, with the URL we just minted.
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(mockSendEmail).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        to: "bob@acme.com",
+        subject: expect.stringContaining("https://app.example.com/invite/pcp_invite_tok1"),
+      }),
+    );
+  });
+
+  it("propagates sendEmail status into the response (sent / failed both flow through)", async () => {
+    const expires = new Date("2099-01-01T00:00:00.000Z");
+    let n = 0;
+    mockInvites.createCompanyInvite.mockImplementation(async () => {
+      n += 1;
+      return { id: `invite-${n}`, token: `tok${n}`, expiresAt: expires };
+    });
+    mockSendEmail
+      .mockResolvedValueOnce({ status: "sent", messageId: "msg-1" })
+      .mockResolvedValueOnce({ status: "failed", error: "rate limited" });
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["a@x.com", "b@x.com"],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.invites.map((i: { emailStatus: string }) => i.emailStatus)).toEqual([
+      "sent",
+      "failed",
+    ]);
+    expect(res.body.errors).toEqual([]); // failed email is NOT a create failure
+  });
+
+  it("rejects batches over MAX_INVITE_BATCH (25) without touching the invite service", async () => {
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+    const big = Array.from({ length: 26 }, (_, i) => `u${i}@x.com`);
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: big,
+    });
+    expect(res.status).toBe(400);
+    expect(mockInvites.createCompanyInvite).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed emails inline (no @, no domain dot) and dedupes within the batch", async () => {
+    let n = 0;
+    mockInvites.createCompanyInvite.mockImplementation(async () => {
+      n += 1;
+      return {
+        id: `invite-${n}`,
+        token: `tok${n}`,
+        expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      };
+    });
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: [
+        "not-an-email",   // no @
+        "missing@domain", // no dot in domain
+        "ok@example.com",
+        "OK@example.com", // case-insensitive duplicate
+        "spaces in@email.com",
+      ],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.inviteIds).toEqual(["invite-1"]);
+    expect(res.body.errors).toEqual([
+      { email: "not-an-email", reason: "invalid-email" },
+      { email: "missing@domain", reason: "invalid-email" },
+      { email: "OK@example.com", reason: "duplicate-email" },
+      { email: "spaces in@email.com", reason: "invalid-email" },
+    ]);
+    expect(mockInvites.createCompanyInvite).toHaveBeenCalledTimes(1);
   });
 
   it("returns 403 for callers without access to companyId", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,6 +15,7 @@ import {
   createAuthRateLimiter,
   createBillingRateLimiter,
   createDefaultApiRateLimiter,
+  createInviteRateLimiter,
 } from "./middleware/rate-limit.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
@@ -246,6 +247,10 @@ export async function createApp(
   api.use(inboxDismissalRoutes(db));
   api.use(instanceSettingsRoutes(db));
   api.use("/conversations", conversationRoutes(db));
+  // AgentDash: tighter cap on the invite endpoint specifically — fans
+  // out to Resend (cost amplification + sender-domain reputation risk).
+  // Default API limiter still covers the rest of /onboarding.
+  api.use("/onboarding/invites", createInviteRateLimiter());
   api.use("/onboarding", onboardingV2Routes(db));
   api.use(assessRoutes(db));
   api.use(agentResearchRoutes(db));

--- a/server/src/auth/email.ts
+++ b/server/src/auth/email.ts
@@ -183,6 +183,76 @@ export function resetPasswordEmailTemplate(input: { resetUrl: string }): {
   return { subject, html, text };
 }
 
+/**
+ * Sanitizer for user-controlled strings that flow into mail subject /
+ * plaintext body. HTML escaping protects the HTML part, but the
+ * plaintext part is rendered as-is and the subject lands in real mail
+ * headers; both are vulnerable to social-engineering payloads like
+ * `"Microsoft Security <security@example.com>"` set as the user's
+ * display name. Strip control chars (CR/LF), quotes, angle brackets,
+ * and `@` (which lets attackers impersonate "Big Co security team
+ * <security@bigco.com>"), collapse whitespace, and cap at 60 chars.
+ *
+ * Returns null on input that's empty after sanitization, so the caller
+ * can fall back to a neutral default ("your teammate" / "AgentDash").
+ */
+export function sanitizeDisplayName(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const cleaned = value
+    .replace(/[\r\n<>"'@]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 60);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+/**
+ * Onboarding-wizard invite email. Plain HTML, no external assets, copy
+ * of the URL in plain text for clients that mangle the link. The
+ * inviter's display name is optional — when null we fall back to "your
+ * teammate" so the body still reads naturally.
+ *
+ * Both `companyName` and `inviterName` flow through `sanitizeDisplayName`
+ * before any rendering so an attacker-controlled `authUsers.name` can't
+ * craft a phishing-friendly subject like "Microsoft Security
+ * <security@microsoft.com> invited you to ...".
+ */
+export function inviteEmailTemplate(input: {
+  inviteUrl: string;
+  companyName: string | null;
+  inviterName: string | null;
+}): { subject: string; html: string; text: string } {
+  const company = sanitizeDisplayName(input.companyName) ?? "AgentDash";
+  const inviter = sanitizeDisplayName(input.inviterName) ?? "your teammate";
+  const subject = `${inviter} invited you to ${company} on AgentDash`;
+  const text = [
+    `${inviter} invited you to join ${company} on AgentDash.`,
+    "",
+    `Accept the invite: ${input.inviteUrl}`,
+    "",
+    "AgentDash gives your team a Chief of Staff agent that coordinates AI",
+    "agents alongside humans. Once you join you'll share the same workspace",
+    "and CoS thread.",
+    "",
+    "If you weren't expecting this email, you can ignore it — the invite",
+    "expires in 72 hours.",
+  ].join("\n");
+
+  const html = `
+    <!doctype html>
+    <html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; max-width: 560px; margin: 24px auto; line-height: 1.6;">
+      <h1 style="font-size: 22px; margin: 0 0 16px;">You're invited to ${escapeHtml(company)}</h1>
+      <p>${escapeHtml(inviter)} invited you to join <strong>${escapeHtml(company)}</strong> on AgentDash.</p>
+      <p><a href="${escapeHtml(input.inviteUrl)}" style="display: inline-block; padding: 10px 16px; background: #1f1e1d; color: #fff; text-decoration: none; border-radius: 6px;">Accept invite</a></p>
+      <p style="font-size: 13px; color: #666;">Or copy this URL: ${escapeHtml(input.inviteUrl)}</p>
+      <p>AgentDash gives your team a Chief of Staff agent that coordinates AI agents alongside humans. Once you join you'll share the same workspace and CoS thread.</p>
+      <p style="font-size: 13px; color: #666;">If you weren't expecting this email, you can ignore it — the invite expires in 72 hours.</p>
+    </body></html>
+  `.trim();
+
+  return { subject, html, text };
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,14 +1,16 @@
 /**
  * AgentDash: tiered API rate limiting (#160)
  *
- * Three tiers:
- *  - Auth  (/api/auth/*): 10 req / 15 min  — brute-force / credential-stuffing vector
- *  - Billing mutations:   20 req / 15 min  — abuse / billing-fraud vector
- *  - Default (/api/*):  200 req / 15 min  — generous ceiling for legit usage
+ * Four tiers:
+ *  - Auth  (/api/auth/*):           10 req / 15 min  — brute-force / credential-stuffing
+ *  - Billing mutations:             20 req / 15 min  — abuse / billing-fraud
+ *  - Onboarding invites:            20 req / 15 min  — Resend cost amplification
+ *  - Default (/api/*):             200 req / 15 min  — generous ceiling for legit usage
  *
  * Env-var overrides:
  *  AGENTDASH_RATE_LIMIT_AUTH_MAX    (default 10)
  *  AGENTDASH_RATE_LIMIT_BILLING_MAX (default 20)
+ *  AGENTDASH_RATE_LIMIT_INVITE_MAX  (default 20)
  *  AGENTDASH_RATE_LIMIT_API_MAX     (default 200)
  *  AGENTDASH_RATE_LIMIT_DISABLED=true  — no-op middleware (tests / dev)
  */
@@ -80,4 +82,16 @@ export function createBillingRateLimiter(): RequestHandler {
 export function createDefaultApiRateLimiter(): RequestHandler {
   if (isDisabled()) return noopMiddleware;
   return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_API_MAX", 200));
+}
+
+/**
+ * Tighter limit for the onboarding invite endpoint. Each request can
+ * batch up to MAX_INVITE_BATCH (25) emails, each of which fans out to
+ * a Resend API call — so 20 req / 15 min × 25 = 500 emails per actor
+ * per quarter-hour. That's well above any legit "invite my team" flow
+ * but caps the cost-amplification window if a token is abused.
+ */
+export function createInviteRateLimiter(): RequestHandler {
+  if (isDisabled()) return noopMiddleware;
+  return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_INVITE_MAX", 20));
 }

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -23,6 +23,7 @@ import { materializeOnboardingGoals } from "../services/materialize-onboarding-g
 import { dispatchLLM } from "../services/dispatch-llm.js";
 import { parseTrailer } from "../services/cos-replier.js";
 import { logger } from "../middleware/logger.js";
+import { sendEmail, inviteEmailTemplate } from "../auth/email.js";
 import {
   FIXED_QUESTIONS,
   isAgentPlanPayload,
@@ -31,10 +32,33 @@ import {
   type InterviewTurn,
 } from "@paperclipai/shared";
 
+// Cap the per-request invite batch size. Closes the abuse vector flagged
+// in security review (H1) — without this an authenticated board user
+// could submit thousands of emails in one POST and trigger thousands of
+// Resend sends per call.
+const MAX_INVITE_BATCH = 25;
+
+// Cheap email shape check — not RFC-compliant, just enough to reject
+// obviously-malformed entries (no `@`, no domain, embedded whitespace,
+// length > 254). Resend rejects bad addresses anyway, but pre-filtering
+// avoids per-row Resend round-trips for typo'd input.
+function isLikelyEmail(value: string): boolean {
+  if (value.length === 0 || value.length > 254) return false;
+  if (/\s/.test(value)) return false;
+  // Require exactly one `@`, both sides non-empty, domain has a dot.
+  const at = value.indexOf("@");
+  if (at <= 0 || at !== value.lastIndexOf("@")) return false;
+  const domain = value.slice(at + 1);
+  return domain.length > 0 && domain.includes(".") && !domain.endsWith(".");
+}
+
 export function onboardingV2Routes(db: Db) {
   const router = Router();
   const conversations = conversationService(db);
   const agents = agentService(db);
+  // Hoisted out of the request handler so we don't re-instantiate the
+  // service per call (fixes review feedback re: per-request churn).
+  const companies = companyService(db);
 
   const users = {
     getById: async (id: string) => {
@@ -533,6 +557,14 @@ No greetings. No markdown headings outside the JSON block.`;
     if (!Array.isArray(emails)) {
       throw badRequest("emails must be an array");
     }
+    // Cap batch size — closes the abuse vector flagged in security
+    // review (H1): without this an authenticated board user can submit
+    // 10k entries and burn 10k Resend sends per request. 25 is enough
+    // for the wizard's "invite your team" workflow without enabling
+    // bulk-spam amplification.
+    if (emails.length > MAX_INVITE_BATCH) {
+      throw badRequest(`Too many invites (max ${MAX_INVITE_BATCH} per request)`);
+    }
     assertCompanyAccess(req, companyId);
 
     // Resolve the public base URL from forwarded headers, with a
@@ -545,7 +577,26 @@ No greetings. No markdown headings outside the JSON block.`;
     const host = forwardedHost || req.header("host") || "";
     const baseUrl = host ? `${proto}://${host}` : "";
 
-    const invites = inviteService(db);
+    // Best-effort lookups for the email body. Failures here don't
+    // block the create — we just fall back to neutral copy.
+    let companyName: string | null = null;
+    let inviterName: string | null = null;
+    try {
+      const company = await companies.getById(companyId);
+      companyName = company?.name ?? null;
+    } catch {
+      /* fall back to default company copy */
+    }
+    try {
+      const user = await users.getById(req.actor.userId);
+      // authUsers schema: both `name` and `email` are text().notNull(),
+      // so the inferred row type covers the fallback chain without `any`.
+      inviterName = user?.name ?? user?.email ?? null;
+    } catch {
+      /* fall back to "your teammate" */
+    }
+
+    const inviteSvc = inviteService(db);
     const inviteIds: string[] = [];
     const created: Array<{
       id: string;
@@ -553,8 +604,10 @@ No greetings. No markdown headings outside the JSON block.`;
       invitePath: string;
       inviteUrl: string;
       expiresAt: string;
+      emailStatus: "sent" | "skipped" | "failed";
     }> = [];
     const errors: Array<{ email: string; reason: string }> = [];
+    const seen = new Set<string>(); // dedupe within the same batch
 
     for (const email of emails) {
       const trimmed = typeof email === "string" ? email.trim() : "";
@@ -562,20 +615,50 @@ No greetings. No markdown headings outside the JSON block.`;
         errors.push({ email: String(email), reason: "empty-email" });
         continue;
       }
+      if (!isLikelyEmail(trimmed)) {
+        errors.push({ email: trimmed, reason: "invalid-email" });
+        continue;
+      }
+      const lower = trimmed.toLowerCase();
+      if (seen.has(lower)) {
+        errors.push({ email: trimmed, reason: "duplicate-email" });
+        continue;
+      }
+      seen.add(lower);
+
       try {
-        const row = await invites.createCompanyInvite({
+        const row = await inviteSvc.createCompanyInvite({
           companyId,
           invitedByUserId: req.actor.userId ?? null,
           email: trimmed,
         });
         const invitePath = `/invite/${row.token}`;
+        const inviteUrl = baseUrl ? `${baseUrl}${invitePath}` : invitePath;
+
+        // Fire the invite email. sendEmail returns {status} rather than
+        // throwing, so a missing RESEND_API_KEY (status:"skipped") or a
+        // Resend 4xx (status:"failed") never aborts the create — the
+        // inviter still has the URL to share by hand.
+        const { subject, html, text } = inviteEmailTemplate({
+          inviteUrl,
+          companyName,
+          inviterName,
+        });
+        const emailResult = await sendEmail({
+          to: trimmed,
+          subject,
+          html,
+          text,
+        });
+
         inviteIds.push(row.id);
         created.push({
           id: row.id,
           email: trimmed,
           invitePath,
-          inviteUrl: baseUrl ? `${baseUrl}${invitePath}` : invitePath,
+          inviteUrl,
           expiresAt: row.expiresAt.toISOString(),
+          emailStatus: emailResult.status,
         });
       } catch (err) {
         logger.warn(

--- a/server/src/services/invites.ts
+++ b/server/src/services/invites.ts
@@ -26,9 +26,16 @@ import { invites } from "@paperclipai/db";
 // Same constants access.ts uses. Kept in sync deliberately — invite tokens
 // are user-visible and the prefix `pcp_invite_` is documented in onboarding
 // emails / CLI prompts. If access.ts evolves these, this file must follow.
+//
+// Followup: extract the token primitives into a shared module so access.ts
+// and this service stop drifting (tracked in repo issues).
 const INVITE_TOKEN_PREFIX = "pcp_invite_";
 const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
-const INVITE_TOKEN_SUFFIX_LENGTH = 8;
+// 16 chars × log2(36) ≈ 82.7 bits of entropy. access.ts still uses 8
+// (~41 bits) which is acceptable when paired with a redeem rate-limit
+// but tight; the new service starts at the safer ceiling so callers that
+// adopt these primitives don't inherit the weaker default.
+const INVITE_TOKEN_SUFFIX_LENGTH = 16;
 const INVITE_TOKEN_MAX_RETRIES = 5;
 const COMPANY_INVITE_TTL_MS = 72 * 60 * 60 * 1000; // 72h, matches access.ts.
 
@@ -36,11 +43,27 @@ function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
 }
 
+/**
+ * Cryptographically uniform draw from `INVITE_TOKEN_ALPHABET`. Naïve
+ * `byte % 36` skews the first four chars ~1.4% high (256 mod 36 = 4).
+ * Reject any byte in the partial bucket and redraw — bias-free at the
+ * cost of an expected ~4/256 = 1.6% retry rate per char.
+ */
+function pickAlphabetChar(): string {
+  const max = INVITE_TOKEN_ALPHABET.length;
+  const ceiling = 256 - (256 % max); // largest multiple of 36 ≤ 256 = 252
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const byte = randomBytes(1)[0]!;
+    if (byte < ceiling) return INVITE_TOKEN_ALPHABET[byte % max]!;
+  }
+  // (4/256)^8 ≈ 1.5e-12 — practically unreachable, but bounded.
+  return INVITE_TOKEN_ALPHABET[randomBytes(1)[0]! % max]!;
+}
+
 function createInviteToken(): string {
-  const bytes = randomBytes(INVITE_TOKEN_SUFFIX_LENGTH);
   let suffix = "";
   for (let idx = 0; idx < INVITE_TOKEN_SUFFIX_LENGTH; idx += 1) {
-    suffix += INVITE_TOKEN_ALPHABET[bytes[idx]! % INVITE_TOKEN_ALPHABET.length];
+    suffix += pickAlphabetChar();
   }
   return `${INVITE_TOKEN_PREFIX}${suffix}`;
 }

--- a/ui/src/api/onboarding.ts
+++ b/ui/src/api/onboarding.ts
@@ -29,6 +29,8 @@ export interface CreatedInvite {
   invitePath: string;
   inviteUrl: string;
   expiresAt: string;
+  /** Result of the optional Resend send. "skipped" when RESEND_API_KEY is unset. */
+  emailStatus: "sent" | "skipped" | "failed";
 }
 
 export interface InvitesResponse {


### PR DESCRIPTION
> **Stacks on top of #337.** This branch was created off `fix/onboarding-invites-stub` while #337 was open. Once #337 merges, rebase this against fresh `main` (the diff against main currently includes #337's commits; the *new* work added in this PR is in commit `efe16d81`).

## Summary
Layered on top of PR #337 (which wired the create + URL surfacing). Sends a real invite email per recipient via the existing Resend wrapper in `server/src/auth/email.ts`, and addresses every finding from the inline code + security review.

### Email send
- New `inviteEmailTemplate` in `email.ts`. Plain HTML + plaintext part, no external assets, copy of the URL in the text body for clients that mangle the link.
- Wired into `POST /api/onboarding/invites`. Result returned per-row as `emailStatus: "sent" | "skipped" | "failed"` so the wizard can surface delivery state. `RESEND_API_KEY` unset → `"skipped"` (the inviter still has the URL in the response).

### Security-review fixes
- **H1 batch cap** (`MAX_INVITE_BATCH = 25`) — closes the cost-amplification vector where a board user could submit 10k entries.
- **H2 rate limiter** — new `createInviteRateLimiter` (20 req / 15 min, same tier as billing) mounted at `/api/onboarding/invites`. Existing `keyGenerator` already prefers actor identity over IP.
- **M1 phishing** — new `sanitizeDisplayName` strips `\r\n<>\"'@`, caps at 60 chars. Applied to both `companyName` and `inviterName` so an attacker-controlled `authUsers.name` like `\"Microsoft Security <security@microsoft.com>\"` can't impersonate a trusted brand in the subject or plaintext body.
- **L1 token entropy** — bumped `INVITE_TOKEN_SUFFIX_LENGTH` 8 → 16 (~82 bits, up from ~41).
- **L2 alphabet bias** — `pickAlphabetChar()` redraws bytes ≥ 252 to remove the ~1.4% skew toward the first 4 alphabet chars.

### Code-review fixes
- New `email-templates.test.ts` (9 cases) covering `sanitizeDisplayName` and `inviteEmailTemplate` phishing-payload protection.
- Route tests extended: email-send invocation + `emailStatus` propagation + Resend skipped/failed + batch-cap + malformed-email + dedupe.
- `companies = companyService(db)` hoisted out of the request handler.
- Local `inviteSvc` no longer shadows the schema-table import.
- `inviterName` lookup uses inferred \`authUsers.\$inferSelect\` types instead of \`(user as any)\`.
- `isLikelyEmail` rejects no-\`@\`, no-domain-dot, embedded-whitespace, and >254-char inputs.

## Test plan
- [x] \`pnpm exec vitest run onboarding-v2-routes invites-service email-templates\` — 25/25 pass
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm exec vitest run\` (server) — 1885 pass / 10 skip / 0 fail
- [ ] CI green (audit, check, drift, policy, e2e, verify)

[no-prompt-update] — board-actor-only endpoint; agents do not call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)