### PR TITLE
Accept adapter aliases for agent setup payloads

### DIFF
--- a/doc/GOAL.md
+++ b/doc/GOAL.md
@@ -1,5 +1,64 @@
 # Paperclip
 
+## Active Goal — Hermes-Supervised Target Testing (2026-05-19)
+
+Current launch goal: use the target Mac mini Hermes agent as the independent tester for AgentDash, while Codex supervises from this repo, fixes filed issues, and sends Hermes back through the same tests until the launch scenario succeeds.
+
+Source repo: https://github.com/thetangstr/agentdash
+
+### Current Status
+
+- 2026-05-19: Hermes completed the first target-machine pass against `agentdash_dev` at commit `74cc0f74e7668def6a373e687627e5668b73e4fb`.
+- Launch blocker fixed and closed: https://github.com/thetangstr/agentdash/issues/358 via https://github.com/thetangstr/agentdash/pull/359 at `62afdb534e89dd53f00fb80769b873b22f027f1d`.
+- Retest result: Hermes retest `agentdash-retest-359b` passed the #358 isolation check on `62afdb534e89dd53f00fb80769b873b22f027f1d`; `pnpm dev` started on `3101` from repo-local `.paperclip/.env`, `/api/health` was healthy, and `/instance/settings/about` plus `/instance/settings/changelog` returned 200.
+- Current blocker: https://github.com/thetangstr/agentdash/issues/360 — agent-directed setup can send `type` / `config`, which currently defaults to a `process` agent and breaks `hermes_local` runs.
+- Remaining target-machine finding: https://github.com/thetangstr/agentdash/issues/345 — `pnpm test:run` still reports a `workspace-runtime.test.ts` timeout on the Mac mini.
+
+### Operating Loop
+
+1. Hermes runs on the target machine against the test environment, not production data.
+   - Target host: `192.168.86.48`
+   - Hermes profile: `agentdash`
+   - Target checkout: `/Users/maxiaoer/workspace/agentdash_dev`
+   - Pull the latest `origin/main` before each test pass.
+
+2. Hermes owns black-box validation.
+   - Install or upgrade AgentDash from GitHub.
+   - Confirm the running app exposes its version/about/changelog information.
+   - Exercise the first-time onboarding path for a new company with two C-level humans, CEO and COO, and one shared Chief of Staff agent.
+   - Confirm the CoS can create company goals and support more than one human user.
+   - Exercise adapter setup and environment tests for the configured local adapters, especially `hermes_local`; also test `codex_local` when Codex OAuth is available and `claude_local` when Claude local auth is available.
+   - Run the available automated checks that fit the target environment: `pnpm test:run`, `pnpm -r typecheck`, `pnpm build`, and browser/UAT checks when the app is running.
+
+3. Hermes files GitHub issues for every reproducible failure.
+   - File issues on https://github.com/thetangstr/agentdash/issues.
+   - Include: tested commit SHA, AgentDash version, target machine/environment, exact steps, expected result, actual result, logs/screenshots, and whether production data was touched.
+   - Use labels when available: `target-machine-test`, `hermes-found`, and `launch-blocker` for anything that blocks the target onboarding scenario.
+
+4. Codex monitors, fixes, and asks Hermes to retest.
+   - Monitor open `target-machine-test` issues.
+   - Fix one launch-blocking issue at a time in small, reviewable diffs.
+   - Verify locally before pushing.
+   - Ask Hermes to pull the fix and rerun the relevant test plus any impacted regression checks.
+   - Keep looping until Hermes can complete the target onboarding scenario without launch-blocking failures.
+
+### Done Criteria
+
+- Hermes completes a clean install or upgrade of latest AgentDash in `agentdash_dev`.
+- The target app shows version/about/changelog information from the UI.
+- The two-executive onboarding scenario succeeds end to end: company created, CEO and COO onboarded, one shared CoS available, company goals created, and agent setup verified.
+- `hermes_local` passes its environment test and can execute at least one successful agent run.
+- Any available `codex_local` OAuth and `claude_local` auth paths are either verified or documented as unavailable with exact remediation.
+- Automated checks pass on the target machine, or every failure is filed as a GitHub issue with enough evidence for Codex to fix it.
+- No open `launch-blocker` / `target-machine-test` GitHub issues remain untriaged.
+
+### Safety Rules
+
+- Do not mutate production company data during testing unless the user explicitly requests it.
+- Use `agentdash_dev` or another clearly named test workspace for destructive or setup tests.
+- Prefer archived throwaway companies over deleting rows from test databases when run/cost records exist.
+- Never paste secrets into GitHub issues, commits, logs, or prompts.
+
 **Paperclip is the backbone of the autonomous economy.** We are building the infrastructure that autonomous AI companies run on. Our goal is for Paperclip-powered companies to collectively generate economic output that rivals the GDP of the world's largest countries. Every decision we make should serve that: make autonomous companies more capable, more governable, more scalable, and more real.
 
 ## The Vision

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -44,6 +44,22 @@ const adapterConfigSchema = z.record(z.unknown()).superRefine((value, ctx) => {
   }
 });
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeAgentAdapterAliases(value: unknown) {
+  if (!isPlainRecord(value)) return value;
+  const normalized = { ...value };
+  if (normalized.adapterType === undefined && typeof normalized.type === "string") {
+    normalized.adapterType = normalized.type;
+  }
+  if (normalized.adapterConfig === undefined && isPlainRecord(normalized.config)) {
+    normalized.adapterConfig = normalized.config;
+  }
+  return normalized;
+}
+
 export const createAgentInstructionsBundleSchema = z.object({
   entryFile: z.string().trim().min(1).optional(),
   files: z.record(z.string()).refine((files) => Object.keys(files).length > 0, {
@@ -63,7 +79,7 @@ export const agentRuntimeConfigSchema = z.object({
   }).strict().optional(),
 }).catchall(z.unknown());
 
-export const createAgentSchema = z.object({
+const createAgentBaseSchema = z.object({
   name: z.string().min(1),
   role: z.enum(AGENT_ROLES).optional().default("general"),
   title: z.string().optional().nullable(),
@@ -81,16 +97,18 @@ export const createAgentSchema = z.object({
   metadata: z.record(z.unknown()).optional().nullable(),
 });
 
+export const createAgentSchema = z.preprocess(normalizeAgentAdapterAliases, createAgentBaseSchema);
+
 export type CreateAgent = z.infer<typeof createAgentSchema>;
 
-export const createAgentHireSchema = createAgentSchema.extend({
+export const createAgentHireSchema = z.preprocess(normalizeAgentAdapterAliases, createAgentBaseSchema.extend({
   sourceIssueId: z.string().uuid().optional().nullable(),
   sourceIssueIds: z.array(z.string().uuid()).optional(),
-});
+}));
 
 export type CreateAgentHire = z.infer<typeof createAgentHireSchema>;
 
-export const updateAgentSchema = createAgentSchema
+export const updateAgentSchema = z.preprocess(normalizeAgentAdapterAliases, createAgentBaseSchema
   .omit({ permissions: true })
   .partial()
   .extend({
@@ -98,7 +116,7 @@ export const updateAgentSchema = createAgentSchema
     replaceAdapterConfig: z.boolean().optional(),
     status: z.enum(AGENT_STATUSES).optional(),
     spentMonthlyCents: z.number().int().nonnegative().optional(),
-  });
+  }));
 
 export type UpdateAgent = z.infer<typeof updateAgentSchema>;
 

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -259,6 +259,27 @@ describe("agent routes adapter validation", () => {
     expect(res.body.adapterType).toBe("external_test");
   });
 
+  it("accepts type/config aliases when agents create local adapter workers", async () => {
+    const app = await createApp();
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents")
+        .send({
+          name: "Hermes Agent",
+          type: "hermes_local",
+          config: {
+            hermesCommand: "/Users/example/.local/bin/hermes",
+          },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.adapterType).toBe("hermes_local");
+    expect(res.body.adapterConfig).toEqual({
+      hermesCommand: "/Users/example/.local/bin/hermes",
+    });
+  });
+
   it("rejects unknown adapter types even when schema accepts arbitrary strings", async () => {
     const app = await createApp();
     const res = await requestApp(app, (baseUrl) =>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - AgentDash target-machine UAT is exercising first-time setup through Hermes instead of a local developer-only path.
> - That setup path sent agent adapter data as `type` and `config`, while the server contract stores `adapterType` and `adapterConfig`.
> - The API accepted the payload but silently defaulted to a `process` adapter, which made the created worker fail with `Process adapter missing command`.
> - This pull request normalizes those setup aliases at the shared validator boundary while keeping canonical fields authoritative.
> - The benefit is that agent-driven setup can create `hermes_local` workers without accidentally creating broken process workers.

Closes #360.

## What Changed

- Added shared create/update/hire agent payload normalization for `type` -> `adapterType` and `config` -> `adapterConfig` when canonical fields are absent.
- Added a route-level regression test for creating a Hermes local adapter worker with the alias payload shape observed on the target machine.
- Updated `doc/GOAL.md` with the active Hermes-supervised target-machine testing loop and current GitHub issue status.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-adapter-validation-routes.test.ts packages/shared/src/adapter-types.test.ts server/src/__tests__/hermes-local-adapter-patch.test.ts`
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`
- `git diff --check`

## Risks

- Low risk. Canonical `adapterType` and `adapterConfig` still win when both canonical and alias fields are present.
- The API now accepts one additional setup payload shape, but unknown adapter types still go through existing route validation.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Codex Desktop, with tool use for repository inspection, tests, git, and GitHub CLI operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
