### PR TITLE
Update target goal and authenticated UAT flow

### DIFF
--- a/doc/GOAL.md
+++ b/doc/GOAL.md
@@ -13,21 +13,20 @@ Source repo: https://github.com/thetangstr/agentdash
 - Retest result: Hermes retest `agentdash-retest-359b` passed the #358 isolation check on `62afdb534e89dd53f00fb80769b873b22f027f1d`; `pnpm dev` started on `3101` from repo-local `.paperclip/.env`, `/api/health` was healthy, and `/instance/settings/about` plus `/instance/settings/changelog` returned 200.
 - Launch blocker fixed and closed: https://github.com/thetangstr/agentdash/issues/360 via https://github.com/thetangstr/agentdash/pull/361 at `d23a546ee70074a9f1ef3de1ef8cf73974633549`.
 - Retest result: target smoke on the Mac mini passed the #360 alias path on `d23a546ee70074a9f1ef3de1ef8cf73974633549`; `POST /api/companies/:companyId/agents` with `type: "hermes_local"` and `config: {}` returned `adapterType: "hermes_local"` / `adapterConfig: {}`, and wakeup run `d36c404c-edc6-4d44-b359-d34d057f2069` succeeded with `exitCode: 0`.
-- Current blocker candidate: https://github.com/thetangstr/agentdash/issues/345 — `pnpm test:run` still reports a `workspace-runtime.test.ts` timeout on the Mac mini.
+- Retired target finding: https://github.com/thetangstr/agentdash/issues/345 — focused `workspace-runtime.test.ts` and full `pnpm test:run` both passed on the Mac mini at `d23a546ee70074a9f1ef3de1ef8cf73974633549`; issue closed as stale/transient.
 
 ### Next Work
 
-1. Reproduce or retire https://github.com/thetangstr/agentdash/issues/345 on latest `origin/main`.
-   - Compare the Mac mini timeout against local CI, where `workspace-runtime.test.ts` has passed.
-   - If it still fails only on the target machine, capture exact test name, timeout duration, machine load, and whether the workspace seed path is slower than the current test budget.
-   - Fix with the smallest focused test/runtime change, then rerun `pnpm test:run` on the target.
-
-2. Resume the full first-time onboarding UAT after #345 is triaged.
+1. Resume the full first-time onboarding UAT on latest `origin/main`.
    - New throwaway company.
    - Two C-level humans: CEO and COO.
    - One shared Chief of Staff agent that supports both humans.
    - Company goals created through the setup flow.
    - Adapter paths verified: `hermes_local` required; `codex_local` when Codex OAuth is available; `claude_local` when Claude local auth is available.
+
+2. Triage or retire remaining open target-machine issues that are no longer launch blockers.
+   - https://github.com/thetangstr/agentdash/issues/354 appears likely fixed by the heartbeat session-id guard, but still needs a GitHub status review against latest `origin/main`.
+   - https://github.com/thetangstr/agentdash/issues/350 remains post-launch/platform work unless a current launch criterion depends on it.
 
 ### Operating Loop
 

--- a/doc/GOAL.md
+++ b/doc/GOAL.md
@@ -11,8 +11,23 @@ Source repo: https://github.com/thetangstr/agentdash
 - 2026-05-19: Hermes completed the first target-machine pass against `agentdash_dev` at commit `74cc0f74e7668def6a373e687627e5668b73e4fb`.
 - Launch blocker fixed and closed: https://github.com/thetangstr/agentdash/issues/358 via https://github.com/thetangstr/agentdash/pull/359 at `62afdb534e89dd53f00fb80769b873b22f027f1d`.
 - Retest result: Hermes retest `agentdash-retest-359b` passed the #358 isolation check on `62afdb534e89dd53f00fb80769b873b22f027f1d`; `pnpm dev` started on `3101` from repo-local `.paperclip/.env`, `/api/health` was healthy, and `/instance/settings/about` plus `/instance/settings/changelog` returned 200.
