### PR TITLE
Start run-healer scans from server startup [no-prompt-update]

### DIFF
--- a/docs/superpowers/specs/2026-05-11-self-healing-run-fixer-design.md
+++ b/docs/superpowers/specs/2026-05-11-self-healing-run-fixer-design.md
@@ -155,19 +155,15 @@ export const healEvents = pgTable("heal_events", {
 });
 ```
 
-## Routine Integration
+## Startup Integration
 
-**Schedule:** `HEALER_SCAN_INTERVAL_MS = 5 * 60 * 1000` (every 5 minutes)
+**Schedule:** `RUN_HEALER_SCAN_INTERVAL_MS = 5 * 60 * 1000` (every 5 minutes)
 
 **Registration:**
 ```typescript
-// In server startup, register with routineService
-routineService.register({
-  id: "run-healer",
-  schedule: "interval",
-  intervalMs: HEALER_SCAN_INTERVAL_MS,
-  handler: () => runHealerService.scan(),
-});
+// In server startup, schedule the run healer directly.
+const healer = runHealerService(db, { enabled: true, scanIntervalMs });
+setInterval(() => void healer.scan(), scanIntervalMs);
 ```
 
 ## Configuration

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -5,6 +5,8 @@ const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL
 const ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
+const ORIGINAL_RUN_HEALER_ENABLED = process.env.RUN_HEALER_ENABLED;
+const ORIGINAL_RUN_HEALER_SCAN_INTERVAL_MS = process.env.RUN_HEALER_SCAN_INTERVAL_MS;
 
 const {
   createAppMock,
@@ -16,6 +18,8 @@ const {
   feedbackServiceFactoryMock,
   fakeServer,
   loadConfigMock,
+  runHealerScanMock,
+  runHealerServiceMock,
 } = vi.hoisted(() => {
   const createAppMock = vi.fn(async () => ((_: unknown, __: unknown) => {}) as never);
   const createBetterAuthInstanceMock = vi.fn(() => ({}));
@@ -26,6 +30,10 @@ const {
     flushPendingFeedbackTraces: vi.fn(async () => ({ attempted: 0, sent: 0, failed: 0 })),
   };
   const feedbackServiceFactoryMock = vi.fn(() => feedbackExportServiceMock);
+  const runHealerScanMock = vi.fn(async () => ({ scanned: 0, fixed: 0, skipped: 0 }));
+  const runHealerServiceMock = vi.fn(() => ({
+    scan: runHealerScanMock,
+  }));
   const fakeServer = {
     once: vi.fn().mockReturnThis(),
     off: vi.fn().mockReturnThis(),
@@ -47,6 +55,8 @@ const {
     feedbackServiceFactoryMock,
     fakeServer,
     loadConfigMock,
+    runHealerScanMock,
+    runHealerServiceMock,
   };
 });
 
@@ -179,6 +189,10 @@ vi.mock("../services/index.js", () => ({
   })),
 }));
 
+vi.mock("../services/run-healer/service.js", () => ({
+  runHealerService: runHealerServiceMock,
+}));
+
 vi.mock("../storage/index.js", () => ({
   createStorageServiceFromConfig: vi.fn(() => ({ id: "storage-service" })),
 }));
@@ -205,6 +219,17 @@ vi.mock("../auth/better-auth.js", () => ({
 }));
 
 import { startServer } from "../index.ts";
+
+function restoreRunHealerEnv() {
+  if (ORIGINAL_RUN_HEALER_ENABLED === undefined) delete process.env.RUN_HEALER_ENABLED;
+  else process.env.RUN_HEALER_ENABLED = ORIGINAL_RUN_HEALER_ENABLED;
+
+  if (ORIGINAL_RUN_HEALER_SCAN_INTERVAL_MS === undefined) {
+    delete process.env.RUN_HEALER_SCAN_INTERVAL_MS;
+  } else {
+    process.env.RUN_HEALER_SCAN_INTERVAL_MS = ORIGINAL_RUN_HEALER_SCAN_INTERVAL_MS;
+  }
+}
 
 describe("startServer feedback export wiring", () => {
   beforeEach(() => {
@@ -356,5 +381,53 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+});
+
+describe("startServer run-healer scheduler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restoreRunHealerEnv();
+    loadConfigMock.mockReturnValue(buildTestConfig());
+    process.env.BETTER_AUTH_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    restoreRunHealerEnv();
+    vi.restoreAllMocks();
+  });
+
+  it("starts a periodic run-healer scan by default", async () => {
+    process.env.RUN_HEALER_SCAN_INTERVAL_MS = "12345";
+    const timer = { unref: vi.fn() };
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockImplementation((handler: TimerHandler, timeout?: number) => {
+        return Object.assign(timer, { handler, timeout }) as unknown as ReturnType<typeof setInterval>;
+      });
+
+    await startServer();
+
+    expect(runHealerServiceMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: true, scanIntervalMs: 12345 }),
+    );
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 12345);
+    expect(timer.unref).toHaveBeenCalled();
+
+    const scheduledScan = setIntervalSpy.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    scheduledScan?.();
+    await Promise.resolve();
+    expect(runHealerScanMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not construct or schedule the run-healer when disabled", async () => {
+    process.env.RUN_HEALER_ENABLED = "false";
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    await startServer();
+
+    expect(runHealerServiceMock).not.toHaveBeenCalled();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1485,7 +1485,7 @@ describe("realizeExecutionWorkspace", () => {
       await fs.realpath(path.join(repoRoot, "packages", "shared")),
     );
     },
-    15_000,
+    30_000,
   );
 
   it("records worktree setup and provision operations when a recorder is provided", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -35,6 +35,7 @@ import {
   reconcilePersistedRuntimeServicesOnStartup,
   routineService,
 } from "./services/index.js";
+import { runHealerService } from "./services/run-healer/service.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
@@ -845,6 +846,29 @@ export async function startServer(): Promise<StartedServer> {
         });
     }, config.heartbeatSchedulerIntervalMs);
   }
+
+  const runHealerEnabled = process.env.RUN_HEALER_ENABLED !== "false";
+  const runHealerScanIntervalMs = (() => {
+    const raw = process.env.RUN_HEALER_SCAN_INTERVAL_MS;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 60 * 1000;
+  })();
+  let runHealerHandle: ReturnType<typeof setInterval> | null = null;
+  if (!runHealerEnabled) {
+    logger.info({ reason: "RUN_HEALER_ENABLED=false" }, "run_healer: schedule skipped");
+  } else {
+    const healer = runHealerService(db as any, {
+      enabled: true,
+      scanIntervalMs: runHealerScanIntervalMs,
+    });
+    logger.info({ intervalMs: runHealerScanIntervalMs }, "run_healer: schedule enabled");
+    runHealerHandle = setInterval(() => {
+      void healer.scan().catch((err) => {
+        logger.error({ err }, "run_healer: scheduled scan failed");
+      });
+    }, runHealerScanIntervalMs);
+    runHealerHandle.unref?.();
+  }
   
   if (config.databaseBackupEnabled) {
     const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
@@ -1094,6 +1118,14 @@ export async function startServer(): Promise<StartedServer> {
           clearInterval(heartbeatDigestHandle);
         } catch (err) {
           logger.error({ err }, "failed to clear heartbeatDigest interval");
+        }
+      }
+
+      if (runHealerHandle) {
+        try {
+          clearInterval(runHealerHandle);
+        } catch (err) {
+          logger.error({ err }, "failed to clear runHealer interval");
         }
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - AgentDash extends that control plane with recovery loops for autonomous agent execution.
> - The run-healer subsystem already had schema, service logic, diagnosis, fix execution, and integration tests.
> - The gap was production reachability: nothing started periodic run-healer scans from server startup.
> - This pull request wires the run-healer into server startup behind the existing `RUN_HEALER_ENABLED=false` escape hatch.
> - The benefit is that eligible failed or stuck runs can be scanned by the existing bounded healer loop without requiring a manual caller.

## What Changed

- Starts a periodic run-healer scheduler during server startup, defaulting to `RUN_HEALER_SCAN_INTERVAL_MS` or five minutes.
- Clears the run-healer interval during server shutdown.
- Adds startup tests for default scheduler registration and the `RUN_HEALER_ENABLED=false` disable path.
- Aligns the duplicate workspace-runtime pnpm provisioning test timeout with its matching case after full-suite verification exposed the shorter duplicate timeout.
- Updates the run-healer design note from the older routine-registration sketch to the direct startup scheduler now implemented.

## Verification

- `pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts`
- `pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts server/src/__tests__/run-healer.test.ts`
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t "provisions worktree-local pnpm node_modules instead of reusing base-repo links"`
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`
- `git diff --check`
- `git diff --cached --check`

## Risks

- Moderate behavioral risk: the healer now actually runs in production by default, which is intended but increases the importance of the existing daily cost/count caps and per-run cap.
- Operator escape hatch remains `RUN_HEALER_ENABLED=false`.
- Live production failed-run healing was not exercised locally.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 in Codex Desktop, high-reasoning coding workflow with local shell/tool execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
