### PR TITLE
Keep invite tokens consistent across creation paths [no-prompt-update]

### DIFF
--- a/server/src/__tests__/invite-create-route.test.ts
+++ b/server/src/__tests__/invite-create-route.test.ts
@@ -133,7 +133,7 @@ describe("POST /companies/:companyId/invites", () => {
 
     expect(res.status).toBe(201);
     expect(res.body.companyName).toBe("Acme Robotics");
-    expect(res.body.invitePath).toMatch(/^\/invite\/pcp_invite_/);
-    expect(res.body.inviteUrl).toMatch(/^https:\/\/paperclip\.example\/invite\/pcp_invite_/);
+    expect(res.body.invitePath).toMatch(/^\/invite\/pcp_invite_[a-z0-9]{16}$/);
+    expect(res.body.inviteUrl).toMatch(/^https:\/\/paperclip\.example\/invite\/pcp_invite_[a-z0-9]{16}$/);
   });
 });

--- a/server/src/__tests__/invite-tokens.test.ts
+++ b/server/src/__tests__/invite-tokens.test.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  COMPANY_INVITE_TTL_MS,
+  INVITE_TOKEN_MAX_RETRIES,
+  createInviteToken,
+  hashToken,
+  isInviteTokenHashCollisionError,
+} from "../lib/invite-tokens.js";
+
+describe("invite token primitives", () => {
+  it("creates 16-character company invite tokens with the public prefix", () => {
+    expect(createInviteToken()).toMatch(/^pcp_invite_[a-z0-9]{16}$/);
+  });
+
+  it("hashes tokens with sha256 hex", () => {
+    const token = "pcp_invite_testtoken";
+    expect(hashToken(token)).toBe(
+      createHash("sha256").update(token).digest("hex")
+    );
+  });
+
+  it("recognizes only invite token hash unique constraint collisions", () => {
+    expect(
+      isInviteTokenHashCollisionError({
+        code: "23505",
+        constraint: "invites_token_hash_unique_idx",
+      })
+    ).toBe(true);
+    expect(
+      isInviteTokenHashCollisionError({
+        cause: {
+          code: "23505",
+          message:
+            'duplicate key value violates unique constraint "invites_token_hash_unique_idx"',
+        },
+      })
+    ).toBe(true);
+    expect(
+      isInviteTokenHashCollisionError({
+        code: "23505",
+        constraint: "other_unique_idx",
+      })
+    ).toBe(false);
+  });
+
+  it("exports the retry and ttl constants used by invite creation call sites", () => {
+    expect(INVITE_TOKEN_MAX_RETRIES).toBe(5);
+    expect(COMPANY_INVITE_TTL_MS).toBe(72 * 60 * 60 * 1000);
+  });
+});

