### PR TITLE
Fix static marketing deploy and visual polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ pr-body.md
 scratch.md
 .draft.*
 tmp/
+.vercel

--- a/ui/src/components/ServerUnreachableOverlay.test.tsx
+++ b/ui/src/components/ServerUnreachableOverlay.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ServerUnreachableOverlay } from "./ServerUnreachableOverlay";
+
+const mockUseServerHealth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useServerHealth", () => ({
+  useServerHealth: () => mockUseServerHealth(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ServerUnreachableOverlay", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockUseServerHealth.mockReturnValue({
+      reachability: "unreachable",
+      lastCheck: new Date(),
+      isOnline: true,
+    });
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root.unmount());
+    }
+    document.body.removeChild(container);
+  });
+
+  function renderAt(pathname: string) {
+    window.history.pushState({}, "", pathname);
+    root = createRoot(container);
+    act(() => {
+      root.render(<ServerUnreachableOverlay />);
+    });
+  }
+
+  it("does not cover the public auth page when the app backend is unavailable", () => {
+    renderAt("/auth");
+
+    expect(container.textContent).not.toContain("Connection Lost");
+  });
+});

--- a/ui/src/components/ServerUnreachableOverlay.tsx
+++ b/ui/src/components/ServerUnreachableOverlay.tsx
@@ -2,6 +2,14 @@ import { useServerHealth } from "@/hooks/useServerHealth";
 
 export function ServerUnreachableOverlay() {
   const { reachability, isOnline } = useServerHealth();
+  const pathname = typeof window !== "undefined" ? window.location.pathname : "";
+  const isPublicMarketingRoute =
+    pathname === "/" ||
+    pathname === "/auth" ||
+    pathname === "/forgot-password" ||
+    pathname === "/reset-password" ||
+    pathname === "/consulting" ||
+    pathname === "/about";
 
   // Closes #233: previously this only short-circuited on "reachable", so
   // on first mount react-query was "checking" → the full-screen overlay
@@ -15,6 +23,7 @@ export function ServerUnreachableOverlay() {
   // no network, we still want to surface the overlay regardless of the
   // health-check state.
   const isBrowserOffline = !isOnline;
+  if (!isBrowserOffline && isPublicMarketingRoute) return null;
   if (!isBrowserOffline && reachability !== "unreachable") return null;
   const message = isBrowserOffline
     ? "You're offline — check your internet connection."

--- a/ui/src/marketing/components/LogoStrip.css
+++ b/ui/src/marketing/components/LogoStrip.css
@@ -1,8 +1,8 @@
 .mkt-logo-strip {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 32px;
+  justify-content: center;
+  gap: 12px;
   flex-wrap: wrap;
 }
 .mkt-logo-strip__item {
@@ -10,9 +10,19 @@
   opacity: 0.7;
   filter: grayscale(1);
 }
-.mkt-logo-strip__placeholder {
-  height: 28px;
-  width: 120px;
-  background: var(--mkt-rule);
+.mkt-logo-strip__marker {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  border: 1px solid var(--mkt-rule);
   border-radius: 4px;
+  background: color-mix(in srgb, var(--mkt-surface-cream-2) 74%, white);
+  color: var(--mkt-ink-soft);
+  font-family: var(--mkt-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  padding: 0 14px;
+  text-transform: uppercase;
+  white-space: nowrap;
 }

--- a/ui/src/marketing/components/LogoStrip.tsx
+++ b/ui/src/marketing/components/LogoStrip.tsx
@@ -13,7 +13,7 @@ export function LogoStrip({ items }: { items: LogoItem[] }) {
           {item.src ? (
             <img src={item.src} alt={item.name} className="mkt-logo-strip__item" />
           ) : (
-            <div className="mkt-logo-strip__placeholder" />
+            <span className="mkt-logo-strip__marker">{item.name}</span>
           )}
         </div>
       ))}

--- a/ui/src/marketing/components/SectionContainer.css
+++ b/ui/src/marketing/components/SectionContainer.css
@@ -1,6 +1,9 @@
 .mkt-section {
   padding-block: clamp(96px, 12vh, 160px);
 }
+.mkt-section--compact {
+  padding-block: clamp(40px, 7vh, 72px);
+}
 .mkt-section--cream-2 { background: var(--mkt-surface-cream-2); }
 .mkt-section__inner {
   max-width: var(--mkt-container-max);

--- a/ui/src/marketing/components/SectionContainer.tsx
+++ b/ui/src/marketing/components/SectionContainer.tsx
@@ -4,15 +4,21 @@ import type { ReactNode } from "react";
 export function SectionContainer({
   children,
   background = "cream",
+  spacing = "normal",
   id,
   as: Tag = "section",
 }: {
   children: ReactNode;
   background?: "cream" | "cream-2";
+  spacing?: "normal" | "compact";
   id?: string;
   as?: "section" | "div";
 }) {
-  const cls = ["mkt-section", background === "cream-2" ? "mkt-section--cream-2" : null]
+  const cls = [
+    "mkt-section",
+    background === "cream-2" ? "mkt-section--cream-2" : null,
+    spacing === "compact" ? "mkt-section--compact" : null,
+  ]
     .filter(Boolean)
     .join(" ");
   return (

--- a/ui/src/marketing/pages/Landing.test.tsx
+++ b/ui/src/marketing/pages/Landing.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Landing } from "./Landing";
+
+const mockHealthGet = vi.hoisted(() => vi.fn());
+const mockGetSession = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/router", () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}));
+
+vi.mock("../../api/health", () => ({
+  healthApi: {
+    get: () => mockHealthGet(),
+  },
+}));
+
+vi.mock("../../api/auth", () => ({
+  authApi: {
+    getSession: () => mockGetSession(),
+  },
+}));
+
+vi.mock("../MarketingShell", () => ({
+  MarketingShell: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock("../sections/Hero", () => ({
+  Hero: () => <h1>Run an AI workforce the way you'd run a company.</h1>,
+}));
+
+vi.mock("../sections/LayeredDescent", () => ({ LayeredDescent: () => null }));
+vi.mock("../sections/CapabilitiesGrid", () => ({ CapabilitiesGrid: () => null }));
+vi.mock("../sections/HowItWorks", () => ({ HowItWorks: () => null }));
+vi.mock("../sections/ConsultingBand", () => ({ ConsultingBand: () => null }));
+vi.mock("../sections/FinalCTA", () => ({ FinalCTA: () => null }));
+vi.mock("../components/SectionContainer", () => ({
+  SectionContainer: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+}));
+vi.mock("../components/LogoStrip", () => ({ LogoStrip: () => null }));
+vi.mock("../components/QuoteBlock", () => ({ QuoteBlock: () => null }));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("Marketing landing", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    mockHealthGet.mockReset();
+    mockGetSession.mockReset();
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root.unmount());
+    }
+    document.body.removeChild(container);
+  });
+
+  function render() {
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Landing />
+        </QueryClientProvider>,
+      );
+    });
+  }
+
+  it("shows the public marketing page when no backend health endpoint is available", async () => {
+    mockHealthGet.mockRejectedValue(new Error("health unavailable"));
+
+    render();
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Run an AI workforce the way you'd run a company.");
+    expect(container.querySelector("[data-testid='navigate']")).toBeNull();
+  });
+});

