### PR TITLE
[no-prompt-update] Bypass rate limits for local trusted UAT

### DIFF
--- a/server/src/__tests__/rate-limit.test.ts
+++ b/server/src/__tests__/rate-limit.test.ts
@@ -79,6 +79,32 @@ describe("rate-limit middleware (#160)", () => {
     }
   });
 
+  it("local_trusted deployment bypasses rate limits for developer UAT", async () => {
+    delete process.env.NODE_ENV;
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED = "false";
+    process.env.AGENTDASH_RATE_LIMIT_API_MAX = "1";
+    const { createDefaultApiRateLimiter } = await loadFactories();
+    const app = buildApp(createDefaultApiRateLimiter({ deploymentMode: "local_trusted" }));
+
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app).get("/").set("X-Forwarded-For", "10.0.0.20");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("authenticated deployment keeps rate limits enabled", async () => {
+    delete process.env.NODE_ENV;
+    process.env.AGENTDASH_RATE_LIMIT_DISABLED = "false";
+    process.env.AGENTDASH_RATE_LIMIT_API_MAX = "1";
+    const { createDefaultApiRateLimiter } = await loadFactories();
+    const app = buildApp(createDefaultApiRateLimiter({ deploymentMode: "authenticated" }));
+
+    const ok = await request(app).get("/").set("X-Forwarded-For", "10.0.0.21");
+    expect(ok.status).toBe(200);
+    const blocked = await request(app).get("/").set("X-Forwarded-For", "10.0.0.21");
+    expect(blocked.status).toBe(429);
+  });
+
   it("billing limiter enforces tighter cap (configurable, set to 2)", async () => {
     delete process.env.NODE_ENV;
     process.env.AGENTDASH_RATE_LIMIT_DISABLED = "false";

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -186,7 +186,7 @@ export async function createApp(
     }),
   );
   // AgentDash (#160): tighter rate limit on /api/auth/* (brute-force vector).
-  app.use("/api/auth", createAuthRateLimiter(), authRoutes(db));
+  app.use("/api/auth", createAuthRateLimiter({ deploymentMode: opts.deploymentMode }), authRoutes(db));
   if (opts.betterAuthHandler) {
     // AgentDash (AGE-104 follow-up): block free-mail signups on Pro at the
     // signup endpoint itself, not at company-creation time.
@@ -194,7 +194,7 @@ export async function createApp(
       corpEmailSignupGuard({ enabled: opts.requireCorpEmail ?? false }),
     );
     // AgentDash (#160): rate-limit better-auth handler too (same /api/auth path).
-    app.use("/api/auth", createAuthRateLimiter());
+    app.use("/api/auth", createAuthRateLimiter({ deploymentMode: opts.deploymentMode }));
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
   app.use(llmRoutes(db));
@@ -206,7 +206,7 @@ export async function createApp(
   const api = Router();
   // AgentDash (#160): default-tier rate limit covering everything under /api
   // (excluding /api/auth which has a tighter limiter mounted on `app` directly).
-  api.use(createDefaultApiRateLimiter());
+  api.use(createDefaultApiRateLimiter({ deploymentMode: opts.deploymentMode }));
   api.use(boardMutationGuard());
   api.use(
     "/health",
@@ -250,7 +250,7 @@ export async function createApp(
   // AgentDash: tighter cap on the invite endpoint specifically — fans
   // out to Resend (cost amplification + sender-domain reputation risk).
   // Default API limiter still covers the rest of /onboarding.
-  api.use("/onboarding/invites", createInviteRateLimiter());
+  api.use("/onboarding/invites", createInviteRateLimiter({ deploymentMode: opts.deploymentMode }));
   api.use("/onboarding", onboardingV2Routes(db));
   api.use(assessRoutes(db));
   api.use(agentResearchRoutes(db));
@@ -286,7 +286,7 @@ export async function createApp(
   // AgentDash (#160): tighter rate limit on /billing/* (abuse vector). The
   // /billing/webhook subpath is hit by Stripe's servers, not users, and must
   // bypass — Stripe can send bursts during retries / high-traffic events.
-  const billingLimiter = createBillingRateLimiter();
+  const billingLimiter = createBillingRateLimiter({ deploymentMode: opts.deploymentMode });
   api.use(
     "/billing",
     (req, res, next) => {

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -13,15 +13,25 @@
  *  AGENTDASH_RATE_LIMIT_INVITE_MAX  (default 20)
  *  AGENTDASH_RATE_LIMIT_API_MAX     (default 200)
  *  AGENTDASH_RATE_LIMIT_DISABLED=true  — no-op middleware (tests / dev)
+ *
+ * Local trusted deployments are loopback/private developer instances, so they
+ * also use no-op middleware by default. Authenticated deployments still keep
+ * the protection unless the explicit env override is set.
  */
 
 import { rateLimit, type Options as RateLimitOptions } from "express-rate-limit";
 import type { Request, Response, NextFunction, RequestHandler } from "express";
+import type { DeploymentMode } from "@paperclipai/shared";
 
 const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 
-function isDisabled(): boolean {
+interface RateLimiterFactoryOptions {
+  deploymentMode?: DeploymentMode;
+}
+
+function isDisabled(opts: RateLimiterFactoryOptions = {}): boolean {
   return (
+    opts.deploymentMode === "local_trusted" ||
     process.env.AGENTDASH_RATE_LIMIT_DISABLED === "true" ||
     process.env.NODE_ENV === "test"
   );
@@ -69,18 +79,18 @@ function noopMiddleware(_req: Request, _res: Response, next: NextFunction): void
   next();
 }
 
-export function createAuthRateLimiter(): RequestHandler {
-  if (isDisabled()) return noopMiddleware;
+export function createAuthRateLimiter(opts: RateLimiterFactoryOptions = {}): RequestHandler {
+  if (isDisabled(opts)) return noopMiddleware;
   return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_AUTH_MAX", 10));
 }
 
-export function createBillingRateLimiter(): RequestHandler {
-  if (isDisabled()) return noopMiddleware;
+export function createBillingRateLimiter(opts: RateLimiterFactoryOptions = {}): RequestHandler {
+  if (isDisabled(opts)) return noopMiddleware;
   return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_BILLING_MAX", 20));
 }
 
-export function createDefaultApiRateLimiter(): RequestHandler {
-  if (isDisabled()) return noopMiddleware;
+export function createDefaultApiRateLimiter(opts: RateLimiterFactoryOptions = {}): RequestHandler {
+  if (isDisabled(opts)) return noopMiddleware;
   return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_API_MAX", 200));
 }
 
@@ -91,7 +101,7 @@ export function createDefaultApiRateLimiter(): RequestHandler {
  * per quarter-hour. That's well above any legit "invite my team" flow
  * but caps the cost-amplification window if a token is abused.
  */
-export function createInviteRateLimiter(): RequestHandler {
-  if (isDisabled()) return noopMiddleware;
+export function createInviteRateLimiter(opts: RateLimiterFactoryOptions = {}): RequestHandler {
+  if (isDisabled(opts)) return noopMiddleware;
   return makeHandler(parseEnvInt("AGENTDASH_RATE_LIMIT_INVITE_MAX", 20));
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and the target-machine loop validates that the control plane works with real local agent adapters.
> - The affected subsystem is the Express API rate limiter used by API/auth/billing/invite routes.
> - Hermes found that the `agentdash_dev` local trusted UAT server can exhaust the default 200 requests / 15 minute API quota before the two-executive onboarding scenario completes.
> - Local trusted mode is already constrained to private loopback developer use, while authenticated mode is the deployment surface that needs production abuse protection.
> - This pull request threads the deployment mode into the existing limiter factories and bypasses rate limiting only for `local_trusted`.
> - The benefit is that target-machine UAT can run to completion without weakening authenticated/public deployments.

## What Changed

- Added deployment-mode-aware rate limiter factory options.
- Bypassed auth/default API/invite/billing limiters for `deploymentMode: "local_trusted"`.
- Kept authenticated deployments rate-limited by default.
- Added focused coverage for local trusted bypass and authenticated enforcement.

Closes #366

## Verification

- `pnpm exec vitest run server/src/__tests__/rate-limit.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk for production: authenticated deployments keep the existing limiter behavior.
- Local trusted instances lose API request caps, but that mode is private/loopback developer mode and already grants implicit board control.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Codex desktop, high-reasoning coding agent with terminal/tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

[no-prompt-update]