-- Current blocker: https://github.com/thetangstr/agentdash/issues/360 — agent-directed setup can send `type` / `config`, which currently defaults to a `process` agent and breaks `hermes_local` runs.
-- Remaining target-machine finding: https://github.com/thetangstr/agentdash/issues/345 — `pnpm test:run` still reports a `workspace-runtime.test.ts` timeout on the Mac mini.
+- Launch blocker fixed and closed: https://github.com/thetangstr/agentdash/issues/360 via https://github.com/thetangstr/agentdash/pull/361 at `d23a546ee70074a9f1ef3de1ef8cf73974633549`.
+- Retest result: target smoke on the Mac mini passed the #360 alias path on `d23a546ee70074a9f1ef3de1ef8cf73974633549`; `POST /api/companies/:companyId/agents` with `type: "hermes_local"` and `config: {}` returned `adapterType: "hermes_local"` / `adapterConfig: {}`, and wakeup run `d36c404c-edc6-4d44-b359-d34d057f2069` succeeded with `exitCode: 0`.
+- Current blocker candidate: https://github.com/thetangstr/agentdash/issues/345 — `pnpm test:run` still reports a `workspace-runtime.test.ts` timeout on the Mac mini.
+
+### Next Work
+
+1. Reproduce or retire https://github.com/thetangstr/agentdash/issues/345 on latest `origin/main`.
+   - Compare the Mac mini timeout against local CI, where `workspace-runtime.test.ts` has passed.
+   - If it still fails only on the target machine, capture exact test name, timeout duration, machine load, and whether the workspace seed path is slower than the current test budget.
+   - Fix with the smallest focused test/runtime change, then rerun `pnpm test:run` on the target.
+
+2. Resume the full first-time onboarding UAT after #345 is triaged.
+   - New throwaway company.
+   - Two C-level humans: CEO and COO.
+   - One shared Chief of Staff agent that supports both humans.
+   - Company goals created through the setup flow.
+   - Adapter paths verified: `hermes_local` required; `codex_local` when Codex OAuth is available; `claude_local` when Claude local auth is available.
 
 ### Operating Loop
 

