### PR TITLE
Record target main retest status

### DIFF
--- a/doc/GOAL.md
+++ b/doc/GOAL.md
@@ -14,15 +14,22 @@ Source repo: https://github.com/thetangstr/agentdash
 - Launch blocker fixed and closed: https://github.com/thetangstr/agentdash/issues/360 via https://github.com/thetangstr/agentdash/pull/361 at `d23a546ee70074a9f1ef3de1ef8cf73974633549`.
 - Retest result: target smoke on the Mac mini passed the #360 alias path on `d23a546ee70074a9f1ef3de1ef8cf73974633549`; `POST /api/companies/:companyId/agents` with `type: "hermes_local"` and `config: {}` returned `adapterType: "hermes_local"` / `adapterConfig: {}`, and wakeup run `d36c404c-edc6-4d44-b359-d34d057f2069` succeeded with `exitCode: 0`.
 - Retired target finding: https://github.com/thetangstr/agentdash/issues/345 — focused `workspace-runtime.test.ts` and full `pnpm test:run` both passed on the Mac mini at `d23a546ee70074a9f1ef3de1ef8cf73974633549`; issue closed as stale/transient.
+- Launch blocker fixed and closed: https://github.com/thetangstr/agentdash/issues/363 via https://github.com/thetangstr/agentdash/pull/362 at `12874d4f40d143b2b7b232ffb3ac2d53c25ccee7`.
+- Post-merge target result: Codex directly retested latest `origin/main` on the Mac mini in `/Users/maxiaoer/workspace/agentdash_dev`; the isolated authenticated multi-user UAT on port `3216` passed with `pnpm test:e2e:multiuser-authenticated` (`1 passed`, 17.6s). Production `/Users/maxiaoer/agentdash` and port `3100` were not touched.
+- Hermes supervisor status: updated steering has been sent to the attached target-machine Hermes session with latest main `12874d4f40d143b2b7b232ffb3ac2d53c25ccee7`; Hermes still needs to produce its independent full-pass report or file any remaining blocker issues.
+- Safety intervention: the follow-up Hermes transcript showed broad process cleanup commands while preparing dev port `3101`; production `3100` was immediately checked and was healthy, then Hermes was steered to stop broad `pkill` usage and avoid `3100` except read-only health checks.
 
 ### Next Work
 
-1. Resume the full first-time onboarding UAT on latest `origin/main`.
+1. Collect the independent Hermes full-pass report on latest `origin/main`.
+   - Confirm Hermes pulled or checked out `12874d4f40d143b2b7b232ffb3ac2d53c25ccee7` or newer.
+   - Confirm Hermes reports production data touched: `no`.
    - New throwaway company.
    - Two C-level humans: CEO and COO.
    - One shared Chief of Staff agent that supports both humans.
    - Company goals created through the setup flow.
    - Adapter paths verified: `hermes_local` required; `codex_local` when Codex OAuth is available; `claude_local` when Claude local auth is available.
+   - Automated checks recorded from the target: `pnpm test:run`, `pnpm -r typecheck`, `pnpm build`, plus browser/UAT evidence.
 
 2. Triage or retire remaining open target-machine issues that are no longer launch blockers.
    - https://github.com/thetangstr/agentdash/issues/354 appears likely fixed by the heartbeat session-id guard, but still needs a GitHub status review against latest `origin/main`.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and the humans who supervise them through a shared control plane.
> - The active launch work is target-machine validation for AgentDash using a Mac mini Hermes tester plus Codex fixes.
> - PR #362 fixed the authenticated invite/cache blocker and merged into main, closing #363.
> - Codex then retested the merged main build on the target Mac mini and proved the authenticated multi-user UAT path passes.
> - The remaining gap is not the fixed bug; it is capturing the independent Hermes full-pass report on the same latest main build.
> - This pull request updates doc/GOAL.md so the next agent starts from the current evidence instead of the stale pre-merge UAT status.
> - The benefit is a simple, accurate handoff: Hermes now needs to report a clean full pass or file the next blocker issue.

## What Changed

- Recorded that #363 was fixed and closed by #362 at merge commit 12874d4f40d143b2b7b232ffb3ac2d53c25ccee7.
- Added post-merge target Mac mini authenticated UAT evidence: `pnpm test:e2e:multiuser-authenticated` passed on the isolated 3216 test server.
- Reframed next work around collecting Hermes' independent full-pass report and preserving the production-safety constraint.
- Recorded the safety intervention after Hermes attempted broad process cleanup during its follow-up run.

## Verification

- `git diff --check`
- Target Mac mini: `pnpm test:e2e:multiuser-authenticated` passed against latest `origin/main` on isolated port 3216 (`1 passed`, 17.6s).
- Earlier in this loop before the docs-only update: `pnpm test:run` passed locally, and PR #362 CI passed all checks before merge.

## Risks

- Low risk: documentation-only status update.
- The main operational risk is stale target-state interpretation; this PR reduces that by naming exactly what remains for Hermes to prove.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.5`, high-reasoning coding agent with shell, git, GitHub CLI, SSH, and repository editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
