### PR TITLE
Honor repo-local env in dev test checkouts

### DIFF
--- a/server/src/__tests__/dev-runner-worktree.test.ts
+++ b/server/src/__tests__/dev-runner-worktree.test.ts
@@ -63,6 +63,31 @@ describe("dev-runner worktree env bootstrap", () => {
     expect(env.PAPERCLIP_OPTIONAL).toBe("");
   });
 
+  it("loads repo-local Paperclip env for normal git checkouts when present", () => {
+    const root = createTempRoot("paperclip-dev-runner-normal-checkout-env-");
+    fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".paperclip"), { recursive: true });
+    fs.writeFileSync(
+      resolveWorktreeEnvFilePath(root),
+      [
+        "PAPERCLIP_HOME=/tmp/paperclip-target-tests",
+        "PAPERCLIP_INSTANCE_ID=agentdash-dev",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const env: NodeJS.ProcessEnv = {};
+    const result = bootstrapDevRunnerWorktreeEnv(root, env);
+
+    expect(result).toEqual({
+      envPath: resolveWorktreeEnvFilePath(root),
+      missingEnv: false,
+    });
+    expect(env.PAPERCLIP_HOME).toBe("/tmp/paperclip-target-tests");
+    expect(env.PAPERCLIP_INSTANCE_ID).toBe("agentdash-dev");
+  });
+
   it("reports uninitialized linked worktrees so dev runner can fail fast", () => {
     const root = createTempRoot("paperclip-dev-runner-worktree-missing-");
     fs.writeFileSync(path.join(root, ".git"), "gitdir: /tmp/paperclip/.git/worktrees/feature\n", "utf8");

--- a/server/src/dev-runner-worktree.ts
+++ b/server/src/dev-runner-worktree.ts
@@ -59,15 +59,16 @@ export function bootstrapDevRunnerWorktreeEnv(
   rootDir: string,
   env: NodeJS.ProcessEnv = process.env,
 ): WorktreeEnvBootstrapResult {
-  if (!isLinkedGitWorktreeCheckout(rootDir)) {
-    return {
-      envPath: null,
-      missingEnv: false,
-    };
-  }
-
+  const isLinkedWorktree = isLinkedGitWorktreeCheckout(rootDir);
   const envPath = resolveWorktreeEnvFilePath(rootDir);
   if (!existsSync(envPath)) {
+    if (!isLinkedWorktree) {
+      return {
+        envPath: null,
+        missingEnv: false,
+      };
+    }
+
     return {
       envPath,
       missingEnv: true,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that runs and supervises local agent companies.
> - AgentDash target-machine testing needs a safe dev checkout that can run beside a production instance on the same host.
> - The dev runner already supports repo-local Paperclip env files for linked worktrees, but normal cloned checkouts skipped `.paperclip/.env` entirely.
> - Hermes reproduced this on the Mac mini: `agentdash_dev` fell back to the default embedded Postgres instance and hit a migration conflict while production was running.
> - This pull request narrows the bootstrap rule so normal checkouts load `.paperclip/.env` when it exists, while linked worktrees still fail fast when their required env file is missing.
> - The benefit is a safer target-test loop: a cloned `agentdash_dev` checkout can use an isolated `PAPERCLIP_INSTANCE_ID` before migration preflight starts.

## What Changed

- Load repo-local `.paperclip/.env` from `bootstrapDevRunnerWorktreeEnv()` whenever the file exists, even when `.git` is a normal directory.
- Preserve the existing strict failure for linked git worktrees that are missing `.paperclip/.env`.
- Add a regression test proving normal git checkouts load `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID` from `.paperclip/.env`.

Closes #358.

## Verification

- `pnpm exec vitest run server/src/__tests__/dev-runner-worktree.test.ts`
- `pnpm -r typecheck`
- `pnpm build`

## Risks

Low risk. This only broadens env-file loading when a repo-local `.paperclip/.env` file is already present. Explicit process env values still win, and linked-worktree missing-env behavior stays strict.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5.5, tool-using coding agent in the Codex desktop app.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not a UI change)
- [x] I have updated relevant documentation to reflect my changes (no docs needed; behavior is covered by regression test)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
