### PR TITLE
Prefer bound host for local runtime API URLs

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -17,6 +17,32 @@ describe("runtime API discovery", () => {
     ).toBe("https://paperclip.example.com");
   });
 
+  it("prefers the concrete bind host over allowed hostnames for local runtime calls", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["192.168.86.48", "mac-mini.tail112187.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3101,
+      }),
+    ).toBe("http://127.0.0.1:3101");
+  });
+
+  it("orders concrete bind host before allowed hostname callback candidates", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["192.168.86.48"],
+        bindHost: "127.0.0.1",
+        port: 3101,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual([
+      "http://127.0.0.1:3101",
+      "http://192.168.86.48:3101",
+    ]);
+  });
+
   it("builds ordered callback candidates from explicit, allowed, bind, and interface hosts", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -61,16 +61,16 @@ export function choosePrimaryRuntimeApiUrl(input: {
     }
   }
 
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && !isWildcardHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const allowedHostname = input.allowedHostnames
     .map((value) => value.trim())
     .find(Boolean);
   if (allowedHostname) {
     return formatOrigin("http:", allowedHostname, input.port);
-  }
-
-  const bindHost = normalizeHost(input.bindHost);
-  if (bindHost && !isWildcardHost(bindHost)) {
-    return formatOrigin("http:", bindHost, input.port);
   }
 
   return formatOrigin("http:", "localhost", input.port);
@@ -128,15 +128,15 @@ export function buildRuntimeApiCandidateUrls(input: {
   pushCandidate(candidates, seen, input.preferredApiUrl);
   pushCandidate(candidates, seen, explicitOrigin);
 
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && !isWildcardHost(bindHost)) {
+    pushCandidate(candidates, seen, formatOrigin(protocol, bindHost, input.port));
+  }
+
   for (const rawHost of input.allowedHostnames) {
     const host = normalizeHost(rawHost);
     if (!host) continue;
     pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
-  }
-
-  const bindHost = normalizeHost(input.bindHost);
-  if (bindHost && !isWildcardHost(bindHost)) {
-    pushCandidate(candidates, seen, formatOrigin(protocol, bindHost, input.port));
   }
 
   if (explicitOrigin) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates AI agents through local and remote adapters, and those agents must be able to call back into the control plane.
> - The affected subsystem is runtime API URL discovery, which seeds `PAPERCLIP_RUNTIME_API_URL` / `PAPERCLIP_API_URL` for adapter prompts.
> - Target-machine UAT proved that a `local_trusted` server bound to `127.0.0.1` can still advertise an allowed LAN hostname first.
> - That LAN URL is not reachable when the server is loopback-bound, so the Hermes agent run exits without actually reaching AgentDash.
> - This pull request makes concrete bind hosts win before allowed hostname fallbacks while preserving explicit public URL priority.
> - The benefit is that local adapters get a callback URL that matches the address the server actually listens on.

## What Changed

- Prefer non-wildcard `bindHost` before allowed hostnames in `choosePrimaryRuntimeApiUrl`.
- Put non-wildcard `bindHost` before allowed hostnames in runtime API candidate ordering.
- Added regression coverage for loopback-bound local trusted instances with LAN allowed hostnames.

Closes #368

## Verification

- `pnpm exec vitest run server/src/__tests__/runtime-api.test.ts server/src/__tests__/paperclip-env.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk: explicit public URLs still win first.
- Candidate ordering changes for concrete bind hosts; wildcard bindings still rely on allowed/interface host candidates.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Codex desktop, high-reasoning coding agent with terminal/tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