--- a/tests/e2e/multi-user-authenticated.spec.ts
+++ b/tests/e2e/multi-user-authenticated.spec.ts
@@ -9,6 +9,9 @@ const CONFIG_PATH = process.env.PAPERCLIP_E2E_CONFIG_PATH ?? path.resolve(proces
 const BOOTSTRAP_SCRIPT_PATH = path.resolve(process.cwd(), "packages/db/scripts/create-auth-bootstrap-invite.ts");
 const OWNER_PASSWORD = "paperclip-owner-password";
 const INVITED_PASSWORD = "paperclip-invited-password";
+const AUTH_SIGN_IN_HEADING = "Welcome back";
+const AUTH_SIGN_UP_HEADING = "Create your workspace";
+const BOOTSTRAP_INVITE_HEADING = "Set up Paperclip";
 
 type HumanUser = {
   name: string;
@@ -90,9 +93,9 @@ function createBootstrapInvite() {
 
 async function signUp(page: Page, user: HumanUser) {
   await page.goto(`${BASE}/auth`);
-  await expect(page.getByRole("heading", { name: "Sign in to Paperclip" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: AUTH_SIGN_IN_HEADING })).toBeVisible();
   await page.getByRole("button", { name: "Create one" }).click();
-  await expect(page.getByRole("heading", { name: "Create your Paperclip account" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: AUTH_SIGN_UP_HEADING })).toBeVisible();
   await page.getByLabel("Name").fill(user.name);
   await page.getByLabel("Email").fill(user.email);
   await page.getByLabel("Password").fill(user.password);
@@ -101,13 +104,21 @@ async function signUp(page: Page, user: HumanUser) {
 }
 
 async function acceptBootstrapInvite(page: Page, inviteUrl: string) {
+  const token = inviteUrl.split("/invite/")[1];
+  expect(token).toBeTruthy();
   await page.goto(inviteUrl);
-  await expect(page.getByRole("heading", { name: "Bootstrap your Paperclip instance" })).toBeVisible();
-  await page.getByRole("button", { name: "Accept bootstrap invite" }).click();
-  await expect(page.getByRole("heading", { name: "Bootstrap complete" })).toBeVisible({
-    timeout: 20_000,
+  await expect(page.getByRole("heading", { name: BOOTSTRAP_INVITE_HEADING })).toBeVisible();
+  const acceptResponsePromise = page.waitForResponse((response) =>
+    response.request().method() === "POST" &&
+    response.url().includes(`/invites/${token}/accept`)
+  );
+  await page.getByRole("button", { name: "Accept invite" }).click();
+  const acceptResponse = await acceptResponsePromise;
+  expect(acceptResponse.status()).toBe(202);
+  await expect(acceptResponse.json()).resolves.toMatchObject({
+    bootstrapAccepted: true,
   });
-  await page.getByRole("link", { name: "Open board" }).click();
+  await page.goto(`${BASE}/`);
 }
 
 async function createCompanyForSession(page: Page, nextCompanyName: string) {
@@ -121,38 +132,60 @@ async function createCompanyForSession(page: Page, nextCompanyName: string) {
 }
 
 async function createAuthenticatedInvite(page: Page, companyPrefix: string) {
-  await page.goto(`${BASE}/${companyPrefix}/company/settings`);
-  await expect(page.getByTestId("company-settings-invites-section")).toBeVisible({
+  await page.goto(`${BASE}/${companyPrefix}/company/settings/invites`);
+  await expect(page.getByRole("heading", { name: "Company Invites" })).toBeVisible({
     timeout: 20_000,
   });
-  await page.getByTestId("company-settings-human-invite-role").selectOption("operator");
-  await page.getByTestId("company-settings-create-human-invite").click();
-  const inviteField = page.getByTestId("company-settings-human-invite-url");
-  await expect(inviteField).toBeVisible({ timeout: 20_000 });
-  return (await inviteField.inputValue()).trim();
+  await page.getByRole("radio", { name: /Operator/ }).check();
+  await page.getByRole("button", { name: "Create invite" }).click();
+  await expect(page.getByText("Latest invite link")).toBeVisible({ timeout: 20_000 });
+  const inviteUrlButton = page.getByRole("button", { name: /\/invite\// }).first();
+  await expect(inviteUrlButton).toBeVisible({ timeout: 20_000 });
+  const inviteUrl = (await inviteUrlButton.textContent())?.trim() ?? "";
+  expect(inviteUrl).toContain("/invite/");
+  return inviteUrl;
 }
 
 async function signUpFromInvite(page: Page, inviteUrl: string, user: HumanUser) {
   await page.goto(inviteUrl);
-  await expect(page.getByText("Sign in or create an account before submitting a human join request.")).toBeVisible();
-  await page.getByRole("link", { name: "Sign in / Create account" }).click();
-  await expect(page).toHaveURL(/\/auth\?next=/);
-  await expect(page.getByRole("heading", { name: "Sign in to Paperclip" })).toBeVisible();
-  await page.getByRole("button", { name: "Create one" }).click();
+  await expect(page.getByTestId("invite-inline-auth")).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole("heading", { name: "Create your account" })).toBeVisible();
   await page.getByLabel("Name").fill(user.name);
   await page.getByLabel("Email").fill(user.email);
   await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Create Account" }).click();
-  await expect(page).toHaveURL(new RegExp(`/invite/[^/]+$`), { timeout: 20_000 });
-}
-
-async function acceptHumanInvite(page: Page) {
-  await expect(page.getByRole("button", { name: "Join company" })).toBeEnabled();
-  await page.getByRole("button", { name: "Join company" }).click();
-  await expect(page.getByRole("heading", { name: "You joined the company" })).toBeVisible({
+  await page.getByRole("button", { name: "Create account and continue" }).click();
+  await expect(page.getByTestId("invite-pending-approval")).toBeVisible({
     timeout: 20_000,
   });
-  await page.getByRole("link", { name: "Open board" }).click();
+}
+
+async function approvePendingHumanJoin(page: Page, companyPrefix: string, email: string) {
+  await page.goto(`${BASE}/${companyPrefix}/company/settings/access`);
+  await expect(page.getByRole("heading", { name: "Company Access" })).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByText(email)).toBeVisible({ timeout: 20_000 });
+  await page.getByRole("button", { name: "Approve human" }).click();
+  await expect(page.getByRole("button", { name: "Approve human" })).toHaveCount(0, {
+    timeout: 20_000,
+  });
+}
+
+async function updateMemberRole(page: Page, companyPrefix: string, email: string, role: CompanyMember["membershipRole"]) {
+  await page.goto(`${BASE}/${companyPrefix}/company/settings/access`);
+  await expect(page.getByRole("heading", { name: "Company Access" })).toBeVisible({
+    timeout: 20_000,
+  });
+  const memberRow = page
+    .getByText(email)
+    .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " grid ")][1]');
+  await expect(memberRow).toBeVisible({ timeout: 20_000 });
+  await memberRow.getByRole("button", { name: "Edit" }).click();
+  const dialog = page.getByRole("dialog", { name: "Edit member" });
+  await expect(dialog).toBeVisible({ timeout: 20_000 });
+  await dialog.getByLabel("Company role").selectOption(role ?? "");
+  await dialog.getByRole("button", { name: "Save access" }).click();
+  await expect(dialog).toHaveCount(0, { timeout: 20_000 });
 }
 
 async function sessionJsonRequest<T>(
@@ -253,7 +286,16 @@ async function waitForMemberRole(
 }
 
 async function newPage(browser: Browser) {
-  const context = await browser.newContext();
+  const context = await browser.newContext({
+    storageState: {
+      cookies: [],
+      origins: [],
+    },
+  });
+  await context.addInitScript(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
   const page = await context.newPage();
   return { context, page };
 }
@@ -279,32 +321,31 @@ test.describe("Multi-user: authenticated mode", () => {
     const company = await createCompanyForSession(page, companyName);
     const companyPrefix = company.issuePrefix ?? company.id;
     await page.goto(`${BASE}/${companyPrefix}/dashboard`);
-    await expect(page.getByTestId("layout-account-menu-trigger")).toContainText(ownerUser.name);
-    await page.getByTestId("layout-account-menu-trigger").click();
+    const accountMenu = page.getByRole("button", { name: "Open account menu" });
+    await expect(accountMenu).toContainText(ownerUser.name);
+    await accountMenu.click();
     await expect(page.getByText(ownerUser.email)).toBeVisible();
     const inviteUrl = await createAuthenticatedInvite(page, companyPrefix);
 
     const invited = await newPage(browser);
     try {
       await signUpFromInvite(invited.page, inviteUrl, invitedUser);
-      await acceptHumanInvite(invited.page);
+
+      await approvePendingHumanJoin(page, companyPrefix, invitedUser.email);
+      await invited.page.reload();
       await expect(invited.page).not.toHaveURL(/\/auth/, { timeout: 10_000 });
 
       const joinedMember = await waitForMember(page, company.id, invitedUser.email);
 
-      await page.goto(`${BASE}/${companyPrefix}/company/settings`);
-      const roleSelect = page.getByTestId(`company-settings-member-role-${joinedMember.id}`);
-      await expect(roleSelect).toBeVisible({ timeout: 20_000 });
-      await roleSelect.selectOption("viewer");
-      await expect(roleSelect).toHaveValue("viewer");
+      await updateMemberRole(page, companyPrefix, invitedUser.email, "viewer");
       await waitForMemberRole(page, company.id, joinedMember.id, "viewer");
 
-      await invited.page.goto(`${BASE}/${companyPrefix}/company/settings`);
+      await invited.page.goto(`${BASE}/${companyPrefix}/company/settings/invites`);
       await expect(
-        invited.page.getByText("Your current company role cannot create human invites.")
+        invited.page.getByText("You do not have permission to manage company invites.")
       ).toBeVisible({ timeout: 20_000 });
       await expect(
-        invited.page.getByTestId("company-settings-create-human-invite")
+        invited.page.getByRole("button", { name: "Create invite" })
       ).toHaveCount(0);
 
       const forbiddenInviteRes = await sessionJsonRequest(

--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InviteLandingPage } from "./InviteLanding";
+import { queryKeys } from "@/lib/queryKeys";
 
 const getInviteMock = vi.hoisted(() => vi.fn());
 const acceptInviteMock = vi.hoisted(() => vi.fn());
@@ -354,7 +355,90 @@ describe("InviteLandingPage", () => {
     });
     expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
     expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+    expect(queryClient.getQueryData(queryKeys.companies.all)).toBeUndefined();
     expect(localStorage.getItem("paperclip:pending-invite-token")).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("still accepts the invite after account creation when the new user has no company list yet", async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+    getSessionMock.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: {
+        id: "user-1",
+        name: "Jane Example",
+        email: "jane@example.com",
+        image: null,
+      },
+    });
+    listCompaniesMock.mockRejectedValue(Object.assign(new Error("Forbidden"), { status: 403 }));
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "pending_approval",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const inputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    expect(inputValueSetter).toBeTypeOf("function");
+
+    const nameInput = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+    const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement | null;
+    const passwordInput = container.querySelector('input[name="password"]') as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    expect(emailInput).not.toBeNull();
+    expect(passwordInput).not.toBeNull();
+
+    await act(async () => {
+      inputValueSetter!.call(nameInput, "Jane Example");
+      nameInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(emailInput, "jane@example.com");
+      emailInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(passwordInput, "supersecret");
+      passwordInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const authForm = container.querySelector('[data-testid="invite-inline-auth"]') as HTMLFormElement | null;
+    expect(authForm).not.toBeNull();
+
+    await act(async () => {
+      authForm?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(signUpEmailMock).toHaveBeenCalledWith({
+      name: "Jane Example",
+      email: "jane@example.com",
+      password: "supersecret",
+    });
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(container.querySelector('[data-testid="invite-pending-approval"]')).not.toBeNull();
+    expect(container.textContent).toContain("Your request is still awaiting approval.");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -42,6 +42,7 @@ const fieldClassName =
 const panelClassName = "border border-zinc-800 bg-zinc-950/95 p-6";
 const modeButtonBaseClassName =
   "flex-1 border px-3 py-2 text-sm transition-colors";
+const INVITE_COMPANIES_QUERY_KEY = ["invite-landing", "companies"] as const;
 
 function formatHumanRole(role: string | null | undefined) {
   if (!role) return null;
@@ -248,7 +249,7 @@ export function InviteLandingPage() {
   });
 
   const companiesQuery = useQuery({
-    queryKey: queryKeys.companies.all,
+    queryKey: INVITE_COMPANIES_QUERY_KEY,
     queryFn: () => companiesApi.list(),
     enabled: !!sessionQuery.data && !!inviteQuery.data?.companyId,
     retry: false,
@@ -375,11 +376,16 @@ export function InviteLandingPage() {
       setAuthFeedback(null);
       rememberPendingInviteToken(token);
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
-      const companies = await queryClient.fetchQuery({
-        queryKey: queryKeys.companies.all,
-        queryFn: () => companiesApi.list(),
-        retry: false,
-      });
+      let companies: Awaited<ReturnType<typeof companiesApi.list>> = [];
+      try {
+        companies = await queryClient.fetchQuery({
+          queryKey: INVITE_COMPANIES_QUERY_KEY,
+          queryFn: () => companiesApi.list(),
+          retry: false,
+        });
+      } catch {
+        companies = [];
+      }
 
       if (invite?.companyId && companies.some((company) => company.id === invite.companyId)) {
         clearPendingInviteToken(token);


### PR DESCRIPTION
## Thinking Path

> - Paperclip/AgentDash is the control plane for AI-agent companies, and the launch loop depends on independent target-machine validation.
> - The active subsystem is the target-machine UAT loop: a Mac mini Hermes tester runs the latest `agentdash_dev` build while Codex fixes launch blockers.
> - #345 was retired after focused and full target test runs passed on the Mac mini.
> - The next target gate is first-time authenticated onboarding for a two-executive company with one shared Chief of Staff agent.
> - The target authenticated multi-user UAT exposed stale selectors, a stale invite-flow assumption, and a real invite-page cache-shape crash after inline sign-up.
> - This PR keeps the goal doc aligned with the target state and unblocks the authenticated onboarding UAT tracked in #363.

## What Changed

- Updated `doc/GOAL.md` to mark #345 retired with Mac mini evidence and make first-time onboarding UAT the next work item.
- Updated `tests/e2e/multi-user-authenticated.spec.ts` for current AgentDash auth copy, dedicated Company Invites and Company Access pages, pending human join approval, and a clean separate browser context for the invited user.
- Fixed `InviteLanding` so invite-local company checks do not overwrite `CompanyProvider`'s `queryKeys.companies.all` cache with a different data shape.
- Added regression coverage that invite sign-up does not poison the shared companies cache.

Fixes #363.

## Verification

- `git diff --check`
- `pnpm exec vitest run ui/src/pages/InviteLanding.test.tsx`
- `pnpm exec playwright test --config tests/e2e/playwright-multiuser-authenticated.config.ts --list`
- `pnpm -r typecheck`
- `pnpm build`
- Target Mac mini before this PR update: `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts` passed 56/56 on `d23a546e`.
- Target Mac mini before this PR update: `pnpm test:run` passed on `d23a546e`.
- Target Mac mini smoke: `http://localhost:3101` health ok, about/changelog 200, throwaway `MKThink UAT 20260519092455` company created, `hermes_local` CoS created, two goals created/listed, CoS wakeup run `cdaa95c8-dda5-4b75-9621-be2a83e7c8fb` succeeded.
- Target Mac mini authenticated UAT: `PAPERCLIP_E2E_BASE_URL=http://127.0.0.1:3216 ... pnpm test:e2e:multiuser-authenticated` passed 1/1 on `a2d1e59e` after restarting the isolated `3216` test server.
- PR diff size: `gh pr diff 362 --repo thetangstr/agentdash | wc -l` -> 375.

## Risks

Moderate risk, focused on authenticated invite onboarding. The production change is narrow: `InviteLanding` now uses a private query key for its local company lookup so it cannot corrupt `CompanyProvider`'s shared companies cache. The e2e updates intentionally match the current pending-approval flow.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex in Codex desktop, GPT-5.5-class coding agent with shell, GitHub CLI, SSH, and repository editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
