### PR TITLE
[no-prompt-update] Test subscription webhook plan-tier update

### DIFF
--- a/server/src/__tests__/billing-webhook-entitlement-integration.test.ts
+++ b/server/src/__tests__/billing-webhook-entitlement-integration.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, stripeWebhookEvents } from "@paperclipai/db";
+import { companyService } from "../services/companies.js";
+import { entitlementSync } from "../services/entitlement-sync.js";
+import { stripeWebhookLedger } from "../services/stripe-webhook-ledger.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("Stripe webhook entitlement integration", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-billing-webhook-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(stripeWebhookEvents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("flips a free company to pro_trial for customer.subscription.created", async () => {
+    const companyId = randomUUID();
+    const periodEnd = new Date("2026-06-01T00:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Billing Co",
+      issuePrefix: `B${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      planTier: "free",
+      stripeCustomerId: "cus_trialing",
+    });
+
+    const sync = entitlementSync({
+      companies: companyService(db),
+      ledger: stripeWebhookLedger(db),
+    });
+
+    await sync.dispatch({
+      id: "evt_subscription_created_trialing",
+      type: "customer.subscription.created",
+      data: {
+        object: {
+          id: "sub_trialing",
+          customer: "cus_trialing",
+          status: "trialing",
+          current_period_end: Math.floor(periodEnd.getTime() / 1000),
+          items: { data: [{ quantity: 3 }] },
+        },
+      },
+    });
+
+    const [company] = await db
+      .select({
+        planTier: companies.planTier,
+        planSeatsPaid: companies.planSeatsPaid,
+        planPeriodEnd: companies.planPeriodEnd,
+        stripeCustomerId: companies.stripeCustomerId,
+        stripeSubscriptionId: companies.stripeSubscriptionId,
+      })
+      .from(companies)
+      .where(eq(companies.id, companyId));
+    const [ledgerEvent] = await db
+      .select({
+        eventId: stripeWebhookEvents.eventId,
+        eventType: stripeWebhookEvents.eventType,
+      })
+      .from(stripeWebhookEvents)
+      .where(eq(stripeWebhookEvents.eventId, "evt_subscription_created_trialing"));
+
+    expect(company).toEqual({
+      planTier: "pro_trial",
+      planSeatsPaid: 3,
+      planPeriodEnd: periodEnd,
+      stripeCustomerId: "cus_trialing",
+      stripeSubscriptionId: "sub_trialing",
+    });
+    expect(ledgerEvent).toEqual({
+      eventId: "evt_subscription_created_trialing",
+      eventType: "customer.subscription.created",
+    });
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI-agent companies, including company-scoped billing entitlements.
> - The billing webhook path is responsible for turning Stripe subscription state into local company plan-tier state.
> - The launch checklist has an unchecked Gate 3 criterion: `customer.subscription.created` must flip a company from Free to `pro_trial`.
> - Unit tests already covered the entitlement mapping, but the database-backed path through `companyService`, `stripeWebhookLedger`, and `entitlementSync.dispatch` needed direct proof.
> - This PR ticks ❌ `customer.subscription.created` webhook flips company `planTier` to `pro_trial` by adding a focused embedded-Postgres integration test.
> - The benefit is launch-gate evidence that the real service adapters update the stored company row and record the webhook ledger event without changing production code.

## What Changed

- Added an embedded-Postgres integration test for `customer.subscription.created` with a `trialing` subscription.
- Asserted a stored `free` company becomes `pro_trial`, receives the Stripe subscription/customer IDs, persists the paid seat quantity, and records the webhook ledger event.

## Verification

- `pnpm exec vitest run server/src/__tests__/billing-webhook-entitlement-integration.test.ts`
- `pnpm -r typecheck`
- `pnpm exec vitest run`
- `pnpm build`

## Risks

- Low risk: test-only change, no production code path changed.
- This does not use live Stripe webhook delivery; it invokes the webhook handler path directly against embedded Postgres as scoped for Iteration B.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, Codex desktop session with tool-enabled code execution and repository access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
