### PR TITLE
[no-prompt-update] Test Pro invite cap removal

### DIFF
--- a/server/src/__tests__/build-tier-deps.test.ts
+++ b/server/src/__tests__/build-tier-deps.test.ts
@@ -146,4 +146,15 @@ describe("requireTierFor wiring (integration via express)", () => {
     const r = await request(app).post("/companies/co-1/invites").send({});
     expect(r.status).toBe(201);
   });
+
+  it("allows pro_active invite creation past Free caps while Free remains capped", async () => {
+    const proApp = makeApp("pro_active", 5, 5);
+    const pro = await request(proApp).post("/companies/co-1/invites").send({});
+    expect(pro.status).toBe(201);
+
+    const freeApp = makeApp("free", 1, 1);
+    const free = await request(freeApp).post("/companies/co-1/invites").send({});
+    expect(free.status).toBe(402);
+    expect(free.body.code).toBe("seat_cap_exceeded");
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Billing entitlements decide which operator actions remain capped on Free and which become available after upgrade.
> - The launch checklist has an unchecked Billing Gate 3 criterion: Free -> Pro cap removal works.
> - This PR ticks ❌ Free → Pro cap removal works by adding a route-level integration test proving pro_active can invite past Free caps while Free remains capped.
> - The existing `requireTierFor(\"invite\", ...)` middleware already enforces the behavior; this PR proves that contract without production-code churn.
> - The benefit is launch-gate evidence for the Free-to-Pro invite-cap transition in a very small, reviewable diff.

## What Changed

- Added an integration assertion to `server/src/__tests__/build-tier-deps.test.ts` covering invite creation for a capped Free company versus a `pro_active` company with existing humans and agents.

## Verification

- `pnpm exec vitest run server/src/__tests__/build-tier-deps.test.ts`
- `pnpm -r typecheck`
- `pnpm exec vitest run`
- `pnpm build`

## Risks

- Low risk: test-only change, no production behavior change.
- This does not exercise a live browser upgrade-and-invite flow; it verifies the route-level entitlement gate directly.

> ROADMAP.md checked. This is a tightly scoped billing-launch verification test and does not duplicate planned roadmap-level core work.

## Model Used

- OpenAI Codex, GPT-5.5-class coding agent with tool use and high-reasoning repository workflow support.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: test-only launch-gate proof)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge