### PR TITLE
[no-prompt-update] Add About and Changelog pages

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,6 +38,8 @@ import { DesignGuide } from "./pages/DesignGuide";
 import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
 import { InstanceAccess } from "./pages/InstanceAccess";
 import { InstanceSettings } from "./pages/InstanceSettings";
+import { InstanceAbout } from "./pages/InstanceAbout";
+import { InstanceChangelog } from "./pages/InstanceChangelog";
 import { InstanceExperimentalSettings } from "./pages/InstanceExperimentalSettings";
 import { ProfileSettings } from "./pages/ProfileSettings";
 import { PluginManager } from "./pages/PluginManager";
@@ -316,6 +318,8 @@ export function App() {
             <Route path="plugins" element={<PluginManager />} />
             <Route path="plugins/:pluginId" element={<PluginSettings />} />
             <Route path="adapters" element={<AdapterManager />} />
+            <Route path="about" element={<InstanceAbout />} />
+            <Route path="changelog" element={<InstanceChangelog />} />
           </Route>
           <Route path="companies" element={<UnprefixedBoardRedirect />} />
           <Route path="issues" element={<UnprefixedBoardRedirect />} />

--- a/ui/src/components/InstanceSidebar.tsx
+++ b/ui/src/components/InstanceSidebar.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Clock3, Cpu, FlaskConical, Puzzle, Settings, Shield, SlidersHorizontal, UserRoundPen } from "lucide-react";
+import { Clock3, Cpu, FlaskConical, Info, Puzzle, ScrollText, Settings, Shield, SlidersHorizontal, UserRoundPen } from "lucide-react";
 import { NavLink } from "@/lib/router";
 import { pluginsApi } from "@/api/plugins";
 import { queryKeys } from "@/lib/queryKeys";
