### PR TITLE
Fail closed for unsupported CoS chat adapters [no-prompt-update]

### DIFF
--- a/server/src/__tests__/dispatch-llm.test.ts
+++ b/server/src/__tests__/dispatch-llm.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HttpError } from "../errors.js";
+
+const anthropicLLM = vi.hoisted(() => vi.fn(async () => "anthropic fallback"));
+
+vi.mock("../services/anthropic-llm.js", () => ({
+  anthropicLLM,
+}));
+
+import { dispatchLLM } from "../services/dispatch-llm.js";
+
+const originalAdapter = process.env.AGENTDASH_DEFAULT_ADAPTER;
+const originalSkipLLM = process.env.PAPERCLIP_E2E_SKIP_LLM;
+
+describe("dispatchLLM", () => {
+  beforeEach(() => {
+    anthropicLLM.mockClear();
+    delete process.env.PAPERCLIP_E2E_SKIP_LLM;
+  });
+
+  afterEach(() => {
+    if (originalAdapter === undefined) {
+      delete process.env.AGENTDASH_DEFAULT_ADAPTER;
+    } else {
+      process.env.AGENTDASH_DEFAULT_ADAPTER = originalAdapter;
+    }
+
+    if (originalSkipLLM === undefined) {
+      delete process.env.PAPERCLIP_E2E_SKIP_LLM;
+    } else {
+      process.env.PAPERCLIP_E2E_SKIP_LLM = originalSkipLLM;
+    }
+  });
+
+  it("rejects unsupported CoS chat adapters instead of silently using claude_api", async () => {
+    process.env.AGENTDASH_DEFAULT_ADAPTER = "codex_local";
+
+    await expect(
+      dispatchLLM({
+        system: "You are a Chief of Staff.",
+        messages: [{ role: "user", content: "Draft a rollout plan." }],
+      }),
+    ).rejects.toMatchObject({
+      status: 501,
+      message: expect.stringContaining("codex_local"),
+    } satisfies Partial<HttpError>);
+
+    expect(anthropicLLM).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -42,9 +42,9 @@ export function conversationRoutes(db: Db) {
         execute: async () => ({ output: "Stub agent reply" }),
       }),
     }),
-    // dispatchLLM routes to whichever adapter the user picked via `agentdash setup`
-    // (AGENTDASH_DEFAULT_ADAPTER). Defaults to claude_api; also supports hermes_local
-    // and claude_local. Falls back to anthropicLLM stub when keys are unset.
+    // dispatchLLM routes to the CoS chat adapter selected via `agentdash setup`
+    // (AGENTDASH_DEFAULT_ADAPTER). Defaults to claude_api; also supports
+    // hermes_local and claude_local. Unsupported adapters fail explicitly.
     replier: cosReplier({
       conversations: svc,
       llm: dispatchLLM,

--- a/server/src/services/dispatch-llm.ts
+++ b/server/src/services/dispatch-llm.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { anthropicLLM } from "./anthropic-llm.js";
 import { logger } from "../middleware/logger.js";
+import { HttpError } from "../errors.js";
 
 // Default hermes binary path — matches the mini's installation.
 // Overridden by AGENTDASH_HERMES_COMMAND env var if set.
@@ -22,6 +23,7 @@ const DEFAULT_HERMES_COMMAND = "/Users/maxiaoer/.local/bin/hermes";
 
 const TOKEN_BUDGET_LOG_ENABLED = Boolean(process.env.AGENTDASH_TOKEN_BUDGET_LOG);
 const TOKEN_BUDGET_FILE = process.env.AGENTDASH_TOKEN_BUDGET_FILE ?? "/tmp/agentdash-token-budget.json";
+const SUPPORTED_COS_CHAT_ADAPTERS = ["claude_api", "hermes_local", "claude_local"] as const;
 
 function emitTokenBudget(adapterName: string, input: LLMInput): void {
   if (!TOKEN_BUDGET_LOG_ENABLED) return;
@@ -217,7 +219,7 @@ function e2eStubResponse(callIndex: number): string {
  *  - "claude_api" (default): calls Anthropic API via anthropicLLM
  *  - "hermes_local": spawns `hermes chat -q "<prompt>" -Q`
  *  - "claude_local": spawns `claude --print -` with prompt on stdin
- *  - everything else: falls back to claude_api with a TODO log
+ *  - everything else: throws 501 so unsupported adapters do not silently misroute
  */
 export async function dispatchLLM(input: LLMInput): Promise<string> {
   const adapter = (process.env.AGENTDASH_DEFAULT_ADAPTER ?? "claude_api").trim();
@@ -273,10 +275,14 @@ export async function dispatchLLM(input: LLMInput): Promise<string> {
     }
   }
 
-  // TODO: add dispatch for gemini_local, codex_local, etc.
   logger.warn(
     { adapter },
-    "[dispatch-llm] adapter not yet supported for CoS chat — falling back to claude_api",
+    "[dispatch-llm] adapter not yet supported for CoS chat",
   );
-  return anthropicLLM(input);
+  throw new HttpError(
+    501,
+    `Adapter "${adapter}" is not supported for CoS chat dispatch. Configure AGENTDASH_DEFAULT_ADAPTER to one of: ${SUPPORTED_COS_CHAT_ADAPTERS.join(", ")}.`,
+    { adapter, supportedAdapters: SUPPORTED_COS_CHAT_ADAPTERS },
+    "unsupported_cos_chat_adapter",
+  );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through a control plane that has to make adapter behavior explicit and debuggable.
> - CoS chat and deep-interview flows use `dispatchLLM` to route prompts through the configured `AGENTDASH_DEFAULT_ADAPTER`.
> - The customer-readiness handoff called out a silent fallback where unsupported adapters such as `codex_local` or `gemini_local` were routed through `claude_api`.
> - That behavior hides configuration mistakes and makes local adapter failures look like Anthropic behavior.
> - This pull request changes unsupported CoS chat adapters to fail closed with a clear 501-style error.
> - The benefit is safer adapter configuration: supported adapters still work, while unsupported ones produce an actionable message instead of misrouting.

## What Changed

- Added a dispatch unit test proving `codex_local` is rejected and does not call the Anthropic fallback.
- Updated `dispatchLLM` to throw `HttpError(501)` for unsupported CoS chat adapters with the requested adapter and supported adapter list in details.
- Updated the conversation route comment so the documented behavior matches the new fail-closed dispatch contract.

## Verification

- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/dispatch-llm.test.ts`
- `pnpm exec vitest run server/src/__tests__/dispatch-llm.test.ts server/src/__tests__/assess-routes.test.ts server/src/__tests__/onboarding-v2-routes.test.ts server/src/__tests__/conversations-routes.test.ts`
- `git diff --check`

## Risks

- Low risk. This is an intentional behavior change for unsupported `AGENTDASH_DEFAULT_ADAPTER` values in CoS chat paths.
- Operators who previously relied on an unsupported adapter silently falling back to `claude_api` will now see a 501 error and must choose `claude_api`, `hermes_local`, or `claude_local`, or implement real dispatch support.
- No database migration, schema change, or UI surface is included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.5`, tool-enabled coding agent in Codex App with shell and git access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: server-only behavior)
- [x] I have updated relevant documentation to reflect my changes (N/A: no user-facing docs changed; inline route behavior comment updated)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
