### PR TITLE
Prevent Hermes resume help text from becoming session state

### DIFF
--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -387,6 +387,93 @@ describe("server adapter registry", () => {
     expect(hermesExecuteMock).toHaveBeenCalledWith(ctx);
   });
 
+  it("drops a poisoned Hermes resume session before execution", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+    const onLog = vi.fn(async () => {});
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "from",
+        sessionParams: { sessionId: "from" },
+        sessionDisplayId: "from",
+        taskKey: "issue:354",
+      },
+      config: {},
+      context: {},
+      onLog,
+      onMeta: async () => {},
+      onSpawn: async () => {},
+    });
+
+    expect(hermesExecuteMock).toHaveBeenCalledTimes(1);
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.runtime).toMatchObject({
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: "issue:354",
+    });
+    expect(onLog).toHaveBeenCalledWith(
+      "stdout",
+      "[hermes] Ignoring invalid persisted session id parsed from resume help text.\n",
+    );
+  });
+
+  it("clears Hermes result state when resume help text was parsed as session id", async () => {
+    hermesExecuteMock.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      sessionParams: { sessionId: "from" },
+      sessionDisplayId: "from",
+      resultJson: {
+        result: "",
+        session_id: "from",
+        usage: null,
+        cost_usd: null,
+      },
+    });
+    const adapter = requireServerAdapter("hermes_local");
+
+    const result = await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      clearSession: true,
+      resultJson: {
+        session_id: null,
+      },
+    });
+  });
+
   it("preserves an explicit Hermes Paperclip API key and does not set promptTemplate when none was configured", async () => {
     const adapter = requireServerAdapter("hermes_local");
 

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -1,4 +1,4 @@
-import type { AdapterModelProfileDefinition, ServerAdapterModule } from "./types.js";
+import type { AdapterExecutionResult, AdapterModelProfileDefinition, ServerAdapterModule } from "./types.js";
 import { getAdapterSessionManagement } from "@paperclipai/adapter-utils";
 import {
   execute as acpxExecute,
@@ -163,6 +163,74 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
   return ctx;
 }
 
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isHermesResumeHelpTextSessionId(value: unknown): boolean {
+  return readNonEmptyString(value)?.toLowerCase() === "from";
+}
+
+function sanitizeHermesRuntimeSession<T extends { runtime?: unknown }>(ctx: T): T {
+  const runtime =
+    ctx.runtime && typeof ctx.runtime === "object" && !Array.isArray(ctx.runtime)
+      ? (ctx.runtime as Record<string, unknown>)
+      : null;
+  const sessionParams =
+    runtime?.sessionParams && typeof runtime.sessionParams === "object" && !Array.isArray(runtime.sessionParams)
+      ? (runtime.sessionParams as Record<string, unknown>)
+      : null;
+  const hasInvalidSession =
+    isHermesResumeHelpTextSessionId(runtime?.sessionId) ||
+    isHermesResumeHelpTextSessionId(runtime?.sessionDisplayId) ||
+    isHermesResumeHelpTextSessionId(sessionParams?.sessionId);
+
+  if (!runtime || !hasInvalidSession) return ctx;
+
+  return {
+    ...ctx,
+    runtime: {
+      ...runtime,
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+    },
+  };
+}
+
+function sanitizeHermesExecutionResult(result: AdapterExecutionResult): AdapterExecutionResult {
+  const resultJson =
+    result.resultJson && typeof result.resultJson === "object" && !Array.isArray(result.resultJson)
+      ? result.resultJson
+      : null;
+  const sessionParams =
+    result.sessionParams && typeof result.sessionParams === "object" && !Array.isArray(result.sessionParams)
+      ? result.sessionParams
+      : null;
+  const hasInvalidSession =
+    result.exitCode !== 0 &&
+    (isHermesResumeHelpTextSessionId(result.sessionId) ||
+      isHermesResumeHelpTextSessionId(result.sessionDisplayId) ||
+      isHermesResumeHelpTextSessionId(sessionParams?.sessionId) ||
+      isHermesResumeHelpTextSessionId(resultJson?.session_id));
+
+  if (!hasInvalidSession) return result;
+
+  return {
+    ...result,
+    sessionId: null,
+    sessionParams: null,
+    sessionDisplayId: null,
+    clearSession: true,
+    resultJson: resultJson
+      ? {
+          ...resultJson,
+          session_id: null,
+        }
+      : result.resultJson,
+  };
+}
+
 const claudeLocalAdapter: ServerAdapterModule = {
   type: "claude_local",
   execute: claudeExecute,
@@ -307,8 +375,14 @@ const executeHermesLocal = hermesExecute as unknown as ServerAdapterModule["exec
 const hermesLocalAdapter: ServerAdapterModule = {
   type: "hermes_local",
   execute: async (ctx) => {
-    const normalizedCtx = normalizeHermesConfig(ctx);
-    if (!ctx.authToken) return executeHermesLocal(normalizedCtx);
+    const normalizedCtx = sanitizeHermesRuntimeSession(normalizeHermesConfig(ctx));
+    if (normalizedCtx !== ctx) {
+      await normalizedCtx.onLog(
+        "stdout",
+        "[hermes] Ignoring invalid persisted session id parsed from resume help text.\n",
+      );
+    }
+    if (!normalizedCtx.authToken) return sanitizeHermesExecutionResult(await executeHermesLocal(normalizedCtx));
 
     const existingConfig = (normalizedCtx.agent.adapterConfig ?? {}) as Record<string, unknown>;
     const existingEnv =
@@ -352,7 +426,7 @@ const hermesLocalAdapter: ServerAdapterModule = {
       },
     };
 
-    return executeHermesLocal(patchedCtx);
+    return sanitizeHermesExecutionResult(await executeHermesLocal(patchedCtx));
   },
   testEnvironment: (ctx) => hermesTestEnvironment(normalizeHermesConfig(ctx) as never),
   sessionCodec: hermesSessionCodec,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through adapter-managed heartbeat runs.
> - Hermes local agents rely on persisted session ids so follow-up wakes can resume the correct Hermes session.
> - Target issue #354 showed failed Hermes resumes persisting the literal word `from` as the next session id.
> - The upstream Hermes adapter can still emit that value when its legacy parser sees the help text phrase `Use a session ID from a previous CLI run`.
> - Repository policy blocks manual `pnpm-lock.yaml` changes in normal PRs, so this PR guards AgentDash at the server adapter boundary instead of patching the dependency.
> - The guard drops already-poisoned `from` runtime session state before Hermes starts, and clears failed adapter results that try to return `from` as a new session id.
>
> Fixes #354.

## What Changed

- Added a Hermes server-adapter guard that refuses to resume persisted `sessionId: "from"`.
- Added a result sanitizer that clears failed Hermes output if `from` is returned as session state.
- Added registry tests for both existing poisoned runtime state and newly malformed adapter output.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/adapter-registry.test.ts`
- `pnpm exec vitest run server/src/__tests__/hermes-local-adapter-patch.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`

## Risks

- Low behavioral risk: the sanitizer only targets the known help-text artifact `from`, and only clears returned session state on failed Hermes runs.
- Existing corrupted Hermes sessions will start fresh instead of resuming; that is the intended recovery path for #354.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.5`, high-reasoning coding agent with shell, git, GitHub CLI, SSH, and repository editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
