### PR TITLE
Respect local Hermes adapter defaults

### DIFF
--- a/patches/hermes-paperclip-adapter+0.3.0.patch
+++ b/patches/hermes-paperclip-adapter+0.3.0.patch
@@ -1,7 +1,126 @@
+diff --git a/dist/server/execute.js b/dist/server/execute.js
+index e96d5c9c0d175a06c668406ba57ac8f5ba750901..ffd90b49c2b5940223ac4dc07a2ec1ac8e132bfe 100644
+--- a/dist/server/execute.js
++++ b/dist/server/execute.js
+@@ -18,7 +18,7 @@
+  *   --source           session source tag for filtering
+  */
+ import { runChildProcess, buildPaperclipEnv, renderTemplate, ensureAbsoluteDirectory, } from "@paperclipai/adapter-utils/server-utils";
+-import { HERMES_CLI, DEFAULT_TIMEOUT_SEC, DEFAULT_GRACE_SEC, DEFAULT_MODEL, } from "../shared/constants.js";
++import { HERMES_CLI, DEFAULT_TIMEOUT_SEC, DEFAULT_GRACE_SEC, } from "../shared/constants.js";
+ import { detectModel, resolveProvider, } from "./detect-model.js";
+ // ---------------------------------------------------------------------------
+ // Config helpers
+@@ -247,7 +247,7 @@ export async function execute(ctx) {
+     const config = (ctx.agent?.adapterConfig ?? {});
+     // ── Resolve configuration ──────────────────────────────────────────────
+     const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
+-    const model = cfgString(config.model) || DEFAULT_MODEL;
++    const model = cfgString(config.model);
+     const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
+     const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
+     const maxTurns = cfgNumber(config.maxTurnsPerRun);
+@@ -350,7 +350,8 @@ export async function execute(ctx) {
+         // Non-fatal
+     }
+     // ── Log start ──────────────────────────────────────────────────────────
+-    await ctx.onLog("stdout", `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`);
++    const modelLabel = model || detectedConfig?.model || "Hermes configured default";
++    await ctx.onLog("stdout", `[hermes] Starting Hermes Agent (model=${modelLabel}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`);
+     if (prevSessionId) {
+         await ctx.onLog("stdout", `[hermes] Resuming session: ${prevSessionId}\n`);
+     }
+@@ -396,7 +397,7 @@ export async function execute(ctx) {
+         signal: result.signal,
+         timedOut: result.timedOut,
+         provider: resolvedProvider,
+-        model,
++        model: modelLabel,
+     };
+     if (parsed.errorMessage) {
+         executionResult.errorMessage = parsed.errorMessage;
+diff --git a/dist/server/test.js b/dist/server/test.js
+index d440427d7df7703dfd469675a2cadfca413e2df1..09929514ff65a55ab5588314092f8a185a02e2b6 100644
+--- a/dist/server/test.js
++++ b/dist/server/test.js
+@@ -12,6 +12,18 @@ const execFileAsync = promisify(execFile);
+ function asString(v) {
+     return typeof v === "string" ? v : undefined;
+ }
++function parsePythonVersion(value) {
++    const match = value.match(/\bPython(?::\s*|\s+)(\d+)\.(\d+)/i);
++    if (!match)
++        return null;
++    return {
++        major: parseInt(match[1], 10),
++        minor: parseInt(match[2], 10),
++    };
++}
++function pythonTooOld(version) {
++    return version.major < 3 || (version.major === 3 && version.minor < 10);
++}
+ // ---------------------------------------------------------------------------
+ // Checks
+ // ---------------------------------------------------------------------------
+@@ -64,17 +76,27 @@ async function checkCliVersion(command) {
+         };
+     }
+ }
+-async function checkPython() {
++async function checkPython(hermesVersionMessage) {
++    const hermesPython = hermesVersionMessage ? parsePythonVersion(hermesVersionMessage) : null;
++    if (hermesPython) {
++        if (pythonTooOld(hermesPython)) {
++            return {
++                level: "error",
++                message: `Hermes reports Python ${hermesPython.major}.${hermesPython.minor} — Hermes requires Python 3.10+`,
++                hint: "Upgrade the Python used by the hermes CLI to 3.10 or later",
++                code: "hermes_python_old",
++            };
++        }
++        return null;
++    }
+     try {
+         const { stdout } = await execFileAsync("python3", ["--version"], {
+             timeout: 5_000,
+         });
+         const version = stdout.trim();
+-        const match = version.match(/(\d+)\.(\d+)/);
+-        if (match) {
+-            const major = parseInt(match[1], 10);
+-            const minor = parseInt(match[2], 10);
+-            if (major < 3 || (major === 3 && minor < 10)) {
++        const parsed = parsePythonVersion(version);
++        if (parsed) {
++            if (pythonTooOld(parsed)) {
+                 return {
+                     level: "error",
+                     message: `Python ${version} found — Hermes requires Python 3.10+`,
+@@ -130,8 +152,8 @@ function checkApiKeys(config) {
+     if (!hasAnthropic && !hasOpenRouter && !hasOpenAI && !hasZai && !hasKimi && !hasMiniMax) {
+         return {
+             level: "warn",
+-            message: "No LLM API keys found in environment",
+-            hint: "Set API keys in the agent's env secrets or ~/.hermes/.env. Hermes supports: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ZAI_API_KEY, KIMI_API_KEY, MINIMAX_API_KEY",
++            message: "No LLM API keys found in AgentDash environment",
++            hint: "Hermes may still use credentials from ~/.hermes/.env or its local provider config. Add AgentDash env secrets only if you want AgentDash to supply them.",
+             code: "hermes_no_api_keys",
+         };
+     }
+@@ -231,7 +253,7 @@ export async function testEnvironment(ctx) {
+     if (versionCheck)
+         checks.push(versionCheck);
+     // 3. Python available?
+-    const pythonCheck = await checkPython();
++    const pythonCheck = await checkPython(versionCheck?.message);
+     if (pythonCheck)
+         checks.push(pythonCheck);
+     // 4. Model config
 diff --git a/dist/shared/constants.js b/dist/shared/constants.js
+index c8be1d158bee16f0f383d8300ae806f2d5d00e53..4f4deaecc670044e852fe4f60bef84ad348b7c3d 100644
 --- a/dist/shared/constants.js
 +++ b/dist/shared/constants.js
-@@ -12,7 +12,7 @@
+@@ -12,7 +12,7 @@ export const DEFAULT_TIMEOUT_SEC = 1800;
  /** Grace period after SIGTERM before SIGKILL (seconds). */
  export const DEFAULT_GRACE_SEC = 10;
  /** Default model to use if none specified. */
@@ -10,7 +129,7 @@ diff --git a/dist/shared/constants.js b/dist/shared/constants.js
  /**
   * Valid --provider choices for the hermes CLI.
   * Must stay in sync with `hermes chat --help`.
-@@ -59,6 +59,7 @@
+@@ -59,6 +59,7 @@ export const MODEL_PREFIX_PROVIDER_HINTS = [
      ["moonshot", "kimi-coding"],
      ["kimi", "kimi-coding"],
      // MiniMax

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ patchedDependencies:
     hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
   hermes-paperclip-adapter@0.3.0:
-    hash: maasrsq2uwlwrv24ir7p7pknpe
+    hash: ehfahkpirmgj5ms4pmtcaxntai
     path: patches/hermes-paperclip-adapter+0.3.0.patch
 
 importers:
@@ -596,7 +596,7 @@ importers:
         version: 7.5.1(express@5.2.1)
       hermes-paperclip-adapter:
         specifier: ^0.3.0
-        version: 0.3.0(patch_hash=maasrsq2uwlwrv24ir7p7pknpe)
+        version: 0.3.0(patch_hash=ehfahkpirmgj5ms4pmtcaxntai)
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0(@noble/hashes@2.0.1)
@@ -741,7 +741,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       hermes-paperclip-adapter:
         specifier: ^0.3.0
-        version: 0.3.0(patch_hash=maasrsq2uwlwrv24ir7p7pknpe)
+        version: 0.3.0(patch_hash=ehfahkpirmgj5ms4pmtcaxntai)
       lexical:
         specifier: 0.35.0
         version: 0.35.0
@@ -11905,7 +11905,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hermes-paperclip-adapter@0.3.0(patch_hash=maasrsq2uwlwrv24ir7p7pknpe):
+  hermes-paperclip-adapter@0.3.0(patch_hash=ehfahkpirmgj5ms4pmtcaxntai):
     dependencies:
       '@paperclipai/adapter-utils': 2026.325.0
       picocolors: 1.1.1

--- a/server/src/__tests__/hermes-local-adapter-patch.test.ts
+++ b/server/src/__tests__/hermes-local-adapter-patch.test.ts
@@ -1,0 +1,97 @@
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("patched hermes-paperclip-adapter behavior", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("does not fail the environment check when Hermes itself reports Python 3.10+", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "agentdash-hermes-env-"));
+    const hermesCommand = join(tempDir, "hermes");
+    const fakePython = join(tempDir, "python3");
+    await writeFile(
+      hermesCommand,
+      [
+        "#!/usr/bin/env node",
+        'if (process.argv[2] === "--version") {',
+        '  process.stdout.write("Hermes Agent v0.14.0 (2026.5.16) Project: /Users/example/.hermes/hermes-agent Python: 3.11.15 OpenAI SDK: 2.24.0\\n");',
+        "  process.exit(0);",
+        "}",
+        "process.exit(1);",
+      ].join("\n"),
+    );
+    await writeFile(fakePython, '#!/usr/bin/env node\nprocess.stdout.write("Python 3.9.6\\n");\n');
+    await chmod(hermesCommand, 0o755);
+    await chmod(fakePython, 0o755);
+
+    const { testEnvironment } = await import("hermes-paperclip-adapter/server");
+
+    const originalPath = process.env.PATH ?? "";
+    process.env.PATH = `${tempDir}:${originalPath}`;
+    let result;
+    try {
+      result = await testEnvironment({ config: { hermesCommand } });
+    } finally {
+      process.env.PATH = originalPath;
+    }
+
+    expect(result.status).not.toBe("fail");
+    expect(result.checks).not.toContainEqual(expect.objectContaining({ code: "hermes_python_old" }));
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "hermes_no_api_keys",
+        level: "warn",
+        message: "No LLM API keys found in AgentDash environment",
+      }),
+    );
+  });
+
+  it("lets Hermes use its configured default model when no adapter model is set", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "agentdash-hermes-adapter-"));
+    const argsPath = join(tempDir, "args.json");
+    const hermesCommand = join(tempDir, "hermes");
+    await writeFile(
+      hermesCommand,
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        'fs.writeFileSync(process.env.HERMES_ARGS_PATH, JSON.stringify(process.argv.slice(2)));',
+        'process.stdout.write("done\\n\\nsession_id: hermes-session-1\\n");',
+      ].join("\n"),
+    );
+    await chmod(hermesCommand, 0o755);
+
+    const { execute } = await import("hermes-paperclip-adapter/server");
+
+    await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          cwd: tempDir,
+          env: {
+            HERMES_ARGS_PATH: argsPath,
+          },
+          hermesCommand,
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+    });
+
+    const args = JSON.parse(await readFile(argsPath, "utf8")) as string[];
+    expect(args).not.toContain("-m");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - AgentDash uses local adapters, including `hermes_local`, to run a user's already-configured local CLI agent.
> - A target machine reported Hermes itself running on Python 3.11.15 while AgentDash failed the adapter check because `python3` on PATH was 3.9.6.
> - The same report showed the missing-key warning was easy to read as an AgentDash requirement, even though Hermes may load credentials from its own local config.
> - The Hermes adapter patch also forced `-m <default model>` when no model was configured, which bypassed the user's Hermes default model.
> - This pull request keeps `hermes_local` aligned with local-Hermes ownership: AgentDash only overrides model/env when explicitly configured.
> - The benefit is that target machines can use their existing Hermes setup without false Python failures or accidental provider/key requirements from AgentDash defaults.

## What Changed

- Updated the `hermes-paperclip-adapter` patch so execution no longer passes `-m` when no adapter model is configured.
- Updated the Hermes environment check to trust the Python runtime reported by `hermes --version` before falling back to `python3` on PATH.
- Reworded the missing-key warning to say no keys were found in the AgentDash environment, while Hermes may still use `~/.hermes/.env` or local provider config.
- Added regression coverage for the reported Python 3.11 Hermes / Python 3.9 PATH case and the no-model default execution path.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/hermes-local-adapter-patch.test.ts server/src/__tests__/adapter-registry.test.ts`
- `pnpm -r typecheck`
- `pnpm exec vitest run`
- `pnpm build`
- Re-ran after rebasing on `origin/main`: `pnpm exec vitest run server/src/__tests__/hermes-local-adapter-patch.test.ts`

## Risks

- Low to moderate risk because this changes patched third-party adapter runtime behavior.
- The intended behavior shift is narrow: no explicit `model` means Hermes uses its own configured default rather than AgentDash forcing a packaged default.
- Existing agents with an explicit `adapterConfig.model` still pass that model through.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.5, high-reasoning coding agent with terminal, test, build, git, and GitHub CLI tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