--- a/ui/src/marketing/pages/Landing.tsx
+++ b/ui/src/marketing/pages/Landing.tsx
@@ -14,12 +14,12 @@ import { SectionContainer } from "../components/SectionContainer";
 import { LogoStrip } from "../components/LogoStrip";
 import { QuoteBlock } from "../components/QuoteBlock";
 
-const PLACEHOLDER_LOGOS = [
-  { name: "Logo 1" },
-  { name: "Logo 2" },
-  { name: "Logo 3" },
-  { name: "Logo 4" },
-  { name: "Logo 5" },
+const TRUST_MARKERS = [
+  { name: "Goals" },
+  { name: "Agents" },
+  { name: "Budgets" },
+  { name: "Approvals" },
+  { name: "Audit trails" },
 ];
 
 export function Landing() {
@@ -42,19 +42,19 @@ export function Landing() {
   });
 
   if (!previewMode && (healthQuery.isLoading || (isAuthenticatedMode && sessionQuery.isLoading))) return null;
-  const loggedIn = !isAuthenticatedMode || Boolean(sessionQuery.data);
+  const loggedIn = healthQuery.isSuccess && (!isAuthenticatedMode || Boolean(sessionQuery.data));
   if (!previewMode && loggedIn) return <Navigate to="/companies" replace />;
 
   return (
     <MarketingShell>
       <Hero />
-      <SectionContainer>
-        <LogoStrip items={PLACEHOLDER_LOGOS} />
+      <SectionContainer spacing="compact">
+        <LogoStrip items={TRUST_MARKERS} />
       </SectionContainer>
       <SectionContainer background="cream-2">
         <QuoteBlock
-          quote="The first week our agents shipped, we caught up on six months of backlog. By month two, the board stopped asking how we'd staff the new initiative."
-          attribution="— Placeholder: replace with a real operator quote"
+          quote="The winning companies won't hire one AI assistant. They'll run accountable AI teams with goals, budgets, audits, and humans in the loop."
+          attribution="AgentDash launch thesis"
         />
       </SectionContainer>
       <LayeredDescent />

--- a/ui/src/marketing/sections/LayeredDescent.css
+++ b/ui/src/marketing/sections/LayeredDescent.css
@@ -7,11 +7,14 @@
   position: sticky;
   top: 0;
   height: 100vh;
+  width: 100%;
+  box-sizing: border-box;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
   align-items: center;
-  gap: 80px;
-  padding: 0 var(--mkt-container-gutter);
+  gap: clamp(32px, 6vw, 72px);
+  overflow: hidden;
+  padding: 0 max(var(--mkt-container-gutter), 32px);
   max-width: var(--mkt-container-max);
   margin-inline: auto;
   --descent-progress: 0;
@@ -20,27 +23,39 @@
 }
 .mkt-descent__rail {
   position: absolute;
-  left: 24px;
+  left: max(var(--mkt-container-gutter), 32px);
   top: 50%;
   transform: translateY(-50%);
   display: grid;
   gap: 16px;
+  width: 72px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
   font-family: var(--mkt-font-mono);
   font-size: 11px;
   color: var(--mkt-ink-soft);
+  z-index: 20;
+  pointer-events: none;
 }
 .mkt-descent__rail-item--active {
   color: var(--mkt-accent);
+  white-space: nowrap;
 }
 .mkt-descent__slabs {
   position: relative;
-  height: 80vh;
+  height: min(460px, 64vh);
+  min-height: 360px;
+  padding-left: 72px;
+  box-sizing: border-box;
   perspective: 1200px;
   transform-style: preserve-3d;
 }
 .mkt-descent__slab {
   position: absolute;
-  inset: 0;
+  inset-block: 0;
+  left: 72px;
+  right: 0;
   border: 1px solid var(--mkt-rule);
   background: var(--mkt-surface-cream-2);
   border-radius: 12px;
@@ -50,13 +65,27 @@
   justify-content: center;
   /* the per-slab JS sets --offset (signed integer relative to active) */
   --offset: 0;
-  transform: translateY(calc(var(--offset) * 24px)) rotateX(calc(var(--offset) * 4deg));
-  opacity: calc(1 - min(abs(var(--offset)), 3) * 0.25);
-  transition: transform 320ms var(--mkt-ease), opacity 320ms var(--mkt-ease);
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(calc(var(--offset) * 18px)) rotateX(calc(var(--offset) * 2deg)) scale(calc(1 - min(abs(var(--offset)), 3) * 0.02));
+  transition: transform 320ms var(--mkt-ease), opacity 320ms var(--mkt-ease), visibility 320ms var(--mkt-ease);
+}
+.mkt-descent__slab--ghost {
+  opacity: 0.13;
+  visibility: visible;
+}
+.mkt-descent__slab--ghost > :not(.mkt-descent__slab-edge) {
+  opacity: 0;
 }
 .mkt-descent__slab--active {
   border-color: var(--mkt-accent);
   background: var(--mkt-surface-cream);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: none;
   z-index: 10;
 }
 .mkt-descent__slab-edge {
@@ -69,6 +98,8 @@
 .mkt-descent__panel {
   display: grid;
   gap: 24px;
+  min-width: 0;
+  justify-self: stretch;
 }
 .mkt-descent__panel h3 {
   font-family: var(--mkt-font-serif);
@@ -78,11 +109,21 @@
   margin: 0;
 }
 .mkt-descent__panel-diagram {
+  width: 100%;
+  max-width: 560px;
+  box-sizing: border-box;
+  margin-inline: auto;
   border: 1px solid var(--mkt-rule);
   border-radius: 8px;
   background: var(--mkt-surface-cream-2);
   padding: 16px;
   color: var(--mkt-ink);
+  overflow: hidden;
+}
+.mkt-descent__panel-diagram > * {
+  display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 /* reduced-motion fallback: no pin, no perspective, vertical stack */
@@ -97,20 +138,28 @@
 }
 .mkt-descent--reduced .mkt-descent__slabs {
   height: auto;
+  min-height: 0;
+  padding-left: 0;
   perspective: none;
 }
 .mkt-descent--reduced .mkt-descent__slab {
   position: static;
   transform: none;
   opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
   margin-bottom: 24px;
   transition: none;
+}
+.mkt-descent--reduced .mkt-descent__slab--ghost > :not(.mkt-descent__slab-edge) {
+  opacity: 1;
 }
 .mkt-descent--reduced .mkt-descent__rail { display: none; }
 @media (max-width: 800px) {
   .mkt-descent { height: auto; }
   .mkt-descent__stage { position: static; height: auto; display: block; }
-  .mkt-descent__slabs { height: auto; perspective: none; }
-  .mkt-descent__slab { position: static; transform: none; opacity: 1; margin-bottom: 24px; }
+  .mkt-descent__slabs { height: auto; min-height: 0; padding-left: 0; perspective: none; }
+  .mkt-descent__slab { position: static; transform: none; opacity: 1; visibility: visible; pointer-events: auto; margin-bottom: 24px; }
+  .mkt-descent__slab--ghost > :not(.mkt-descent__slab-edge) { opacity: 1; }
   .mkt-descent__rail { display: none; }
 }

--- a/ui/src/marketing/sections/LayeredDescent.tsx
+++ b/ui/src/marketing/sections/LayeredDescent.tsx
@@ -48,10 +48,17 @@ export function LayeredDescent() {
           {DESCENT_LAYERS.map((layer, i) => {
             const offset = i - activeIndex;
             const isActive = i === activeIndex;
+            const isGhost = !isActive && Math.abs(offset) <= 3;
             return (
               <section
                 key={layer.number}
-                className={`mkt-descent__slab ${isActive ? "mkt-descent__slab--active" : ""}`}
+                className={[
+                  "mkt-descent__slab",
+                  isActive ? "mkt-descent__slab--active" : null,
+                  isGhost ? "mkt-descent__slab--ghost" : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 style={{ ["--offset" as string]: String(offset) }}
                 aria-current={isActive ? "true" : undefined}
               >

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @paperclipai/ui build",
+  "outputDirectory": "ui/dist",
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/api/(.*)", "status": 404 },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and AgentDash extends that into a polished public onboarding and operating surface.
> - The affected subsystem is the React/Vite marketing UI plus the Vercel static deployment configuration.
> - The live Vercel deployment was serving a static UI without the AgentDash API, so `/api/health` failures could redirect or cover public marketing/auth pages.
> - User screenshots also showed visible placeholder/logo blocks, fake testimonial copy, and the layered descent section leaking inactive card text into the active viewport.
> - This pull request makes the static Vercel deployment serve `ui/dist`, keeps public marketing/auth routes visible when no backend is attached, and tightens the problematic marketing sections.
> - The benefit is that the public Vercel URL now shows the current AgentDash marketing/login experience cleanly across desktop and mobile.

## What Changed

- Added `vercel.json` so the Vercel project builds `@paperclipai/ui`, serves `ui/dist`, falls back SPA routes to `index.html`, and intentionally leaves `/api/*` as 404 for the static marketing deployment.
- Kept public marketing/auth routes from being hidden by backend health failures in static deployments.
- Replaced fake logo placeholders and placeholder testimonial copy with concrete AgentDash trust markers and launch-thesis copy.
- Tightened the layered descent layout so inactive desktop slabs remain decorative without leaking text, while mobile still stacks all sections legibly.
- Added regression tests for the static landing route and public auth overlay behavior.

## Verification

- `pnpm exec vitest run ui/src/marketing/pages/Landing.test.tsx ui/src/components/ServerUnreachableOverlay.test.tsx`
- `pnpm --filter @paperclipai/ui build`
- `pnpm -r typecheck`
- `pnpm test:run`
- `vercel build --prod --scope thetangstrs-projects`
- `vercel deploy --prebuilt --prod --scope thetangstrs-projects`
- Production smoke checked with Playwright at https://agentdash-steel.vercel.app/: launch pitch present, placeholder copy absent, trust markers visible, layered descent has no desktop overlap, and mobile has no horizontal overflow.
- Before screenshots were provided in the issue prompt; after screenshots were captured locally during verification at `/tmp/agentdash-production-quote.png`, `/tmp/agentdash-production-descent.png`, and `/tmp/agentdash-production-mobile-descent.png`.

## Risks

- Low risk for the app backend: this only changes static public-route behavior and marketing presentation.
- The Vercel config intentionally returns 404 for `/api/*`; a full hosted AgentDash backend should be deployed separately.
- The authenticated production API flow behind a real AgentDash backend was not exercised in this PR.
- The existing Vite large chunk warning remains unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Codex desktop, high-reasoning coding workflow with shell, Vercel CLI, and Playwright verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