@@ -30,6 +30,8 @@ export function InstanceSidebar() {
           <SidebarNavItem to="/instance/settings/experimental" label="Experimental" icon={FlaskConical} />
           <SidebarNavItem to="/instance/settings/plugins" label="Plugins" icon={Puzzle} />
           <SidebarNavItem to="/instance/settings/adapters" label="Adapters" icon={Cpu} />
+          <SidebarNavItem to="/instance/settings/about" label="About" icon={Info} />
+          <SidebarNavItem to="/instance/settings/changelog" label="Changelog" icon={ScrollText} />
           {(plugins ?? []).length > 0 ? (
             <div className="ml-4 mt-1 flex flex-col gap-0.5 border-l border-border/70 pl-3">
               {(plugins ?? []).map((plugin) => (

--- a/ui/src/components/SidebarAccountMenu.test.tsx
+++ b/ui/src/components/SidebarAccountMenu.test.tsx
@@ -107,7 +107,7 @@ describe("SidebarAccountMenu", () => {
 
     expect(document.body.textContent).toContain("Edit profile");
     expect(document.body.textContent).toContain("Documentation");
-    expect(document.body.textContent).toContain("Paperclip v1.2.3");
+    expect(document.body.textContent).toContain("AgentDash v1.2.3");
     expect(document.body.textContent).toContain("jane@example.com");
 
     await act(async () => {

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   BookOpen,
+  Info,
   LogOut,
   type LucideIcon,
   Moon,
@@ -180,7 +181,7 @@ export function SidebarAccountMenu({
                 </div>
                 <p className="truncate text-sm text-muted-foreground">{secondaryLabel}</p>
                 {version ? (
-                  <p className="mt-1 text-xs text-muted-foreground">Paperclip v{version}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">AgentDash v{version}</p>
                 ) : null}
               </div>
             </div>
@@ -205,6 +206,13 @@ export function SidebarAccountMenu({
                 description="Jump back to the last settings page you opened."
                 icon={Settings}
                 href={instanceSettingsTarget}
+                onClick={closeNavigationChrome}
+              />
+              <MenuAction
+                label="About AgentDash"
+                description="View version, deployment, and changelog."
+                icon={Info}
+                href="/instance/settings/about"
                 onClick={closeNavigationChrome}
               />
               <MenuAction

--- a/ui/src/lib/release-notes.test.ts
+++ b/ui/src/lib/release-notes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { listReleaseNotes, parseReleaseMarkdown } from "./release-notes";
+
+describe("release notes", () => {
+  it("parses version, release date, and summary sections from release markdown", () => {
+    const note = parseReleaseMarkdown(`\
+# v2026.428.0
+
+> Released: 2026-04-28
+
+## Highlights
+
+- **One** — see [#123](https://example.com)
+- Two
+
+## Fixes
+
+- Three
+`);
+
+    expect(note).toEqual({
+      version: "v2026.428.0",
+      releasedAt: "2026-04-28",
+      sections: [
+        { title: "Highlights", items: ["One — see #123", "Two"] },
+        { title: "Fixes", items: ["Three"] },
+      ],
+      body: expect.stringContaining("## Highlights"),
+    });
+  });
+
+  it("lists bundled release notes newest first", () => {
+    const notes = listReleaseNotes();
+
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes[0]?.version).toMatch(/^v/);
+    expect(notes.map((note) => note.version)).toContain("v0.3.1");
+  });
+});

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -1,0 +1,65 @@
+export interface ReleaseNoteSection {
+  title: string;
+  items: string[];
+}
+
+export interface ReleaseNote {
+  version: string;
+  releasedAt: string | null;
+  sections: ReleaseNoteSection[];
+  body: string;
+}
+
+const releaseModules = import.meta.glob("../../../releases/*.md", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+}) as Record<string, string>;
+
+function cleanInlineMarkdown(value: string) {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1");
+}
+
+export function parseReleaseMarkdown(markdown: string): ReleaseNote {
+  const body = markdown.trim();
+  const lines = body.split(/\r?\n/);
+  const version = lines.find((line) => line.startsWith("# "))?.replace(/^#\s+/, "").trim() ?? "Unversioned";
+  const releasedAt = lines
+    .find((line) => /^>\s*Released:/i.test(line))
+    ?.replace(/^>\s*Released:\s*/i, "")
+    .trim() ?? null;
+
+  const sections: ReleaseNoteSection[] = [];
+  let current: ReleaseNoteSection | null = null;
+
+  for (const line of lines) {
+    const heading = /^##\s+(.+)$/.exec(line);
+    if (heading) {
+      current = { title: heading[1]!.trim(), items: [] };
+      sections.push(current);
+      continue;
+    }
+
+    const item = /^-\s+(.+)$/.exec(line);
+    if (item && current) {
+      current.items.push(cleanInlineMarkdown(item[1]!.trim()));
+    }
+  }
+
+  return { version, releasedAt, sections, body };
+}
+
+function releaseSortValue(note: ReleaseNote) {
+  if (!note.releasedAt) return 0;
+  const parsed = Date.parse(note.releasedAt);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function listReleaseNotes(): ReleaseNote[] {
+  return Object.values(releaseModules)
+    .map(parseReleaseMarkdown)
+    .sort((a, b) => releaseSortValue(b) - releaseSortValue(a));
+}

--- a/ui/src/pages/InstanceAbout.tsx
+++ b/ui/src/pages/InstanceAbout.tsx
@@ -1,0 +1,78 @@
+import { useQuery } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { healthApi } from "@/api/health";
+import { queryKeys } from "@/lib/queryKeys";
+
+function ValueRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-border/60 py-3 last:border-b-0">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate text-right text-sm font-medium text-foreground">{value}</span>
+    </div>
+  );
+}
+
+function boolLabel(value: boolean | undefined) {
+  if (value === undefined) return "unknown";
+  return value ? "yes" : "no";
+}
+
+export function InstanceAbout() {
+  const { data: health, isLoading, error } = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+  });
+
+  const version = health?.version ? `v${health.version}` : isLoading ? "loading..." : "unknown";
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-6">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-bold text-foreground">About AgentDash</h1>
+          <Badge variant="secondary">{version}</Badge>
+        </div>
+      </div>
+
+      {error ? (
+        <Card>
+          <CardContent className="text-sm text-destructive">
+            Unable to load instance health metadata.
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Instance</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ValueRow label="App version" value={version} />
+            <ValueRow label="Source repository" value="github.com/thetangstr/agentdash" />
+            <ValueRow label="Health status" value={health?.status ?? (isLoading ? "loading..." : "unknown")} />
+            <ValueRow label="Deployment mode" value={health?.deploymentMode ?? "unknown"} />
+            <ValueRow label="Deployment exposure" value={health?.deploymentExposure ?? "unknown"} />
+            <ValueRow label="Auth ready" value={boolLabel(health?.authReady)} />
+            <ValueRow label="Bootstrap status" value={health?.bootstrapStatus ?? "unknown"} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Release Notes</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <a
+              href="/instance/settings/changelog"
+              className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent/50"
+            >
+              Open changelog
+            </a>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/InstanceChangelog.tsx
+++ b/ui/src/pages/InstanceChangelog.tsx
@@ -1,0 +1,47 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { listReleaseNotes } from "@/lib/release-notes";
+
+const MAX_RELEASES = 8;
+const MAX_ITEMS_PER_SECTION = 5;
+
+export function InstanceChangelog() {
+  const notes = listReleaseNotes().slice(0, MAX_RELEASES);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-xl font-bold text-foreground">Changelog</h1>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {notes.map((note) => (
+          <Card key={note.version}>
+            <CardHeader>
+              <div className="flex flex-wrap items-center gap-2">
+                <CardTitle className="text-base">{note.version}</CardTitle>
+                {note.releasedAt ? <Badge variant="secondary">{note.releasedAt}</Badge> : null}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {note.sections.slice(0, 4).map((section) => (
+                <section key={`${note.version}-${section.title}`} className="space-y-2">
+                  <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                    {section.title}
+                  </h2>
+                  <ul className="space-y-1 text-sm text-foreground">
+                    {section.items.slice(0, MAX_ITEMS_PER_SECTION).map((item) => (
+                      <li key={item} className="leading-6">
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Thinking Path
> - Paperclip is the control plane AgentDash builds on for operating AI-agent companies.
> - Target-machine operators need a visible way to confirm which app version they are running.
> - The UI previously exposed only a small package version in the account popover.
> - Release notes already exist in `releases/*.md`, but there was no in-app changelog surface.
> - This pull request adds instance-level About and Changelog pages under Instance Settings.
> - The benefit is a simple UI path for confirming app version, repository, deployment state, and bundled release notes.

## What Changed
- Added `/instance/settings/about` showing AgentDash version, repository, health, deployment, auth, and bootstrap state.
- Added `/instance/settings/changelog` backed by bundled `releases/*.md` files.
- Added Instance Settings nav entries and an account-menu link for About.
- Added release-note parsing that strips inline Markdown syntax for readable UI output.

## Verification
- `pnpm exec vitest run ui/src/lib/release-notes.test.ts ui/src/components/SidebarAccountMenu.test.tsx ui/src/App.test.tsx`
- `pnpm exec vitest run`
- `pnpm build`
- Playwright screenshot smoke:
  - `/instance/settings/about` captured at `/tmp/agentdash-about.png`
  - `/instance/settings/changelog` captured at `/tmp/agentdash-changelog.png`

## Risks
- Low risk. UI-only settings pages plus a local release-note parser.
- About currently shows package version and repository; exact source commit/build metadata was split into a follow-up slice to keep this PR under the strict diff cap.

> For core feature work, include any schema/API/UI contract implications. For cleanup-only work, summarize why behavior is preserved.

## Model Used
- OpenAI Codex, GPT-5.5, high-reasoning coding agent with terminal, test, build, git, and browser-smoke tooling.

## Checklist
- [x] I read the relevant project docs and agent instructions.
- [x] I ran the smallest useful verification first.
- [x] I ran the required broader verification for this PR-ready hand-off or explained why not.
- [x] I updated docs when behavior or commands changed, or this change did not require docs.
- [x] I kept company-scoping and auth boundaries intact.
- [x] I included a complete PR description using this template.