--- a/server/src/lib/invite-tokens.ts
+++ b/server/src/lib/invite-tokens.ts
@@ -1,0 +1,61 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export const INVITE_TOKEN_PREFIX = "pcp_invite_";
+export const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+export const INVITE_TOKEN_SUFFIX_LENGTH = 16;
+export const INVITE_TOKEN_MAX_RETRIES = 5;
+export const COMPANY_INVITE_TTL_MS = 72 * 60 * 60 * 1000;
+
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Cryptographically uniform draw from `INVITE_TOKEN_ALPHABET`.
+ *
+ * Naive `byte % 36` skews the first four chars high because 256 mod 36 = 4.
+ * Reject the partial bucket and redraw instead.
+ */
+function pickInviteTokenChar(): string {
+  const max = INVITE_TOKEN_ALPHABET.length;
+  const ceiling = 256 - (256 % max);
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const byte = randomBytes(1)[0]!;
+    if (byte < ceiling) return INVITE_TOKEN_ALPHABET[byte % max]!;
+  }
+  return INVITE_TOKEN_ALPHABET[randomBytes(1)[0]! % max]!;
+}
+
+export function createInviteToken(): string {
+  let suffix = "";
+  for (let idx = 0; idx < INVITE_TOKEN_SUFFIX_LENGTH; idx += 1) {
+    suffix += pickInviteTokenChar();
+  }
+  return `${INVITE_TOKEN_PREFIX}${suffix}`;
+}
+
+export function isInviteTokenHashCollisionError(error: unknown): boolean {
+  const candidates = [
+    error,
+    (error as { cause?: unknown } | null)?.cause ?? null,
+  ];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const code =
+      "code" in candidate && typeof candidate.code === "string"
+        ? candidate.code
+        : null;
+    const message =
+      "message" in candidate && typeof candidate.message === "string"
+        ? candidate.message
+        : "";
+    const constraint =
+      "constraint" in candidate && typeof candidate.constraint === "string"
+        ? candidate.constraint
+        : null;
+    if (code !== "23505") continue;
+    if (constraint === "invites_token_hash_unique_idx") return true;
+    if (message.includes("invites_token_hash_unique_idx")) return true;
+  }
+  return false;
+}

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1,5 +1,4 @@
 import {
-  createHash,
   generateKeyPairSync,
   randomBytes,
   timingSafeEqual
@@ -79,6 +78,13 @@ import {
   collapseDuplicatePendingHumanJoinRequests,
   findReusableHumanJoinRequest,
 } from "../lib/join-request-dedupe.js";
+import {
+  COMPANY_INVITE_TTL_MS,
+  INVITE_TOKEN_MAX_RETRIES,
+  createInviteToken,
+  hashToken,
+  isInviteTokenHashCollisionError,
+} from "../lib/invite-tokens.js";
 import { assertAuthenticated, assertCompanyAccess } from "./authz.js";
 import {
   claimBoardOwnership,
@@ -86,30 +92,12 @@ import {
 } from "../board-claim.js";
 import { getStorageService } from "../storage/index.js";
 
-function hashToken(token: string) {
-  return createHash("sha256").update(token).digest("hex");
-}
-
-const INVITE_TOKEN_PREFIX = "pcp_invite_";
-const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
-const INVITE_TOKEN_SUFFIX_LENGTH = 8;
-const INVITE_TOKEN_MAX_RETRIES = 5;
-const COMPANY_INVITE_TTL_MS = 72 * 60 * 60 * 1000;
 const INVITE_RESOLUTION_DNS_TIMEOUT_MS = 3_000;
 
 type MemberGrantPayload = {
   permissionKey: PermissionKey;
   scope?: Record<string, unknown> | null;
 };
-
-function createInviteToken() {
-  const bytes = randomBytes(INVITE_TOKEN_SUFFIX_LENGTH);
-  let suffix = "";
-  for (let idx = 0; idx < INVITE_TOKEN_SUFFIX_LENGTH; idx += 1) {
-    suffix += INVITE_TOKEN_ALPHABET[bytes[idx]! % INVITE_TOKEN_ALPHABET.length];
-  }
-  return `${INVITE_TOKEN_PREFIX}${suffix}`;
-}
 
 function createClaimSecret() {
   return `pcp_claim_${randomBytes(24).toString("hex")}`;
@@ -2079,32 +2067,6 @@ export function resolveJoinRequestAgentManagerId(
     (candidate) => candidate.reportsTo === null
   );
   return (rootCeo ?? ceoCandidates[0] ?? null)?.id ?? null;
-}
-
-function isInviteTokenHashCollisionError(error: unknown) {
-  const candidates = [
-    error,
-    (error as { cause?: unknown } | null)?.cause ?? null
-  ];
-  for (const candidate of candidates) {
-    if (!candidate || typeof candidate !== "object") continue;
-    const code =
-      "code" in candidate && typeof candidate.code === "string"
-        ? candidate.code
-        : null;
-    const message =
-      "message" in candidate && typeof candidate.message === "string"
-        ? candidate.message
-        : "";
-    const constraint =
-      "constraint" in candidate && typeof candidate.constraint === "string"
-        ? candidate.constraint
-        : null;
-    if (code !== "23505") continue;
-    if (constraint === "invites_token_hash_unique_idx") return true;
-    if (message.includes("invites_token_hash_unique_idx")) return true;
-  }
-  return false;
 }
 
 function isAbortError(error: unknown) {

--- a/server/src/services/invites.ts
+++ b/server/src/services/invites.ts
@@ -19,61 +19,15 @@
 //     to delegate here, but that's a bigger refactor and not required to
 //     unblock the onboarding-wizard customer-facing fix.
 
-import { createHash, randomBytes } from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { invites } from "@paperclipai/db";
-
-// Same constants access.ts uses. Kept in sync deliberately — invite tokens
-// are user-visible and the prefix `pcp_invite_` is documented in onboarding
-// emails / CLI prompts. If access.ts evolves these, this file must follow.
-//
-// Followup: extract the token primitives into a shared module so access.ts
-// and this service stop drifting (tracked in repo issues).
-const INVITE_TOKEN_PREFIX = "pcp_invite_";
-const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
-// 16 chars × log2(36) ≈ 82.7 bits of entropy. access.ts still uses 8
-// (~41 bits) which is acceptable when paired with a redeem rate-limit
-// but tight; the new service starts at the safer ceiling so callers that
-// adopt these primitives don't inherit the weaker default.
-const INVITE_TOKEN_SUFFIX_LENGTH = 16;
-const INVITE_TOKEN_MAX_RETRIES = 5;
-const COMPANY_INVITE_TTL_MS = 72 * 60 * 60 * 1000; // 72h, matches access.ts.
-
-function hashToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex");
-}
-
-/**
- * Cryptographically uniform draw from `INVITE_TOKEN_ALPHABET`. Naïve
- * `byte % 36` skews the first four chars ~1.4% high (256 mod 36 = 4).
- * Reject any byte in the partial bucket and redraw — bias-free at the
- * cost of an expected ~4/256 = 1.6% retry rate per char.
- */
-function pickAlphabetChar(): string {
-  const max = INVITE_TOKEN_ALPHABET.length;
-  const ceiling = 256 - (256 % max); // largest multiple of 36 ≤ 256 = 252
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    const byte = randomBytes(1)[0]!;
-    if (byte < ceiling) return INVITE_TOKEN_ALPHABET[byte % max]!;
-  }
-  // (4/256)^8 ≈ 1.5e-12 — practically unreachable, but bounded.
-  return INVITE_TOKEN_ALPHABET[randomBytes(1)[0]! % max]!;
-}
-
-function createInviteToken(): string {
-  let suffix = "";
-  for (let idx = 0; idx < INVITE_TOKEN_SUFFIX_LENGTH; idx += 1) {
-    suffix += pickAlphabetChar();
-  }
-  return `${INVITE_TOKEN_PREFIX}${suffix}`;
-}
-
-function isInviteTokenHashCollisionError(error: unknown): boolean {
-  // Postgres unique-constraint violation. We retry to dodge the (vanishingly
-  // rare) randBytes hash collision rather than surfacing a 5xx.
-  const code = (error as { code?: string } | null)?.code;
-  return code === "23505";
-}
+import {
+  COMPANY_INVITE_TTL_MS,
+  INVITE_TOKEN_MAX_RETRIES,
+  createInviteToken,
+  hashToken,
+  isInviteTokenHashCollisionError,
+} from "../lib/invite-tokens.js";
 
 export type CreateCompanyInviteInput = {
   companyId: string;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Customer-readiness work depends on a reliable human invite flow so real operators can join boards from surfaced invite URLs.
> - Invite creation currently has two server paths: the board access route and the onboarding invite service.
> - Those paths had duplicated token primitives and had already drifted: one route emitted 8-character suffixes while the newer service emitted 16-character suffixes with unbiased sampling.
> - Drift is risky because customer-facing invite URLs and emailed prompts should follow one token contract.
> - This pull request extracts invite token generation, hashing, TTL, retry, and collision handling into a shared server primitive.
> - The benefit is one future edit point and uniformly stronger public invite tokens for both creation paths.

## What Changed

- Added `server/src/lib/invite-tokens.ts` for shared invite token constants, SHA-256 hashing, unbiased token generation, retry limits, TTL, and unique-index collision detection.
- Updated `server/src/routes/access.ts` and `server/src/services/invites.ts` to use the shared primitive instead of copied helpers.
- Added `server/src/__tests__/invite-tokens.test.ts` and tightened the board invite route assertion to require `pcp_invite_` plus a 16-character lowercase alphanumeric suffix.

## Verification

- `pnpm exec vitest run server/src/__tests__/invite-tokens.test.ts server/src/__tests__/invite-create-route.test.ts server/src/__tests__/invites-service.test.ts`
- `pnpm exec vitest run server/src/__tests__/invite-create-route.test.ts server/src/__tests__/invites-service.test.ts server/src/__tests__/invite-summary-route.test.ts server/src/__tests__/invite-logo-route.test.ts server/src/__tests__/invite-accept-existing-member.test.ts server/src/__tests__/invite-test-resolution-route.test.ts server/src/__tests__/openclaw-invite-prompt-route.test.ts server/src/__tests__/cli-auth-routes.test.ts server/src/__tests__/invite-tokens.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm -r typecheck`
- `pnpm build`
- `git diff --check`
- `pnpm test:run` was attempted twice locally and did not complete cleanly because of unrelated full-suite contention outside this diff. The latest run failed in `agent-research`, `cursor-local-execute`, and `environment-service`; each failing file/test passed when isolated with:
  - `pnpm exec vitest run server/src/__tests__/agent-research.test.ts`
  - `pnpm exec vitest run server/src/__tests__/cursor-local-execute.test.ts -t "keeps explicit command overrides for remote sandbox execution"`
  - `pnpm exec vitest run server/src/__tests__/environment-service.test.ts`

## Risks

- Board-created invite tokens now use a 16-character suffix instead of the previous 8-character suffix. Existing invite redemption remains compatible because redemption hashes the provided token and does not enforce token length.
- Collision retry detection is now constrained to `invites_token_hash_unique_idx`; unrelated unique violations will surface instead of being retried as invite-token collisions.
- No schema or data migration is involved.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex in Codex App, `gpt-5.5` class coding model with local shell/editing tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and documented the unrelated full-suite failure above
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A; server-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A; no user-facing docs changed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
