### PR TITLE
Enforce Free single-seat tier capacity

### DIFF
--- a/server/src/__tests__/admin-company-access-tier-route.test.ts
+++ b/server/src/__tests__/admin-company-access-tier-route.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
+
+const listUserCompanyAccessMock = vi.fn();
+const setUserCompanyAccessMock = vi.fn();
+const isInstanceAdminMock = vi.fn();
+const tierDepsMock = {
+  getCompany: vi.fn(async (_id: string) => ({ planTier: "free" })),
+  counts: {
+    humans: vi.fn(async (_companyId: string) => 1),
+    agents: vi.fn(async (_companyId: string) => 0),
+  },
+};
+const companyId = "11111111-1111-4111-8111-111111111111";
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      isInstanceAdmin: isInstanceAdminMock,
+      listUserCompanyAccess: listUserCompanyAccessMock,
+      setUserCompanyAccess: setUserCompanyAccessMock,
+      canUser: vi.fn(),
+      hasPermission: vi.fn(),
+      ensureMembership: vi.fn(),
+      setPrincipalGrants: vi.fn(),
+    }),
+    agentService: () => ({
+      list: vi.fn(),
+      create: vi.fn(),
+      getById: vi.fn(),
+    }),
+    boardAuthService: () => ({
+      createChallenge: vi.fn(),
+      resolveBoardAccess: vi.fn(),
+      assertCurrentBoardKey: vi.fn(),
+      revokeBoardApiKey: vi.fn(),
+    }),
+    deduplicateAgentName: (name: string) => name,
+    logActivity: vi.fn(),
+    notifyHireApproved: vi.fn(),
+  }));
+  vi.doMock("../middleware/build-tier-deps.js", () => ({
+    buildRequireTierDeps: () => tierDepsMock,
+  }));
+  vi.doMock("../services/seat-quantity-syncer.js", () => ({
+    seatQuantitySyncer: () => ({ onMembershipChanged: vi.fn() }),
+  }));
+}
+
+function createDbStub() {
+  const db: any = {
+    execute: vi.fn().mockResolvedValue([]),
+  };
+  db.transaction = vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(db));
+  return db;
+}
+
+async function createApp(db: unknown) {
+  const [{ accessRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/access.js"),
+    import("../middleware/error-handler.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source: "session",
+      userId: "admin-1",
+      companyIds: [companyId],
+      isInstanceAdmin: true,
+    };
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes(db as any, {
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("PUT /admin/users/:userId/company-access Free tier caps", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/access.js");
+    vi.doUnmock("../middleware/error-handler.js");
+    vi.doUnmock("../middleware/build-tier-deps.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/seat-quantity-syncer.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    delete process.env.AGENTDASH_BILLING_DISABLED;
+    isInstanceAdminMock.mockResolvedValue(true);
+    listUserCompanyAccessMock.mockResolvedValue([]);
+    setUserCompanyAccessMock.mockResolvedValue([]);
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "free" });
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    tierDepsMock.counts.agents.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
+  });
+
+  it("blocks instance-admin access grants that would add a second Free human", async () => {
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .put("/api/admin/users/user-2/company-access")
+      .send({ companyIds: [companyId] });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("seat_cap_exceeded");
+    expect(setUserCompanyAccessMock).not.toHaveBeenCalled();
+    expect(db.execute).toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1,9 +1,11 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const agentId = "11111111-1111-4111-8111-111111111111";
 const companyId = "22222222-2222-4222-8222-222222222222";
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
 const baseAgent = {
   id: agentId,
@@ -184,7 +186,6 @@ function registerModuleMocks() {
 
   vi.doMock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
-    ISSUE_LIST_DEFAULT_LIMIT: 50,
     agentService: () => mockAgentService,
     agentInstructionsService: () => mockAgentInstructionsService,
     accessService: () => mockAccessService,
@@ -203,22 +204,44 @@ function registerModuleMocks() {
   }));
 }
 
-function createDbStub(options: { requireBoardApprovalForNewAgents?: boolean } = {}) {
-  return {
-    select: vi.fn().mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          then: vi.fn((resolve) =>
-            Promise.resolve(resolve([{
-              id: companyId,
-              name: "Paperclip",
-              requireBoardApprovalForNewAgents: options.requireBoardApprovalForNewAgents ?? false,
-            }])),
-          ),
-        }),
-      }),
-    }),
+function createDbStub(
+  options: {
+    requireBoardApprovalForNewAgents?: boolean;
+    planTier?: string;
+    activeAgents?: number;
+  } = {},
+) {
+  const db: any = {
+    execute: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(db)),
   };
+  db.select = vi.fn((shape?: Record<string, unknown>) => {
+    const rowsForShape = () => {
+      if (shape && Object.prototype.hasOwnProperty.call(shape, "count")) {
+        return [{ count: options.activeAgents ?? 0 }];
+      }
+      if (shape && Object.prototype.hasOwnProperty.call(shape, "spentMonthlyCents")) {
+        return [];
+      }
+      return [{
+        id: companyId,
+        name: "Paperclip",
+        spentMonthlyCents: 0,
+        planTier: options.planTier ?? "pro_active",
+        requireBoardApprovalForNewAgents: options.requireBoardApprovalForNewAgents ?? false,
+        logoAssetId: null,
+      }];
+    };
+    const chain: any = {
+      from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      groupBy: vi.fn(() => chain),
+      then: vi.fn((resolve, reject) => Promise.resolve(rowsForShape()).then(resolve, reject)),
+    };
+    return chain;
+  });
+  return db;
 }
 
 async function createApp(actor: Record<string, unknown>, dbOptions: { requireBoardApprovalForNewAgents?: boolean } = {}) {
@@ -389,6 +412,13 @@ describe.sequential("agent permission routes", () => {
       censorUsernameInLogs: false,
     });
     mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("redacts agent detail for authenticated company members without agent admin permission", async () => {
@@ -803,6 +833,90 @@ describe.sequential("agent permission routes", () => {
     );
   });
 
+  it("checks direct agent creation authorization before returning Free tier cap errors", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp(
+      {
+        type: "board",
+        userId: "other-company-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: ["different-company"],
+      },
+      { planTier: "free", activeAgents: 1 },
+    );
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Backdoor",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("does not have access");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("blocks direct agent creation on Free workspaces after the agent slot is used", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+
+    const app = await createApp(
+      {
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      },
+      { planTier: "free", activeAgents: 1 },
+    );
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows the first direct agent creation on a Free workspace", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+
+    const app = await createApp(
+      {
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      },
+      { planTier: "free", activeAgents: 0 },
+    );
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects direct agent creation when new agents require board approval", async () => {
     const app = await createApp(
       {
@@ -959,6 +1073,35 @@ describe.sequential("agent permission routes", () => {
         },
       }),
     );
+  });
+
+  it("blocks agent hire requests on Free workspaces after the agent slot is used", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+
+    const app = await createApp(
+      {
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      },
+      { planTier: "free", activeAgents: 1 },
+    );
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
   });
 
   it("allows board users to directly approve pending agents", async () => {

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockApprovalService = vi.hoisted(() => ({
   list: vi.fn(),
@@ -28,6 +28,8 @@ const mockSecretService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
@@ -41,7 +43,39 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp(actorOverrides: Record<string, unknown> = {}) {
+function createTierDbStub(options: { planTier?: string; activeAgents?: number } = {}) {
+  const db: any = {
+    execute: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(db)),
+  };
+  db.select = vi.fn((shape?: Record<string, unknown>) => {
+    const rowsForShape = () => {
+      if (shape && Object.prototype.hasOwnProperty.call(shape, "count")) {
+        return [{ count: options.activeAgents ?? 0 }];
+      }
+      if (shape && Object.prototype.hasOwnProperty.call(shape, "spentMonthlyCents")) {
+        return [];
+      }
+      return [{
+        id: "company-1",
+        planTier: options.planTier ?? "pro_active",
+        spentMonthlyCents: 0,
+        logoAssetId: null,
+      }];
+    };
+    const chain: any = {
+      from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      groupBy: vi.fn(() => chain),
+      then: vi.fn((resolve, reject) => Promise.resolve(rowsForShape()).then(resolve, reject)),
+    };
+    return chain;
+  });
+  return db;
+}
+
+async function createApp(actorOverrides: Record<string, unknown> = {}, db: unknown = {}) {
   const [{ errorHandler }, { approvalRoutes }] = await Promise.all([
     import("../middleware/index.js"),
     import("../routes/approvals.js"),
@@ -59,7 +93,7 @@ async function createApp(actorOverrides: Record<string, unknown> = {}) {
     };
     next();
   });
-  app.use("/api", approvalRoutes({} as any));
+  app.use("/api", approvalRoutes(db as any));
   app.use(errorHandler);
   return app;
 }
@@ -112,6 +146,13 @@ describe("approval routes idempotent retries", () => {
     mockHeartbeatService.wakeup.mockResolvedValue({ id: "wake-1" });
     mockIssueApprovalService.listIssuesForApproval.mockResolvedValue([{ id: "issue-1" }]);
     mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("does not emit duplicate approval side effects when approve is already resolved", async () => {
@@ -233,6 +274,90 @@ describe("approval routes idempotent retries", () => {
 
     expect(res.status).toBe(200);
     expect(mockApprovalService.approve).toHaveBeenCalledWith("approval-4", "user-1", "ship it");
+  });
+
+  it("blocks approving a hire_agent approval that would create a second Free agent", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-free-cap",
+      companyId: "company-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: { name: "Extra Agent" },
+      requestedByAgentId: null,
+    });
+
+    const res = await request(await createApp({}, createTierDbStub({
+      planTier: "free",
+      activeAgents: 1,
+    })))
+      .post("/api/approvals/approval-free-cap/approve")
+      .send({});
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("blocks approving a revision-requested hire_agent approval that would create a second Free agent", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-free-cap-revision",
+      companyId: "company-1",
+      type: "hire_agent",
+      status: "revision_requested",
+      payload: { name: "Revised Agent" },
+      requestedByAgentId: null,
+    });
+
+    const res = await request(await createApp({}, createTierDbStub({
+      planTier: "free",
+      activeAgents: 1,
+    })))
+      .post("/api/approvals/approval-free-cap-revision/approve")
+      .send({});
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("keeps approved hire_agent retries idempotent even when the Free agent slot is used", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-free-retry",
+      companyId: "company-1",
+      type: "hire_agent",
+      status: "approved",
+      payload: { name: "Extra Agent" },
+      requestedByAgentId: null,
+    });
+    mockApprovalService.approve.mockResolvedValue({
+      approval: {
+        id: "approval-free-retry",
+        companyId: "company-1",
+        type: "hire_agent",
+        status: "approved",
+        payload: { name: "Extra Agent" },
+        requestedByAgentId: null,
+      },
+      applied: false,
+    });
+    const db = createTierDbStub({
+      planTier: "free",
+      activeAgents: 1,
+    });
+
+    const res = await request(await createApp({}, db))
+      .post("/api/approvals/approval-free-retry/approve")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockApprovalService.approve).toHaveBeenCalledWith("approval-free-retry", "user-1", undefined);
+    expect(db.execute).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
   it("derives approval attribution from the authenticated actor on reject", async () => {

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -31,6 +31,16 @@ const mockLogActivity = vi.hoisted(() => vi.fn());
 const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
 const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
+function disableBillingForApprovalDefaults() {
+  delete process.env.STRIPE_SECRET_KEY;
+  process.env.AGENTDASH_BILLING_DISABLED = "true";
+}
+
+function enableBillingForFreeTierTest() {
+  process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+  delete process.env.AGENTDASH_BILLING_DISABLED;
+}
+
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
@@ -146,6 +156,7 @@ describe("approval routes idempotent retries", () => {
     mockHeartbeatService.wakeup.mockResolvedValue({ id: "wake-1" });
     mockIssueApprovalService.listIssuesForApproval.mockResolvedValue([{ id: "issue-1" }]);
     mockLogActivity.mockResolvedValue(undefined);
+    disableBillingForApprovalDefaults();
   });
 
   afterEach(() => {
@@ -277,7 +288,7 @@ describe("approval routes idempotent retries", () => {
   });
 
   it("blocks approving a hire_agent approval that would create a second Free agent", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     mockApprovalService.getById.mockResolvedValue({
       id: "approval-free-cap",
       companyId: "company-1",
@@ -301,7 +312,7 @@ describe("approval routes idempotent retries", () => {
   });
 
   it("blocks approving a revision-requested hire_agent approval that would create a second Free agent", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     mockApprovalService.getById.mockResolvedValue({
       id: "approval-free-cap-revision",
       companyId: "company-1",
@@ -325,7 +336,7 @@ describe("approval routes idempotent retries", () => {
   });
 
   it("keeps approved hire_agent retries idempotent even when the Free agent slot is used", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     mockApprovalService.getById.mockResolvedValue({
       id: "approval-free-retry",
       companyId: "company-1",

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompanyPortabilityFileEntry } from "@paperclipai/shared";
 
 const companySvc = {
@@ -68,6 +68,8 @@ const agentInstructionsSvc = {
   exportFiles: vi.fn(),
   materializeManagedBundle: vi.fn(),
 };
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
 vi.mock("../services/companies.js", () => ({
   companyService: () => companySvc,
@@ -115,6 +117,14 @@ vi.mock("../routes/org-chart-svg.js", () => ({
 
 const { companyPortabilityService, parseGitHubSourceUrl } = await import("../services/company-portability.js");
 
+function createTierDbStub() {
+  const db: any = {
+    execute: vi.fn().mockResolvedValue([]),
+  };
+  db.transaction = vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(db));
+  return db;
+}
+
 function asTextFile(entry: CompanyPortabilityFileEntry | undefined) {
   expect(typeof entry).toBe("string");
   return typeof entry === "string" ? entry : "";
@@ -134,6 +144,7 @@ describe("company portability", () => {
     companySvc.getById.mockResolvedValue({
       id: "company-1",
       name: "Paperclip",
+      planTier: "pro_active",
       description: null,
       issuePrefix: "PAP",
       brandColor: "#5c5fff",
@@ -388,6 +399,17 @@ describe("company portability", () => {
         instructionsFilePath: `/tmp/${agent.id}/AGENTS.md`,
       },
     }));
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("parses canonical GitHub import URLs with explicit ref and package path", () => {
@@ -1589,6 +1611,123 @@ describe("company portability", () => {
     expect(issueSvc.create).not.toHaveBeenCalled();
   });
 
+  it("blocks agent imports on Free workspaces after the agent slot is used", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    companySvc.getById.mockResolvedValue({
+      id: "company-1",
+      name: "Paperclip",
+      planTier: "free",
+      requireBoardApprovalForNewAgents: false,
+    });
+    agentSvc.list.mockResolvedValue([
+      {
+        id: "cos-1",
+        name: "Chief of Staff",
+        status: "idle",
+        role: "chief_of_staff",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        budgetMonthlyCents: 0,
+        permissions: {},
+        metadata: null,
+      },
+    ]);
+    const portability = companyPortabilityService(createTierDbStub() as any);
+    const files = {
+      "COMPANY.md": [
+        "---",
+        'schema: "agentcompanies/v1"',
+        'name: "Paperclip"',
+        "---",
+        "",
+      ].join("\n"),
+      "agents/imported/AGENTS.md": [
+        "---",
+        'name: "Imported Agent"',
+        'role: "engineer"',
+        "---",
+        "",
+        "You write code.",
+        "",
+      ].join("\n"),
+    };
+
+    await expect(portability.importBundle({
+      source: { type: "inline", rootPath: "paperclip-demo", files },
+      include: { company: false, agents: true, projects: false, issues: false, skills: false },
+      target: { mode: "existing_company", companyId: "company-1" },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1")).rejects.toMatchObject({
+      status: 402,
+      code: "agent_cap_exceeded",
+    });
+
+    expect(agentSvc.create).not.toHaveBeenCalled();
+    expect(companySkillSvc.importPackageFiles).not.toHaveBeenCalled();
+  });
+
+  it("rechecks existing-company import capacity under lock before importing skills", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    companySvc.getById.mockResolvedValue({
+      id: "company-1",
+      name: "Paperclip",
+      planTier: "free",
+      requireBoardApprovalForNewAgents: false,
+    });
+    const cosAgent = {
+      id: "cos-1",
+      name: "Chief of Staff",
+      status: "idle",
+      role: "chief_of_staff",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+      permissions: {},
+      metadata: null,
+    };
+    agentSvc.list
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([cosAgent]);
+
+    const portability = companyPortabilityService(createTierDbStub() as any);
+    const files = {
+      "COMPANY.md": [
+        "---",
+        'schema: "agentcompanies/v1"',
+        'name: "Paperclip"',
+        "---",
+        "",
+      ].join("\n"),
+      "agents/imported/AGENTS.md": [
+        "---",
+        'name: "Imported Agent"',
+        'role: "engineer"',
+        "---",
+        "",
+        "You write code.",
+        "",
+      ].join("\n"),
+    };
+
+    await expect(portability.importBundle({
+      source: { type: "inline", rootPath: "paperclip-demo", files },
+      include: { company: false, agents: true, projects: false, issues: false, skills: false },
+      target: { mode: "existing_company", companyId: "company-1" },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1")).rejects.toMatchObject({
+      status: 402,
+      code: "agent_cap_exceeded",
+    });
+
+    expect(companySkillSvc.importPackageFiles).not.toHaveBeenCalled();
+    expect(agentSvc.create).not.toHaveBeenCalled();
+  });
+
   it("migrates legacy schedule.recurrence imports into routine triggers", async () => {
     const portability = companyPortabilityService({} as any);
 
@@ -2106,6 +2245,111 @@ describe("company portability", () => {
     expect(companySkillSvc.importPackageFiles).toHaveBeenCalledWith("company-imported", textOnlyFiles, {
       onConflict: "rename",
     });
+  });
+
+  it("blocks safe new-company imports that would copy multiple humans into a Free workspace", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    const portability = companyPortabilityService({} as any);
+
+    const exported = await portability.exportBundle("company-1", {
+      include: {
+        company: true,
+        agents: false,
+        projects: false,
+        issues: false,
+      },
+    });
+
+    accessSvc.listActiveUserMemberships.mockResolvedValueOnce([
+      {
+        id: "membership-1",
+        companyId: "company-1",
+        principalType: "user",
+        principalId: "user-1",
+        membershipRole: "owner",
+        status: "active",
+      },
+      {
+        id: "membership-2",
+        companyId: "company-1",
+        principalType: "user",
+        principalId: "user-2",
+        membershipRole: "operator",
+        status: "active",
+      },
+    ]);
+
+    await expect(portability.importBundle({
+      source: {
+        type: "inline",
+        rootPath: exported.rootPath,
+        files: exported.files,
+      },
+      include: {
+        company: true,
+        agents: false,
+        projects: false,
+        issues: false,
+      },
+      target: {
+        mode: "new_company",
+        newCompanyName: "Imported Paperclip",
+      },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, null, {
+      mode: "agent_safe",
+      sourceCompanyId: "company-1",
+    })).rejects.toMatchObject({
+      status: 402,
+      code: "seat_cap_exceeded",
+    });
+
+    expect(companySvc.create).not.toHaveBeenCalled();
+    expect(accessSvc.copyActiveUserMemberships).not.toHaveBeenCalled();
+  });
+
+  it("blocks multi-agent imports into a new Free workspace before creating partial state", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    const portability = companyPortabilityService({} as any);
+
+    const exported = await portability.exportBundle("company-1", {
+      include: {
+        company: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+    });
+
+    agentSvc.list.mockResolvedValue([]);
+
+    await expect(portability.importBundle({
+      source: {
+        type: "inline",
+        rootPath: exported.rootPath,
+        files: exported.files,
+      },
+      include: {
+        company: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+      target: {
+        mode: "new_company",
+        newCompanyName: "Imported Paperclip",
+      },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1")).rejects.toMatchObject({
+      status: 402,
+      code: "agent_cap_exceeded",
+    });
+
+    expect(companySvc.create).not.toHaveBeenCalled();
+    expect(companySkillSvc.importPackageFiles).not.toHaveBeenCalled();
+    expect(agentSvc.create).not.toHaveBeenCalled();
   });
 
   it("disables timer heartbeats on imported agents", async () => {

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -71,6 +71,16 @@ const agentInstructionsSvc = {
 const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
 const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
+function disableBillingForPortabilityDefaults() {
+  delete process.env.STRIPE_SECRET_KEY;
+  process.env.AGENTDASH_BILLING_DISABLED = "true";
+}
+
+function enableBillingForFreeTierTest() {
+  process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+  delete process.env.AGENTDASH_BILLING_DISABLED;
+}
+
 vi.mock("../services/companies.js", () => ({
   companyService: () => companySvc,
 }));
@@ -399,10 +409,7 @@ describe("company portability", () => {
         instructionsFilePath: `/tmp/${agent.id}/AGENTS.md`,
       },
     }));
-    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
-    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
-    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
-    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
+    disableBillingForPortabilityDefaults();
   });
 
   afterEach(() => {
@@ -1612,7 +1619,7 @@ describe("company portability", () => {
   });
 
   it("blocks agent imports on Free workspaces after the agent slot is used", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     companySvc.getById.mockResolvedValue({
       id: "company-1",
       name: "Paperclip",
@@ -1669,7 +1676,7 @@ describe("company portability", () => {
   });
 
   it("rechecks existing-company import capacity under lock before importing skills", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     companySvc.getById.mockResolvedValue({
       id: "company-1",
       name: "Paperclip",
@@ -2248,7 +2255,7 @@ describe("company portability", () => {
   });
 
   it("blocks safe new-company imports that would copy multiple humans into a Free workspace", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     const portability = companyPortabilityService({} as any);
 
     const exported = await portability.exportBundle("company-1", {
@@ -2310,7 +2317,7 @@ describe("company portability", () => {
   });
 
   it("blocks multi-agent imports into a new Free workspace before creating partial state", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    enableBillingForFreeTierTest();
     const portability = companyPortabilityService({} as any);
 
     const exported = await portability.exportBundle("company-1", {

--- a/server/src/__tests__/cos-reviewer-auto-hire.test.ts
+++ b/server/src/__tests__/cos-reviewer-auto-hire.test.ts
@@ -4,7 +4,7 @@
 // drive db.transaction to call its callback inline. The convergence guard
 // (FOR UPDATE) is exercised by sequencing the SELECT-active result so that
 // the second concurrent call observes the first hire.
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLogActivity = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock("../services/activity-log.js", () => ({
@@ -15,14 +15,24 @@ vi.mock("../services/activity-log.js", () => ({
 
 const mockAgentService = vi.hoisted(() => ({
   create: vi.fn(),
+  list: vi.fn(),
 }));
 vi.mock("../services/agents.js", () => ({
   agentService: vi.fn(() => mockAgentService),
 }));
 
+const mockCompanyService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+vi.mock("../services/companies.js", () => ({
+  companyService: vi.fn(() => mockCompanyService),
+}));
+
 import { cosReviewerAutoHire } from "../services/cos-reviewer-auto-hire.ts";
 
 const C = "11111111-1111-1111-1111-111111111111";
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
 interface DbScript {
   /** Sequence of rows returned by tx.select().for("update") (active reviewers). */
@@ -120,6 +130,7 @@ function makeDb(script: DbScript) {
   });
 
   const db: any = {
+    execute: vi.fn().mockResolvedValue([]),
     select: select2,
     insert: vi.fn(() => ({ values: insertValues })),
     update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
@@ -133,8 +144,21 @@ function makeDb(script: DbScript) {
 beforeEach(() => {
   mockLogActivity.mockClear();
   mockAgentService.create.mockReset();
+  mockAgentService.list.mockReset();
+  mockCompanyService.getById.mockReset();
+  mockAgentService.list.mockResolvedValue([]);
+  mockCompanyService.getById.mockResolvedValue({ id: C, planTier: "pro_active" });
   delete process.env.AGENTDASH_REVIEWER_QUEUE_DEPTH_THRESHOLD;
   delete process.env.AGENTDASH_REVIEWER_MAX_CONCURRENT_HIRES;
+  delete process.env.STRIPE_SECRET_KEY;
+  delete process.env.AGENTDASH_BILLING_DISABLED;
+});
+
+afterEach(() => {
+  if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+  else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+  if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+  else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
 });
 
 describe("cosReviewerAutoHire — neutrality_conflict", () => {
@@ -223,6 +247,30 @@ describe("cosReviewerAutoHire — MAX_CONCURRENT_HIRES cap", () => {
       (c: any[]) => c[1]?.action === "reviewer_hire_throttled",
     );
     expect(throttled).toHaveLength(1);
+  });
+});
+
+describe("cosReviewerAutoHire — Free tier cap", () => {
+  it("does not auto-hire a reviewer after the Free agent slot is used", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanyService.getById.mockResolvedValue({ id: C, planTier: "free" });
+    mockAgentService.list.mockResolvedValue([{ id: "cos-1", status: "idle" }]);
+    const inserts: DbScript["inserts"] = [];
+    const db = makeDb({
+      activeReviewerSeq: [[]],
+      depthSeq: [{ value: 1000 }],
+      inserts,
+    });
+    const createAgent = vi.fn().mockResolvedValue({ id: "agent-new" });
+    const svc = cosReviewerAutoHire(db, { createAgent });
+
+    const result = await svc.evaluateAndHireIfNeeded(C, "queue_depth");
+
+    expect(result.hired).toBe(false);
+    expect(result.reason).toBe("cap_reached");
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(inserts).toHaveLength(0);
+    expect(db.execute).toHaveBeenCalled();
   });
 });
 

--- a/server/src/__tests__/invite-create-route.test.ts
+++ b/server/src/__tests__/invite-create-route.test.ts
@@ -1,8 +1,17 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const logActivityMock = vi.fn();
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
+const tierDepsMock = {
+  getCompany: vi.fn(async (_id: string) => ({ planTier: "pro_active" })),
+  counts: {
+    humans: vi.fn(async (_companyId: string) => 0),
+    agents: vi.fn(async (_companyId: string) => 0),
+  },
+};
 
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
@@ -26,6 +35,9 @@ function registerModuleMocks() {
     logActivity: (...args: unknown[]) => logActivityMock(...args),
     notifyHireApproved: vi.fn(),
   }));
+  vi.doMock("../middleware/build-tier-deps.js", () => ({
+    buildRequireTierDeps: () => tierDepsMock,
+  }));
 }
 
 function createDbStub() {
@@ -44,13 +56,15 @@ function createDbStub() {
     updatedAt: new Date("2026-03-07T00:00:00.000Z"),
   };
 
-  return {
+  const db = {
+    execute: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(db)),
     insert() {
       return {
-        values() {
+        values(insertValues: Record<string, unknown>) {
           return {
             returning() {
-              return Promise.resolve([createdInvite]);
+              return Promise.resolve([{ ...createdInvite, ...insertValues }]);
             },
           };
         },
@@ -76,6 +90,7 @@ function createDbStub() {
       };
     },
   };
+  return db;
 }
 
 async function createApp() {
@@ -114,9 +129,20 @@ describe("POST /companies/:companyId/invites", () => {
     vi.doUnmock("../routes/access.js");
     vi.doUnmock("../routes/authz.js");
     vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("../middleware/build-tier-deps.js");
     registerModuleMocks();
     vi.clearAllMocks();
     logActivityMock.mockReset();
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "pro_active" });
+    tierDepsMock.counts.humans.mockResolvedValue(0);
+    tierDepsMock.counts.agents.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("returns an absolute invite URL using the request base URL", async () => {
@@ -135,5 +161,66 @@ describe("POST /companies/:companyId/invites", () => {
     expect(res.body.companyName).toBe("Acme Robotics");
     expect(res.body.invitePath).toMatch(/^\/invite\/pcp_invite_[a-z0-9]{16}$/);
     expect(res.body.inviteUrl).toMatch(/^https:\/\/paperclip\.example\/invite\/pcp_invite_[a-z0-9]{16}$/);
+  });
+
+  it("allows agent-only invites on Free workspaces with a human owner but no agent yet", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "free" });
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    tierDepsMock.counts.agents.mockResolvedValue(0);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "agent" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.allowedJoinTypes).toBe("agent");
+    expect(tierDepsMock.counts.humans).not.toHaveBeenCalled();
+    expect(tierDepsMock.counts.agents).toHaveBeenCalledWith("company-1");
+  });
+
+  it("blocks human invites on Free workspaces that already have one human", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "free" });
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "human" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("seat_cap_exceeded");
+  });
+
+  it("allows both-type invites when at least one join type still has Free capacity", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "free" });
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    tierDepsMock.counts.agents.mockResolvedValue(0);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "both" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.allowedJoinTypes).toBe("both");
+  });
+
+  it("blocks both-type invites when no Free human or agent capacity remains", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "free" });
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    tierDepsMock.counts.agents.mockResolvedValue(1);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "both" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("seat_cap_exceeded");
   });
 });

--- a/server/src/__tests__/join-approval-tier-route.test.ts
+++ b/server/src/__tests__/join-approval-tier-route.test.ts
@@ -1,0 +1,276 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
+const logActivityMock = vi.fn();
+const notifyHireApprovedMock = vi.fn().mockResolvedValue(undefined);
+const seatSyncMock = vi.fn().mockResolvedValue(undefined);
+const ensureMembershipMock = vi.fn().mockResolvedValue(undefined);
+const setPrincipalGrantsMock = vi.fn().mockResolvedValue(undefined);
+const agentCreateMock = vi.fn();
+const agentListMock = vi.fn();
+const tierDepsMock = {
+  getCompany: vi.fn(async (_id: string) => ({ planTier: "pro_active" })),
+  counts: {
+    humans: vi.fn(async (_companyId: string) => 0),
+    agents: vi.fn(async (_companyId: string) => 0),
+  },
+};
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      isInstanceAdmin: vi.fn(),
+      canUser: vi.fn(),
+      hasPermission: vi.fn(),
+      ensureMembership: ensureMembershipMock,
+      setPrincipalGrants: setPrincipalGrantsMock,
+    }),
+    agentService: () => ({
+      list: agentListMock,
+      create: agentCreateMock,
+      getById: vi.fn(),
+    }),
+    boardAuthService: () => ({
+      createChallenge: vi.fn(),
+      resolveBoardAccess: vi.fn(),
+      assertCurrentBoardKey: vi.fn(),
+      revokeBoardApiKey: vi.fn(),
+    }),
+    deduplicateAgentName: (name: string) => name,
+    logActivity: (...args: unknown[]) => logActivityMock(...args),
+    notifyHireApproved: (...args: unknown[]) => notifyHireApprovedMock(...args),
+  }));
+  vi.doMock("../middleware/build-tier-deps.js", () => ({
+    buildRequireTierDeps: () => tierDepsMock,
+  }));
+  vi.doMock("../services/seat-quantity-syncer.js", () => ({
+    seatQuantitySyncer: () => ({ onMembershipChanged: seatSyncMock }),
+  }));
+}
+
+type JoinRequestRow = {
+  id: string;
+  companyId: string;
+  inviteId: string;
+  requestType: "human" | "agent";
+  status: string;
+  requestingUserId: string | null;
+  agentName: string | null;
+  adapterType: string | null;
+  capabilities: string[] | null;
+  agentDefaultsPayload: Record<string, unknown> | null;
+  createdAgentId: string | null;
+  claimSecretHash: string | null;
+};
+
+function joinRequestRow(overrides: Partial<JoinRequestRow>): JoinRequestRow {
+  return {
+    id: "join-1",
+    companyId: "company-1",
+    inviteId: "invite-1",
+    requestType: "human",
+    status: "pending_approval",
+    requestingUserId: "user-2",
+    agentName: null,
+    adapterType: null,
+    capabilities: null,
+    agentDefaultsPayload: null,
+    createdAgentId: null,
+    claimSecretHash: "hash",
+    ...overrides,
+  };
+}
+
+function inviteRow() {
+  return {
+    id: "invite-1",
+    companyId: "company-1",
+    inviteType: "company_join",
+    allowedJoinTypes: "both",
+    defaultsPayload: null,
+  };
+}
+
+function createDbStub(
+  joinRequest: JoinRequestRow,
+  options: { lockedJoinRequest?: JoinRequestRow } = {},
+) {
+  const selectQueue: unknown[][] = [
+    [joinRequest],
+    [inviteRow()],
+    [options.lockedJoinRequest ?? joinRequest],
+    [inviteRow()],
+  ];
+  const db: any = {
+    execute: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn(db)),
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () => Promise.resolve(selectQueue.shift() ?? []),
+      }),
+    })),
+    update: vi.fn(() => ({
+      set(values: Record<string, unknown>) {
+        return {
+          where() {
+            return {
+              returning: () =>
+                Promise.resolve([{ ...joinRequest, ...values }]),
+            };
+          },
+        };
+      },
+    })),
+  };
+  return db;
+}
+
+async function createApp(db: unknown) {
+  const [{ accessRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/access.js"),
+    import("../middleware/error-handler.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source: "local_implicit",
+      userId: "owner-1",
+      companyIds: ["company-1"],
+    };
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes(db as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("POST /companies/:companyId/join-requests/:requestId/approve Free tier caps", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/access.js");
+    vi.doUnmock("../middleware/error-handler.js");
+    vi.doUnmock("../middleware/build-tier-deps.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/seat-quantity-syncer.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    delete process.env.AGENTDASH_BILLING_DISABLED;
+    tierDepsMock.getCompany.mockResolvedValue({ planTier: "free" });
+    tierDepsMock.counts.humans.mockResolvedValue(0);
+    tierDepsMock.counts.agents.mockResolvedValue(0);
+    agentListMock.mockResolvedValue([{ id: "ceo-1", role: "ceo", reportsTo: null }]);
+    agentCreateMock.mockResolvedValue({
+      id: "agent-join-1",
+      role: "general",
+      status: "idle",
+    });
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
+  });
+
+  it("blocks approving a human join request after the Free human seat is used", async () => {
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    const db = createDbStub(joinRequestRow({ requestType: "human" }));
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post("/api/companies/company-1/join-requests/join-1/approve")
+      .send({});
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("seat_cap_exceeded");
+    expect(ensureMembershipMock).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("blocks approving an agent join request after the Free agent slot is used", async () => {
+    tierDepsMock.counts.agents.mockResolvedValue(1);
+    const db = createDbStub(joinRequestRow({
+      requestType: "agent",
+      requestingUserId: null,
+      agentName: "Ops Agent",
+    }));
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post("/api/companies/company-1/join-requests/join-1/approve")
+      .send({});
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(agentCreateMock).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("allows approving the first Free agent join request when only the human seat is used", async () => {
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    tierDepsMock.counts.agents.mockResolvedValue(0);
+    const db = createDbStub(joinRequestRow({
+      requestType: "agent",
+      requestingUserId: null,
+      agentName: "Ops Agent",
+    }));
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post("/api/companies/company-1/join-requests/join-1/approve")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("approved");
+    expect(agentCreateMock).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ name: "Ops Agent" }),
+    );
+    expect(ensureMembershipMock).toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-join-1",
+      "member",
+      "active",
+    );
+  });
+
+  it("checks the locked join-request status before enforcing Free tier capacity", async () => {
+    tierDepsMock.counts.humans.mockResolvedValue(1);
+    const db = createDbStub(
+      joinRequestRow({ requestType: "human", status: "pending_approval" }),
+      {
+        lockedJoinRequest: joinRequestRow({
+          requestType: "human",
+          status: "approved",
+        }),
+      },
+    );
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post("/api/companies/company-1/join-requests/join-1/approve")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Join request is not pending");
+    expect(tierDepsMock.counts.humans).not.toHaveBeenCalled();
+    expect(ensureMembershipMock).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/onboarding-orchestrator.test.ts
+++ b/server/src/__tests__/onboarding-orchestrator.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { onboardingOrchestrator } from "../services/onboarding-orchestrator.js";
+import {
+  OnboardingTierCapacityExceededError,
+  onboardingOrchestrator,
+} from "../services/onboarding-orchestrator.js";
 
-const mockAccess = { ensureMembership: vi.fn(), setPrincipalPermission: vi.fn(), listUserCompanyAccess: vi.fn() };
+const mockAccess = {
+  ensureMembership: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+  listUserCompanyAccess: vi.fn(),
+  listActiveUserMemberships: vi.fn(),
+};
 const mockCompanies = { create: vi.fn(), getById: vi.fn(), findByEmailDomain: vi.fn(), hasActiveCompany: vi.fn(), list: vi.fn() };
 const mockAgents = { create: vi.fn(), createApiKey: vi.fn(), list: vi.fn(), listKeys: vi.fn() };
 const mockInstructions = { materializeManagedBundle: vi.fn() };
@@ -9,12 +17,36 @@ const mockConversations = { findByCompany: vi.fn(), create: vi.fn(), addParticip
 const mockUsers = { getById: vi.fn() };
 
 const deps = { access: mockAccess, companies: mockCompanies, agents: mockAgents, instructions: mockInstructions, conversations: mockConversations, users: mockUsers };
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+
+function tierCapacityDeps() {
+  return {
+    withCompanyLock: vi.fn(async (_companyId: string, work: (services: typeof deps) => Promise<unknown>) =>
+      work(deps),
+    ),
+    capacityDepsFor: (services: typeof deps) => ({
+      getCompany: async (id: string) => {
+        const company = await services.companies.getById(id);
+        return { planTier: company?.planTier ?? "free" };
+      },
+      counts: {
+        humans: async (companyId: string) =>
+          (await services.access.listActiveUserMemberships(companyId)).length,
+        agents: async (companyId: string) =>
+          (await services.agents.list(companyId)).length,
+      },
+    }),
+  };
+}
 
 describe("onboardingOrchestrator.bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
     mockUsers.getById.mockResolvedValue({ id: "user-1", email: "alice@acme.com", name: "Alice Anderson" });
     mockAccess.listUserCompanyAccess.mockResolvedValue([]);
+    mockAccess.listActiveUserMemberships.mockResolvedValue([]);
     mockCompanies.hasActiveCompany.mockResolvedValue(false);
     mockCompanies.list.mockResolvedValue([]);
     mockCompanies.create.mockResolvedValue({ id: "company-1", name: "Acme", emailDomain: "acme.com" });
@@ -137,6 +169,66 @@ describe("onboardingOrchestrator.bootstrap", () => {
     expect(result.companyId).toBe("company-acme");
     expect(mockCompanies.findByEmailDomain).toHaveBeenCalledWith("acme.com");
     expect(mockCompanies.create).not.toHaveBeenCalled();
+  });
+
+  it("blocks a second corp-domain human from joining a Free workspace through bootstrap", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockUsers.getById.mockResolvedValue({ id: "user-3", email: "alice@acme.com" });
+    mockAccess.listUserCompanyAccess.mockResolvedValue([]);
+    mockAccess.listActiveUserMemberships.mockResolvedValue([
+      { companyId: "company-acme", principalId: "existing-user" },
+    ]);
+    mockCompanies.findByEmailDomain.mockResolvedValue({
+      id: "company-acme",
+      name: "Acme",
+      emailDomain: "acme.com",
+    });
+    mockCompanies.getById.mockResolvedValue({
+      id: "company-acme",
+      name: "Acme",
+      emailDomain: "acme.com",
+      planTier: "free",
+    });
+    mockAgents.list.mockResolvedValue([
+      { id: "agent-cos-acme", role: "chief_of_staff" },
+    ]);
+
+    const tierCapacity = tierCapacityDeps();
+    await expect(
+      onboardingOrchestrator({ ...(deps as any), tierCapacity }).bootstrap("user-3"),
+    ).rejects.toBeInstanceOf(OnboardingTierCapacityExceededError);
+
+    expect(tierCapacity.withCompanyLock).toHaveBeenCalledWith("company-acme", expect.any(Function));
+    expect(mockAccess.ensureMembership).not.toHaveBeenCalled();
+    expect(mockAgents.create).not.toHaveBeenCalled();
+    expect(mockConversations.addParticipant).not.toHaveBeenCalled();
+  });
+
+  it("blocks bootstrap CoS creation when a Free workspace already has an agent", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockAccess.listUserCompanyAccess.mockResolvedValue([
+      { companyId: "company-1", status: "active", principalId: "user-1" },
+    ]);
+    mockAccess.listActiveUserMemberships.mockResolvedValue([
+      { companyId: "company-1", principalId: "user-1" },
+    ]);
+    mockCompanies.getById.mockResolvedValue({
+      id: "company-1",
+      name: "Acme",
+      emailDomain: "acme.com",
+      planTier: "free",
+    });
+    mockAgents.list.mockResolvedValue([
+      { id: "agent-1", role: "researcher", status: "idle" },
+    ]);
+
+    await expect(
+      onboardingOrchestrator({ ...(deps as any), tierCapacity: tierCapacityDeps() }).bootstrap("user-1"),
+    ).rejects.toBeInstanceOf(OnboardingTierCapacityExceededError);
+
+    expect(mockAccess.ensureMembership).not.toHaveBeenCalled();
+    expect(mockAgents.create).not.toHaveBeenCalled();
+    expect(mockConversations.addParticipant).not.toHaveBeenCalled();
   });
 
   it("throws SingleCompanyInstallationError when an active company exists and the override is not active", async () => {

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockOrchestrator = { bootstrap: vi.fn() };
 const mockConversations = {
@@ -17,6 +17,12 @@ const mockAgents = {
   list: vi.fn().mockResolvedValue([]),
   listKeys: vi.fn().mockResolvedValue([]),
 };
+const mockAccess = {
+  listActiveUserMemberships: vi.fn().mockResolvedValue([]),
+};
+const mockCompanies = {
+  getById: vi.fn().mockResolvedValue({ id: "c1", name: "Acme", planTier: "pro_active" }),
+};
 const mockInterview = { nextTurn: vi.fn() };
 const mockProposer = { propose: vi.fn() };
 const mockCreator = { create: vi.fn() };
@@ -27,6 +33,10 @@ const mockCosState = {
   setGoals: vi.fn(),
   advancePhase: vi.fn().mockResolvedValue(undefined),
 };
+const mockMaterializeOnboardingGoals = vi.fn().mockResolvedValue({
+  created: 0,
+  skipped: 0,
+});
 
 const mockInvites = {
   createCompanyInvite: vi.fn(),
@@ -51,17 +61,29 @@ vi.mock("../auth/email.js", () => ({
   sanitizeDisplayName: (s: string | null) => s,
 }));
 
+vi.mock("../services/materialize-onboarding-goals.js", () => ({
+  materializeOnboardingGoals: () => mockMaterializeOnboardingGoals,
+}));
+
 vi.mock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
     ISSUE_LIST_DEFAULT_LIMIT: 50,
   onboardingOrchestrator: () => mockOrchestrator,
+  OnboardingTierCapacityExceededError: class OnboardingTierCapacityExceededError extends Error {
+    action: "invite" | "hire";
+
+    constructor(action: "invite" | "hire") {
+      super(action);
+      this.action = action;
+    }
+  },
   cosInterview: () => mockInterview,
   agentProposer: () => mockProposer,
   agentCreatorFromProposal: () => mockCreator,
   conversationService: () => mockConversations,
   agentService: () => mockAgents,
-  accessService: () => ({}),
-  companyService: () => ({}),
+  accessService: () => mockAccess,
+  companyService: () => mockCompanies,
   agentInstructionsService: () => mockInstructions,
   cosOnboardingStateService: () => mockCosState,
   inviteService: () => mockInvites,
@@ -81,10 +103,25 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
   and: vi.fn(),
   desc: vi.fn(),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
 }));
 
 import { onboardingV2Routes } from "../routes/onboarding-v2.js";
 import { errorHandler } from "../middleware/error-handler.js";
+
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+
+beforeEach(() => {
+  mockAccess.listActiveUserMemberships.mockResolvedValue([]);
+  mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "pro_active" });
+  mockAgents.list.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+  else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+  delete process.env.AGENTDASH_BILLING_DISABLED;
+});
 
 function buildApp(actor: any, dbResults: Array<unknown[]> = []) {
   const app = express();
@@ -109,6 +146,16 @@ function buildApp(actor: any, dbResults: Array<unknown[]> = []) {
     return chain;
   };
   const stubDb: any = makeChain();
+  let transactionTail = Promise.resolve();
+  stubDb.execute = vi.fn().mockResolvedValue([]);
+  stubDb.transaction = vi.fn((fn: (tx: any) => Promise<unknown>) => {
+    const run = transactionTail.then(() => fn(stubDb));
+    transactionTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  });
   app.use("/api/onboarding", onboardingV2Routes(stubDb));
   app.use(errorHandler);
   return app;
@@ -178,6 +225,105 @@ describe("POST /api/onboarding/agent/confirm", () => {
       agent: { id: "agent-2", name: "Reese", title: "SDR" },
       apiKey: { token: "agk_x" },
     });
+  });
+
+  it("allows the first onboarding agent on a Free workspace", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    mockAgents.list.mockResolvedValue([]);
+    mockProposer.propose.mockResolvedValue({
+      name: "Casey",
+      role: "Chief of Staff",
+      oneLineOkr: "ok",
+      rationale: "x",
+    });
+    mockCreator.create.mockResolvedValue({
+      agentId: "cos1",
+      apiKey: { id: "k", token: "agk_x" },
+    });
+    const app = buildApp({ type: "board", userId: "u1", source: "session", companyIds: ["c1"] });
+
+    const res = await request(app).post("/api/onboarding/agent/confirm").send({
+      conversationId: "conv1",
+      reportsToAgentId: "owner",
+      companyId: "c1",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      agent: { id: "cos1", name: "Casey", title: "Chief of Staff" },
+      apiKey: { token: "agk_x" },
+    });
+  });
+
+  it("blocks onboarding agent confirmation on Free workspaces that already have the CoS", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    mockAgents.list.mockResolvedValue([
+      { id: "cos1", role: "chief_of_staff", status: "idle" },
+    ]);
+    const app = buildApp({ type: "board", userId: "u1", source: "session", companyIds: ["c1"] });
+
+    const res = await request(app).post("/api/onboarding/agent/confirm").send({
+      conversationId: "conv1",
+      reportsToAgentId: "cos1",
+      companyId: "c1",
+    });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(mockProposer.propose).not.toHaveBeenCalled();
+    expect(mockCreator.create).not.toHaveBeenCalled();
+    expect(mockConversations.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("serializes concurrent Free onboarding agent confirmations so only one agent is created", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    const activeAgents: Array<{ id: string; role: string; status: string }> = [];
+    mockAgents.list.mockImplementation(async () => activeAgents);
+
+    let proposalCalls = 0;
+    let releaseProposals!: () => void;
+    const bothRequestsReachedProposal = new Promise<void>((resolve) => {
+      releaseProposals = resolve;
+    });
+    mockProposer.propose.mockImplementation(async () => {
+      proposalCalls += 1;
+      if (proposalCalls === 2) releaseProposals();
+      await bothRequestsReachedProposal;
+      return {
+        name: "Casey",
+        role: "Chief of Staff",
+        oneLineOkr: "ok",
+        rationale: "x",
+      };
+    });
+    mockCreator.create.mockImplementation(async () => {
+      const id = `agent-${activeAgents.length + 1}`;
+      activeAgents.push({ id, role: "chief_of_staff", status: "idle" });
+      return {
+        agentId: id,
+        apiKey: { id: `key-${id}`, token: `agk_${id}` },
+      };
+    });
+
+    const app = buildApp({ type: "board", userId: "u1", source: "session", companyIds: ["c1"] });
+    const requestBody = {
+      conversationId: "conv1",
+      reportsToAgentId: "owner",
+      companyId: "c1",
+    };
+
+    const [first, second] = await Promise.all([
+      request(app).post("/api/onboarding/agent/confirm").send(requestBody),
+      request(app).post("/api/onboarding/agent/confirm").send(requestBody),
+    ]);
+
+    expect([first.status, second.status].sort()).toEqual([201, 402]);
+    expect([first.body.code, second.body.code]).toContain("agent_cap_exceeded");
+    expect(mockCreator.create).toHaveBeenCalledTimes(1);
+    expect(mockConversations.postMessage).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -262,6 +408,45 @@ describe("POST /api/onboarding/confirm-plan", () => {
         body: expect.stringContaining("Done"),
       }),
     );
+  });
+
+  it("blocks plan materialization on Free workspaces that already have the CoS", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    mockAgents.list.mockResolvedValue([
+      { id: "cos1", role: "chief_of_staff", name: "CoS", status: "idle" },
+    ]);
+    const planPayload = {
+      rationale: "ship + seed",
+      agents: [
+        {
+          role: "engineering_lead",
+          name: "Ellie",
+          adapterType: "hermes_local",
+          responsibilities: ["own dashboard"],
+          kpis: ["ship Q3"],
+        },
+      ],
+      alignmentToShortTerm: "ships v2",
+      alignmentToLongTerm: "lays groundwork",
+    };
+    const app = buildApp(
+      { type: "board", userId: "u1", source: "session", companyIds: ["c1"] },
+      [
+        [{ id: "conv1", companyId: "c1" }],
+        [{ id: "msg1", cardKind: "agent_plan_proposal_v1", cardPayload: planPayload }],
+      ],
+    );
+
+    const res = await request(app)
+      .post("/api/onboarding/confirm-plan")
+      .send({ conversationId: "conv1" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect(mockCosState.advancePhase).not.toHaveBeenCalled();
+    expect(mockAgents.create).not.toHaveBeenCalled();
+    expect(mockInstructions.materializeManagedBundle).not.toHaveBeenCalled();
   });
 
   it("returns 404 when the conversation has no plan card", async () => {
@@ -369,6 +554,86 @@ describe("POST /api/onboarding/invites", () => {
         subject: expect.stringContaining("https://app.example.com/invite/pcp_invite_tok1"),
       }),
     );
+  });
+
+  it("allows the first teammate invite on a Free workspace with no active humans", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    mockAccess.listActiveUserMemberships.mockResolvedValue([]);
+    const expires = new Date("2099-01-01T00:00:00.000Z");
+    mockInvites.createCompanyInvite.mockResolvedValue({
+      id: "invite-1",
+      token: "tok1",
+      expiresAt: expires,
+    });
+    mockSendEmail.mockResolvedValue({ status: "skipped" });
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["owner@acme.com"],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.inviteIds).toEqual(["invite-1"]);
+    expect(mockInvites.createCompanyInvite).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks teammate invites on Free workspaces that already have one human", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    mockAccess.listActiveUserMemberships.mockResolvedValue([
+      { id: "member-1", principalType: "user", status: "active" },
+    ]);
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["teammate@acme.com"],
+    });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("seat_cap_exceeded");
+    expect(mockInvites.createCompanyInvite).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rechecks teammate capacity inside the lock before creating onboarding invites", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockCompanies.getById.mockResolvedValue({ id: "c1", name: "Acme", planTier: "free" });
+    mockAccess.listActiveUserMemberships
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "member-1", principalType: "user", status: "active" }]);
+    const app = buildApp({
+      type: "board",
+      userId: "u1",
+      source: "session",
+      companyIds: ["c1"],
+    });
+
+    const res = await request(app).post("/api/onboarding/invites").send({
+      conversationId: "conv1",
+      companyId: "c1",
+      emails: ["teammate@acme.com"],
+    });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("seat_cap_exceeded");
+    expect(mockInvites.createCompanyInvite).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
   });
 
   it("propagates sendEmail status into the response (sent / failed both flow through)", async () => {

--- a/server/src/__tests__/openclaw-invite-prompt-route.test.ts
+++ b/server/src/__tests__/openclaw-invite-prompt-route.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { errorHandler } from "../middleware/index.js";
 import { accessRoutes } from "../routes/access.js";
 
@@ -37,6 +37,15 @@ const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockStorage = vi.hoisted(() => ({
   headObject: vi.fn(),
 }));
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
+const mockTierDeps = vi.hoisted(() => ({
+  getCompany: vi.fn(async (_id: string) => ({ planTier: "pro_active" })),
+  counts: {
+    humans: vi.fn(async (_companyId: string) => 0),
+    agents: vi.fn(async (_companyId: string) => 0),
+  },
+}));
 
 vi.mock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
@@ -51,6 +60,10 @@ vi.mock("../services/index.js", () => ({
 
 vi.mock("../storage/index.js", () => ({
   getStorageService: () => mockStorage,
+}));
+
+vi.mock("../middleware/build-tier-deps.js", () => ({
+  buildRequireTierDeps: () => mockTierDeps,
 }));
 
 function createSelectChain(rows: unknown[]) {
@@ -102,6 +115,12 @@ function createDbStub(...selectResponses: unknown[][]) {
     ),
   );
   return {
+    execute: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) => fn({
+      insert,
+      select,
+      execute: vi.fn().mockResolvedValue([]),
+    })),
     insert,
     select,
     __insertValues: values,
@@ -148,6 +167,16 @@ describe.sequential("POST /companies/:companyId/openclaw/invite-prompt", () => {
     mockAgentService.getById.mockReset();
     mockLogActivity.mockResolvedValue(undefined);
     mockStorage.headObject.mockResolvedValue({ exists: true, contentLength: 3, contentType: "image/png" });
+    mockTierDeps.getCompany.mockResolvedValue({ planTier: "pro_active" });
+    mockTierDeps.counts.humans.mockResolvedValue(0);
+    mockTierDeps.counts.agents.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("rejects non-CEO agent callers", async () => {
@@ -206,6 +235,60 @@ describe.sequential("POST /companies/:companyId/openclaw/invite-prompt", () => {
         allowedJoinTypes: "agent",
       }),
     );
+  });
+
+  it("allows OpenClaw agent invites on Free workspaces with a human owner but no agent yet", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockTierDeps.getCompany.mockResolvedValue({ planTier: "free" });
+    mockTierDeps.counts.humans.mockResolvedValue(1);
+    mockTierDeps.counts.agents.mockResolvedValue(0);
+    const db = createDbStub([companyBranding], [logoAsset]);
+    mockAccessService.canUser.mockResolvedValue(true);
+    const app = createApp(
+      {
+        type: "board",
+        userId: "user-1",
+        companyIds: ["company-1"],
+        source: "session",
+        isInstanceAdmin: false,
+      },
+      db,
+    );
+
+    const res = await request(app)
+      .post("/api/companies/company-1/openclaw/invite-prompt")
+      .send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body.allowedJoinTypes).toBe("agent");
+    expect(mockTierDeps.counts.humans).not.toHaveBeenCalled();
+    expect(mockTierDeps.counts.agents).toHaveBeenCalledWith("company-1");
+  });
+
+  it("blocks OpenClaw agent invites on Free workspaces that already have the CoS", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_free_caps";
+    mockTierDeps.getCompany.mockResolvedValue({ planTier: "free" });
+    mockTierDeps.counts.agents.mockResolvedValue(1);
+    const db = createDbStub();
+    mockAccessService.canUser.mockResolvedValue(true);
+    const app = createApp(
+      {
+        type: "board",
+        userId: "user-1",
+        companyIds: ["company-1"],
+        source: "session",
+        isInstanceAdmin: false,
+      },
+      db,
+    );
+
+    const res = await request(app)
+      .post("/api/companies/company-1/openclaw/invite-prompt")
+      .send({});
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("agent_cap_exceeded");
+    expect((db as any).__insertValues).not.toHaveBeenCalled();
   });
 
   it("includes companyName in invite summary responses", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -531,22 +531,44 @@ export async function startServer(): Promise<StartedServer> {
     const onUserCreated = legacyAutoBootstrap
       ? async (user: { id: string; email: string; name: string | null }) => {
           const services = await import("./services/index.js");
+          const tierPolicy = await import("./services/tier-policy.js");
           const { authUsers } = await import("@paperclipai/db");
           const { eq } = await import("drizzle-orm");
-          const orch = services.onboardingOrchestrator({
-            access: services.accessService(db as any),
-            companies: services.companyService(db as any),
-            agents: services.agentService(db as any),
+          const orchestratorServices = (dbOrTx: any) => ({
+            access: services.accessService(dbOrTx),
+            companies: services.companyService(dbOrTx),
+            agents: services.agentService(dbOrTx),
             instructions: services.agentInstructionsService(),
-            conversations: services.conversationService(db as any),
+            conversations: services.conversationService(dbOrTx),
             users: {
               getById: async (id: string) => {
-                const rows = await (db as any)
+                const rows = await dbOrTx
                   .select()
                   .from(authUsers)
                   .where(eq(authUsers.id, id));
                 return rows[0] ?? null;
               },
+            },
+          });
+          const orch = services.onboardingOrchestrator({
+            ...orchestratorServices(db as any),
+            tierCapacity: {
+              withCompanyLock: (companyId, work) =>
+                tierPolicy.withCompanyTierCapacityLock(db as any, companyId, (tx) =>
+                  work(orchestratorServices(tx)),
+                ),
+              capacityDepsFor: (scoped) => ({
+                getCompany: async (id) => {
+                  const company = await scoped.companies.getById(id);
+                  return { planTier: company?.planTier ?? "free" };
+                },
+                counts: {
+                  humans: async (companyId) =>
+                    (await scoped.access.listActiveUserMemberships(companyId)).length,
+                  agents: async (companyId) =>
+                    (await scoped.agents.list(companyId)).length,
+                },
+              }),
             },
           });
           const result = await orch.bootstrap(user.id);

--- a/server/src/middleware/require-tier.ts
+++ b/server/src/middleware/require-tier.ts
@@ -1,57 +1,21 @@
 import type { RequestHandler } from "express";
+import {
+  exceededFreeTierCapacityAction,
+  freeTierCapExceededPayload,
+  type TierCapacityDeps,
+  type TierCapAction,
+} from "../services/tier-policy.js";
 
-interface Deps {
-  getCompany: (id: string) => Promise<{ planTier: string }>;
-  counts: {
-    humans: (companyId: string) => Promise<number>;
-    agents: (companyId: string) => Promise<number>;
-  };
-}
-
-// AgentDash (#157): pro_past_due is intentionally excluded — past-due customers
-// do not get Pro features until they resolve the payment issue.
-const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
-
-/**
- * Billing is "disabled" — and all caps bypass — when the operator explicitly opts out
- * via AGENTDASH_BILLING_DISABLED=true, OR when no Stripe key is configured (the
- * implicit signal that this is a dev/test deployment without payments wired). In
- * both cases we treat every company as if it's on Pro.
- *
- * Production deployments set STRIPE_SECRET_KEY → caps are enforced as designed.
- * Local-trusted dev never sets the key → caps never block.
- */
-export function isBillingDisabled(): boolean {
-  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
-  if (!process.env.STRIPE_SECRET_KEY) return true;
-  return false;
-}
-
-export function requireTierFor(action: "invite" | "hire", deps: Deps): RequestHandler {
+export function requireTierFor(action: TierCapAction, deps: TierCapacityDeps): RequestHandler {
   return async (req, res, next) => {
-    if (isBillingDisabled()) return next();
     const companyId = (req as any).companyId ?? req.params.companyId ?? (req.body as any)?.companyId;
     if (!companyId) return next();
-    const company = await deps.getCompany(companyId);
-    if (PRO_LIVE.has(company.planTier)) return next();
-    if (action === "invite") {
-      const humans = await deps.counts.humans(companyId);
-      if (humans >= 1) {
-        return res.status(402).json({
-          code: "seat_cap_exceeded",
-          message: "Free workspaces are limited to 1 user. Upgrade to Pro to invite teammates.",
-        });
-      }
-    }
-    if (action === "hire") {
-      const agents = await deps.counts.agents(companyId);
-      if (agents >= 1) {
-        return res.status(402).json({
-          code: "agent_cap_exceeded",
-          message: "Free workspaces include only the Chief of Staff. Upgrade to Pro to hire more agents.",
-        });
-      }
-    }
+    const blockedAction = await exceededFreeTierCapacityAction(
+      deps,
+      companyId,
+      action === "invite" ? { humans: 1 } : { agents: 1 },
+    );
+    if (blockedAction) return res.status(402).json(freeTierCapExceededPayload(blockedAction));
     next();
   };
 }

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -80,6 +80,12 @@ When you make HTTP calls to the AgentDash API (`/api/...` endpoints):
 The same key works for all `/api/companies/:companyId/...` endpoints under your company; cross-company access is rejected with HTTP 403.
 <!-- /AgentDash: agent-api-auth -->
 
+<!-- AgentDash: free-tier-capacity — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Free-tier capacity limits
+
+Free workspaces allow one human user and one agent, normally the Chief of Staff. If hiring an agent, inviting a teammate, approving a join request, importing a company package, or delegating setup work returns HTTP 402 with `seat_cap_exceeded` or `agent_cap_exceeded`, treat it as a plan-limit decision. Do not retry through another endpoint or create a workaround. Explain the blocked action to the board and ask them to upgrade or remove existing capacity first.
+<!-- /AgentDash: free-tier-capacity -->
+
 ## References
 
 These files are essential. Read them.

--- a/server/src/onboarding-assets/chief_of_staff/AGENTS.md
+++ b/server/src/onboarding-assets/chief_of_staff/AGENTS.md
@@ -112,3 +112,9 @@ When you make HTTP calls to the AgentDash API (`/api/...` endpoints):
 
 The same key works for all `/api/companies/:companyId/...` endpoints under your company; cross-company access is rejected with HTTP 403.
 <!-- /AgentDash: agent-api-auth -->
+
+<!-- AgentDash: free-tier-capacity — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Free-tier capacity limits
+
+Free workspaces allow one human user and one agent, normally you as Chief of Staff. If auto-hiring a reviewer, inviting a teammate or agent, approving a join request, importing a company package, or creating setup capacity returns HTTP 402 with `seat_cap_exceeded` or `agent_cap_exceeded`, treat it as a plan-limit decision. Do not retry through another endpoint or create a workaround. Surface the blocked action to the board and ask them to upgrade or remove existing capacity first.
+<!-- /AgentDash: free-tier-capacity -->

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -47,3 +47,9 @@ When you make HTTP calls to the AgentDash API (`/api/...` endpoints):
 
 The same key works for all `/api/companies/:companyId/...` endpoints under your company; cross-company access is rejected with HTTP 403.
 <!-- /AgentDash: agent-api-auth -->
+
+<!-- AgentDash: free-tier-capacity — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Free-tier capacity limits
+
+Free workspaces allow one human user and one agent, normally the Chief of Staff. If an API call returns HTTP 402 with `seat_cap_exceeded` or `agent_cap_exceeded`, do not retry through another endpoint or create a workaround. Comment on the Issue or CoS thread with the blocked action and ask the board to upgrade the workspace or remove existing capacity first. The API is the source of truth for current plan limits.
+<!-- /AgentDash: free-tier-capacity -->

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -54,8 +54,16 @@ import {
 } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { validate } from "../middleware/validate.js";
-// AgentDash: billing-trio (#151, #153)
-import { requireTierFor } from "../middleware/require-tier.js";
+import {
+  exceededFreeTierCapacityAction,
+  freeTierCapExceededPayload,
+  isBillingDisabled,
+  lockCompanyTierCapacity,
+  withCompanyTierCapacityGuard,
+  withCompanyTierCapacityLock,
+  withCompanyTierInviteCapacityGuard,
+  type TierInviteJoinType,
+} from "../services/tier-policy.js";
 import { buildRequireTierDeps } from "../middleware/build-tier-deps.js";
 import { seatQuantitySyncer } from "../services/seat-quantity-syncer.js";
 import { companyService } from "../services/companies.js";
@@ -2393,43 +2401,6 @@ async function probeInviteResolutionTarget(
   }
 }
 
-// AgentDash: billing-trio (#151) — Inline tier-cap check for the join-request
-// approve route. The route can approve either a human or an agent join, so the
-// requireTierFor middleware (which is fixed to "invite" or "hire" at mount
-// time) can't be used. This helper applies the same shape and codes as the
-// middleware. Sends a 402 to `res` when the cap is exceeded.
-async function assertJoinRequestTierAllowed(
-  deps: ReturnType<typeof buildRequireTierDeps>,
-  companyId: string,
-  requestType: string,
-  res: import("express").Response,
-): Promise<void> {
-  const billingDisabled =
-    process.env.AGENTDASH_BILLING_DISABLED === "true" || !process.env.STRIPE_SECRET_KEY;
-  if (billingDisabled) return;
-  const company = await deps.getCompany(companyId);
-  if (company.planTier === "pro_trial" || company.planTier === "pro_active") return;
-  if (requestType === "human") {
-    const humans = await deps.counts.humans(companyId);
-    if (humans >= 1) {
-      res.status(402).json({
-        code: "seat_cap_exceeded",
-        message: "Free workspaces are limited to 1 user. Upgrade to Pro to invite teammates.",
-      });
-      return;
-    }
-  } else if (requestType === "agent") {
-    const agents = await deps.counts.agents(companyId);
-    if (agents >= 1) {
-      res.status(402).json({
-        code: "agent_cap_exceeded",
-        message: "Free workspaces include only the Chief of Staff. Upgrade to Pro to hire more agents.",
-      });
-      return;
-    }
-  }
-}
-
 // AgentDash: billing-trio (#153) — Stripe seat-quantity syncer wired with the
 // real Stripe SDK when STRIPE_SECRET_KEY is set, otherwise a no-op shim that
 // preserves the service contract (idempotent, side-effect free in dev).
@@ -2442,6 +2413,7 @@ function createSeatSyncerForAccessRoutes(db: Db) {
       },
     };
   }
+
   const companies = companyService(db);
   const counts = {
     humans: async (companyId: string) => {
@@ -2491,17 +2463,76 @@ export function accessRoutes(
   const boardAuth = boardAuthService(db);
   const agents = agentService(db);
   // AgentDash: billing-trio (#151, #153)
-  const tierDeps = buildRequireTierDeps(db);
   const seatSyncer = createSeatSyncerForAccessRoutes(db);
   const routeInviteResolutionNetwork = opts.inviteResolutionNetwork
     ? { ...defaultInviteResolutionNetwork, ...opts.inviteResolutionNetwork }
     : inviteResolutionNetwork;
+
+  async function withTierCapacityForJoinWrite<T>(
+    companyId: string,
+    work: (dbOrTx: Db) => Promise<T | null>,
+  ): Promise<T | null> {
+    if (isBillingDisabled()) return work(db);
+    return withCompanyTierCapacityLock(db, companyId, work);
+  }
+
+  async function withTierCapacityForInviteWrite<T>(
+    companyId: string,
+    allowedJoinTypes: TierInviteJoinType,
+    res: import("express").Response,
+    work: (dbOrTx: Db) => Promise<T>,
+  ): Promise<T | null> {
+    return withCompanyTierInviteCapacityGuard(
+      db,
+      companyId,
+      allowedJoinTypes,
+      buildRequireTierDeps,
+      (action) => res.status(402).json(freeTierCapExceededPayload(action)),
+      work,
+    );
+  }
 
   async function assertInstanceAdmin(req: Request) {
     if (req.actor.type !== "board") throw unauthorized();
     if (isLocalImplicit(req)) return;
     const allowed = await access.isInstanceAdmin(req.actor.userId);
     if (!allowed) throw forbidden("Instance admin required");
+  }
+
+  async function enforceAdminCompanyAccessTierCapacity(
+    dbOrTx: Db,
+    userId: string,
+    companyIds: string[],
+    res: import("express").Response,
+  ): Promise<boolean> {
+    if (isBillingDisabled()) return true;
+
+    const target = Array.from(new Set(companyIds));
+    const scopedAccess = accessService(dbOrTx);
+    const existing = await scopedAccess.listUserCompanyAccess(userId);
+    const existingByCompany = new Map(existing.map((row) => [row.companyId, row]));
+    const activatingCompanyIds = target
+      .filter((companyId) => existingByCompany.get(companyId)?.status !== "active")
+      .sort();
+
+    if (activatingCompanyIds.length === 0) return true;
+
+    for (const companyId of activatingCompanyIds) {
+      await lockCompanyTierCapacity(dbOrTx, companyId);
+    }
+
+    const deps = buildRequireTierDeps(dbOrTx);
+    for (const companyId of activatingCompanyIds) {
+      const blockedAction = await exceededFreeTierCapacityAction(deps, companyId, {
+        humans: 1,
+      });
+      if (blockedAction) {
+        res.status(402).json(freeTierCapExceededPayload(blockedAction));
+        return false;
+      }
+    }
+
+    return true;
   }
 
   router.get("/board-claim/:token", async (req, res) => {
@@ -2764,12 +2795,14 @@ export function accessRoutes(
 
   async function createCompanyInviteForCompany(input: {
     req: Request;
+    db?: Db;
     companyId: string;
     allowedJoinTypes: "human" | "agent" | "both";
     humanRole?: "owner" | "admin" | "operator" | "viewer" | null;
     defaultsPayload?: Record<string, unknown> | null;
     agentMessage?: string | null;
   }) {
+    const writeDb = input.db ?? db;
     const normalizedAgentMessage =
       typeof input.agentMessage === "string"
         ? input.agentMessage.trim() || null
@@ -2796,7 +2829,7 @@ export function accessRoutes(
     for (let attempt = 0; attempt < INVITE_TOKEN_MAX_RETRIES; attempt += 1) {
       const candidateToken = createInviteToken();
       try {
-        const row = await db
+        const row = await writeDb
           .insert(invites)
           .values({
             ...insertValues,
@@ -2941,21 +2974,28 @@ export function accessRoutes(
 
   router.post(
     "/companies/:companyId/invites",
-    // AgentDash: billing-trio (#151) — Free workspaces capped at 1 human.
-    requireTierFor("invite", tierDeps),
     validate(createCompanyInviteSchema),
     async (req, res) => {
       const companyId = req.params.companyId as string;
       await assertCompanyPermission(req, companyId, "users:invite");
-      const { token, created, normalizedAgentMessage } =
-        await createCompanyInviteForCompany({
-          req,
-          companyId,
-          allowedJoinTypes: req.body.allowedJoinTypes,
-          humanRole: req.body.humanRole ?? null,
-          defaultsPayload: req.body.defaultsPayload ?? null,
-          agentMessage: req.body.agentMessage ?? null
-        });
+      const allowedJoinTypes = req.body.allowedJoinTypes as TierInviteJoinType;
+      const inviteResult = await withTierCapacityForInviteWrite(
+        companyId,
+        allowedJoinTypes,
+        res,
+        (dbOrTx) =>
+          createCompanyInviteForCompany({
+            req,
+            db: dbOrTx,
+            companyId,
+            allowedJoinTypes,
+            humanRole: req.body.humanRole ?? null,
+            defaultsPayload: req.body.defaultsPayload ?? null,
+            agentMessage: req.body.agentMessage ?? null
+          }),
+      );
+      if (!inviteResult) return;
+      const { token, created, normalizedAgentMessage } = inviteResult;
 
       await logActivity(db, {
         companyId,
@@ -3002,15 +3042,22 @@ export function accessRoutes(
     async (req, res) => {
       const companyId = req.params.companyId as string;
       await assertCanGenerateOpenClawInvitePrompt(req, companyId);
-      const { token, created, normalizedAgentMessage } =
-        await createCompanyInviteForCompany({
+      const inviteResult = await withTierCapacityForInviteWrite(
+        companyId,
+        "agent",
+        res,
+        (dbOrTx) => createCompanyInviteForCompany({
           req,
+          db: dbOrTx,
           companyId,
           allowedJoinTypes: "agent",
           humanRole: null,
           defaultsPayload: null,
           agentMessage: req.body.agentMessage ?? null
-        });
+        }),
+      );
+      if (!inviteResult) return;
+      const { token, created, normalizedAgentMessage } = inviteResult;
 
       await logActivity(db, {
         companyId,
@@ -3788,113 +3835,165 @@ export function accessRoutes(
         .then((rows) => rows[0] ?? null);
       if (!invite) throw notFound("Invite not found");
 
-      // AgentDash: billing-trio (#151) — Free workspaces enforce 1 human + 1
-      // agent. The middleware can't run on this route because the cap to apply
-      // depends on the join-request type, so we apply it inline here.
-      await assertJoinRequestTierAllowed(tierDeps, companyId, existing.requestType, res);
-      if (res.headersSent) return;
+      const joinApproval = await withTierCapacityForJoinWrite(
+        companyId,
+        async (dbOrTx) => {
+          const txAccess = accessService(dbOrTx);
+          const txAgents = agentService(dbOrTx);
+          const lockedRequest = await dbOrTx
+            .select()
+            .from(joinRequests)
+            .where(
+              and(
+                eq(joinRequests.companyId, companyId),
+                eq(joinRequests.id, requestId)
+              )
+            )
+            .then((rows) => rows[0] ?? null);
+          if (!lockedRequest) throw notFound("Join request not found");
+          if (lockedRequest.status !== "pending_approval") {
+            throw conflict("Join request is not pending");
+          }
 
-      let createdAgentId: string | null = existing.createdAgentId ?? null;
-      if (existing.requestType === "human") {
-        if (!existing.requestingUserId)
-          throw conflict("Join request missing user identity");
-        const membershipRole = resolveHumanInviteRole(
-          invite.defaultsPayload as Record<string, unknown> | null,
-        );
-        await access.ensureMembership(
-          companyId,
-          "user",
-          existing.requestingUserId,
-          membershipRole,
-          "active"
-        );
-        // AgentDash: billing-trio (#153) — sync Stripe seat quantity after the
-        // membership lands. Failures must not block the membership write.
+          const lockedInvite = await dbOrTx
+            .select()
+            .from(invites)
+            .where(eq(invites.id, lockedRequest.inviteId))
+            .then((rows) => rows[0] ?? null);
+          if (!lockedInvite) throw notFound("Invite not found");
+
+          // AgentDash: billing-trio (#151) — Free workspaces enforce 1 human
+          // + 1 agent. The cap must be checked after locking and re-reading
+          // the join request so idempotent retries see the real status before
+          // capacity is consumed.
+          const blockedAction = await exceededFreeTierCapacityAction(
+            buildRequireTierDeps(dbOrTx),
+            companyId,
+            lockedRequest.requestType === "human"
+              ? { humans: 1 }
+              : lockedRequest.requestType === "agent"
+                ? { agents: 1 }
+                : {},
+          );
+          if (blockedAction) {
+            res.status(402).json(freeTierCapExceededPayload(blockedAction));
+            return null;
+          }
+
+          let createdAgentId: string | null = lockedRequest.createdAgentId ?? null;
+          if (lockedRequest.requestType === "human") {
+            if (!lockedRequest.requestingUserId)
+              throw conflict("Join request missing user identity");
+            const membershipRole = resolveHumanInviteRole(
+              lockedInvite.defaultsPayload as Record<string, unknown> | null,
+            );
+            await txAccess.ensureMembership(
+              companyId,
+              "user",
+              lockedRequest.requestingUserId,
+              membershipRole,
+              "active"
+            );
+            const grants = humanJoinGrantsFromDefaults(
+              lockedInvite.defaultsPayload as Record<string, unknown> | null,
+              membershipRole
+            );
+            await txAccess.setPrincipalGrants(
+              companyId,
+              "user",
+              lockedRequest.requestingUserId,
+              grants,
+              req.actor.userId ?? null
+            );
+          } else {
+            const existingAgents = await txAgents.list(companyId);
+            const managerId = resolveJoinRequestAgentManagerId(existingAgents);
+            if (!managerId) {
+              throw conflict(
+                "Join request cannot be approved because this company has no active CEO"
+              );
+            }
+
+            const agentName = deduplicateAgentName(
+              lockedRequest.agentName ?? "New Agent",
+              existingAgents.map((a) => ({
+                id: a.id,
+                name: a.name,
+                status: a.status
+              }))
+            );
+
+            const created = await txAgents.create(companyId, {
+              name: agentName,
+              role: "general",
+              title: null,
+              status: "idle",
+              reportsTo: managerId,
+              capabilities: lockedRequest.capabilities ?? null,
+              adapterType: lockedRequest.adapterType ?? "process",
+              adapterConfig:
+                lockedRequest.agentDefaultsPayload &&
+                typeof lockedRequest.agentDefaultsPayload === "object"
+                  ? (lockedRequest.agentDefaultsPayload as Record<string, unknown>)
+                  : {},
+              runtimeConfig: {},
+              budgetMonthlyCents: 0,
+              spentMonthlyCents: 0,
+              permissions: {},
+              lastHeartbeatAt: null,
+              metadata: null
+            });
+            createdAgentId = created.id;
+            await txAccess.ensureMembership(
+              companyId,
+              "agent",
+              created.id,
+              "member",
+              "active"
+            );
+            const grants = agentJoinGrantsFromDefaults(
+              lockedInvite.defaultsPayload as Record<string, unknown> | null
+            );
+            await txAccess.setPrincipalGrants(
+              companyId,
+              "agent",
+              created.id,
+              grants,
+              req.actor.userId ?? null
+            );
+          }
+
+          const approved = await dbOrTx
+            .update(joinRequests)
+            .set({
+              status: "approved",
+              approvedByUserId:
+                req.actor.userId ?? (isLocalImplicit(req) ? "local-board" : null),
+              approvedAt: new Date(),
+              createdAgentId,
+              updatedAt: new Date()
+            })
+            .where(eq(joinRequests.id, requestId))
+            .returning()
+            .then((rows) => rows[0]);
+
+          return {
+            approved,
+            createdAgentId,
+            requestType: lockedRequest.requestType,
+          };
+        },
+      );
+      if (!joinApproval) return;
+      const { approved, createdAgentId } = joinApproval;
+
+      // AgentDash: billing-trio (#153) — sync Stripe seat quantity after the
+      // membership lands. Failures must not block the membership write.
+      if (joinApproval.requestType === "human") {
         seatSyncer.onMembershipChanged(companyId).catch((err) => {
           logger.error({ err, companyId }, "seat-quantity sync after join approval failed");
         });
-        const grants = humanJoinGrantsFromDefaults(
-          invite.defaultsPayload as Record<string, unknown> | null,
-          membershipRole
-        );
-        await access.setPrincipalGrants(
-          companyId,
-          "user",
-          existing.requestingUserId,
-          grants,
-          req.actor.userId ?? null
-        );
-      } else {
-        const existingAgents = await agents.list(companyId);
-        const managerId = resolveJoinRequestAgentManagerId(existingAgents);
-        if (!managerId) {
-          throw conflict(
-            "Join request cannot be approved because this company has no active CEO"
-          );
-        }
-
-        const agentName = deduplicateAgentName(
-          existing.agentName ?? "New Agent",
-          existingAgents.map((a) => ({
-            id: a.id,
-            name: a.name,
-            status: a.status
-          }))
-        );
-
-        const created = await agents.create(companyId, {
-          name: agentName,
-          role: "general",
-          title: null,
-          status: "idle",
-          reportsTo: managerId,
-          capabilities: existing.capabilities ?? null,
-          adapterType: existing.adapterType ?? "process",
-          adapterConfig:
-            existing.agentDefaultsPayload &&
-            typeof existing.agentDefaultsPayload === "object"
-              ? (existing.agentDefaultsPayload as Record<string, unknown>)
-              : {},
-          runtimeConfig: {},
-          budgetMonthlyCents: 0,
-          spentMonthlyCents: 0,
-          permissions: {},
-          lastHeartbeatAt: null,
-          metadata: null
-        });
-        createdAgentId = created.id;
-        await access.ensureMembership(
-          companyId,
-          "agent",
-          created.id,
-          "member",
-          "active"
-        );
-        const grants = agentJoinGrantsFromDefaults(
-          invite.defaultsPayload as Record<string, unknown> | null
-        );
-        await access.setPrincipalGrants(
-          companyId,
-          "agent",
-          created.id,
-          grants,
-          req.actor.userId ?? null
-        );
       }
-
-      const approved = await db
-        .update(joinRequests)
-        .set({
-          status: "approved",
-          approvedByUserId:
-            req.actor.userId ?? (isLocalImplicit(req) ? "local-board" : null),
-          approvedAt: new Date(),
-          createdAgentId,
-          updatedAt: new Date()
-        })
-        .where(eq(joinRequests.id, requestId))
-        .returning()
-        .then((rows) => rows[0]);
 
       await logActivity(db, {
         companyId,
@@ -3903,7 +4002,7 @@ export function accessRoutes(
         action: "join.approved",
         entityType: "join_request",
         entityId: requestId,
-        details: { requestType: existing.requestType, createdAgentId }
+        details: { requestType: joinApproval.requestType, createdAgentId }
       });
 
       if (createdAgentId) {
@@ -4469,11 +4568,31 @@ export function accessRoutes(
     async (req, res) => {
       await assertInstanceAdmin(req);
       const userId = req.params.userId as string;
-      await access.setUserCompanyAccess(
-        userId,
-        req.body.companyIds ?? [],
-        { actorUserId: req.actor.userId ?? null },
-      );
+      const companyIds = req.body.companyIds ?? [];
+      if (isBillingDisabled()) {
+        await access.setUserCompanyAccess(
+          userId,
+          companyIds,
+          { actorUserId: req.actor.userId ?? null },
+        );
+      } else {
+        await db.transaction(async (tx) => {
+          const dbOrTx = tx as unknown as Db;
+          const allowed = await enforceAdminCompanyAccessTierCapacity(
+            dbOrTx,
+            userId,
+            companyIds,
+            res,
+          );
+          if (!allowed) return;
+          await accessService(dbOrTx).setUserCompanyAccess(
+            userId,
+            companyIds,
+            { actorUserId: req.actor.userId ?? null },
+          );
+        });
+        if (res.headersSent) return;
+      }
       res.json(await loadUserCompanyAccessResponse(db, access, userId));
     }
   );

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -31,9 +31,11 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-// AgentDash: billing-trio (#151)
-import { requireTierFor } from "../middleware/require-tier.js";
 import { buildRequireTierDeps } from "../middleware/build-tier-deps.js";
+import {
+  freeTierCapExceededPayload,
+  withCompanyTierCapacityGuard,
+} from "../services/tier-policy.js";
 import {
   agentInstructionRefreshService,
   agentService,
@@ -159,8 +161,6 @@ export function agentRoutes(
   const router = Router();
   const svc = agentService(db);
   const access = accessService(db);
-  // AgentDash: billing-trio (#151)
-  const tierDeps = buildRequireTierDeps(db);
   const approvalsSvc = approvalService(db);
   const budgets = budgetService(db);
   const environmentsSvc = environmentService(db);
@@ -186,6 +186,21 @@ export function agentRoutes(
     await assertEnvironmentSelectionForCompany(environmentService(db), companyId, environmentId, {
       allowedDrivers: allowedEnvironmentDriversForAgent(adapterType),
     });
+  }
+
+  async function createAgentWithinTierCapacity<T>(
+    companyId: string,
+    res: Response,
+    create: (dbOrTx: Db) => Promise<T>,
+  ): Promise<T | null> {
+    return withCompanyTierCapacityGuard(
+      db,
+      companyId,
+      { agents: 1 },
+      buildRequireTierDeps,
+      (action) => res.status(402).json(freeTierCapExceededPayload(action)),
+      create,
+    );
   }
 
   /**
@@ -1796,7 +1811,7 @@ export function agentRoutes(
     res.json(state);
   });
 
-  router.post("/companies/:companyId/agent-hires", requireTierFor("hire", tierDeps), validate(createAgentHireSchema), async (req, res) => {
+  router.post("/companies/:companyId/agent-hires", validate(createAgentHireSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     await assertCanCreateAgentsForCompany(req, companyId);
     const sourceIssueIds = parseSourceIssueIds(req.body);
@@ -1854,12 +1869,15 @@ export function agentRoutes(
 
     const requiresApproval = company.requireBoardApprovalForNewAgents;
     const status = requiresApproval ? "pending_approval" : "idle";
-    const createdAgent = await svc.create(companyId, {
-      ...normalizedHireInput,
-      status,
-      spentMonthlyCents: 0,
-      lastHeartbeatAt: null,
-    });
+    const createdAgent = await createAgentWithinTierCapacity(companyId, res, (dbOrTx) =>
+      agentService(dbOrTx).create(companyId, {
+        ...normalizedHireInput,
+        status,
+        spentMonthlyCents: 0,
+        lastHeartbeatAt: null,
+      }),
+    );
+    if (!createdAgent) return;
     const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
 
     let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
@@ -1969,7 +1987,7 @@ export function agentRoutes(
     res.status(201).json({ agent, approval });
   });
 
-  router.post("/companies/:companyId/agents", requireTierFor("hire", tierDeps), validate(createAgentSchema), async (req, res) => {
+  router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     await assertCanCreateAgentsForCompany(req, companyId);
 
@@ -2028,14 +2046,17 @@ export function agentRoutes(
       allowedSandboxProviders: allowedSandboxProvidersForAgent(createInput.adapterType),
     });
 
-    const createdAgent = await svc.create(companyId, {
-      ...createInput,
-      adapterConfig: normalizedAdapterConfig,
-      runtimeConfig: normalizedRuntimeConfig,
-      status: "idle",
-      spentMonthlyCents: 0,
-      lastHeartbeatAt: null,
-    });
+    const createdAgent = await createAgentWithinTierCapacity(companyId, res, (dbOrTx) =>
+      agentService(dbOrTx).create(companyId, {
+        ...createInput,
+        adapterConfig: normalizedAdapterConfig,
+        runtimeConfig: normalizedRuntimeConfig,
+        status: "idle",
+        spentMonthlyCents: 0,
+        lastHeartbeatAt: null,
+      }),
+    );
+    if (!createdAgent) return;
     const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
 
     const actor = getActorInfo(req);

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -19,6 +19,13 @@ import {
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { redactEventPayload } from "../redaction.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { buildRequireTierDeps } from "../middleware/build-tier-deps.js";
+import {
+  exceededFreeTierCapacityAction,
+  freeTierCapExceededPayload,
+  isBillingDisabled,
+  withCompanyTierCapacityLock,
+} from "../services/tier-policy.js";
 
 function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(approval: T): T {
   return {
@@ -40,6 +47,20 @@ export function approvalRoutes(
   const secretsSvc = secretService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
+  function hireApprovalCreatesAgent(approval: {
+    type: string;
+    status?: string | null;
+    payload: unknown;
+  }): boolean {
+    if (approval.type !== "hire_agent") return false;
+    if (approval.status !== "pending" && approval.status !== "revision_requested") return false;
+    const payload =
+      typeof approval.payload === "object" && approval.payload !== null
+        ? (approval.payload as Record<string, unknown>)
+        : {};
+    return typeof payload.agentId !== "string";
+  }
+
   async function requireApprovalAccess(req: Request, id: string) {
     const approval = await svc.getById(id);
     if (!approval) {
@@ -47,6 +68,43 @@ export function approvalRoutes(
     }
     assertCompanyAccess(req, approval.companyId);
     return approval;
+  }
+
+  async function approveWithTierCapacity(
+    id: string,
+    existingApproval: Awaited<ReturnType<typeof svc.getById>>,
+    decidedByUserId: string,
+    decisionNote: string | null | undefined,
+    res: import("express").Response,
+  ) {
+    if (!existingApproval) return null;
+    if (!hireApprovalCreatesAgent(existingApproval) || isBillingDisabled()) {
+      return svc.approve(id, decidedByUserId, decisionNote);
+    }
+
+    return withCompanyTierCapacityLock(db, existingApproval.companyId, async (dbOrTx) => {
+      const txSvc = approvalService(dbOrTx);
+      const lockedApproval = await txSvc.getById(id);
+      if (!lockedApproval) {
+        res.status(404).json({ error: "Approval not found" });
+        return null;
+      }
+      if (!hireApprovalCreatesAgent(lockedApproval)) {
+        return txSvc.approve(id, decidedByUserId, decisionNote);
+      }
+
+      const blockedAction = await exceededFreeTierCapacityAction(
+        buildRequireTierDeps(dbOrTx),
+        lockedApproval.companyId,
+        { agents: 1 },
+      );
+      if (blockedAction) {
+        res.status(402).json(freeTierCapExceededPayload(blockedAction));
+        return null;
+      }
+
+      return txSvc.approve(id, decidedByUserId, decisionNote);
+    });
   }
 
   router.get("/companies/:companyId/approvals", async (req, res) => {
@@ -136,12 +194,21 @@ export function approvalRoutes(
   router.post("/approvals/:id/approve", validate(resolveApprovalSchema), async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
-    if (!(await requireApprovalAccess(req, id))) {
+    const existingApproval = await requireApprovalAccess(req, id);
+    if (!existingApproval) {
       res.status(404).json({ error: "Approval not found" });
       return;
     }
     const decidedByUserId = req.actor.userId ?? "board";
-    const { approval, applied } = await svc.approve(id, decidedByUserId, req.body.decisionNote);
+    const resolution = await approveWithTierCapacity(
+      id,
+      existingApproval,
+      decidedByUserId,
+      req.body.decisionNote,
+      res,
+    );
+    if (!resolution) return;
+    const { approval, applied } = resolution;
 
     if (applied) {
       const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -29,7 +29,7 @@ import {
 import { DomainAlreadyClaimedError } from "../services/companies.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
-import { isBillingDisabled } from "../middleware/require-tier.js";
+import { isBillingDisabled } from "../services/tier-policy.js";
 
 // AgentDash (#157): pro_past_due is intentionally excluded — past-due customers
 // do not get Pro features until they resolve the payment issue.

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -14,10 +14,19 @@ import {
   agentInstructionsService,
   cosOnboardingStateService,
   inviteService,
+  OnboardingTierCapacityExceededError,
 } from "../services/index.js";
 import { unauthorized, badRequest, notFound } from "../errors.js";
 import { assertCompanyAccess } from "./authz.js";
 import { SingleCompanyInstallationError } from "../services/companies.js";
+import {
+  exceededFreeTierCapacityAction,
+  freeTierCapExceededPayload,
+  type TierCapacityAdds,
+  type TierCapacityDeps,
+  withCompanyTierCapacityLock,
+  withCompanyTierCapacityGuard,
+} from "../services/tier-policy.js";
 import { crystallizeAndAdvanceCos } from "../services/deep-interview-crystallize.js";
 import { materializeOnboardingGoals } from "../services/materialize-onboarding-goals.js";
 import { dispatchLLM } from "../services/dispatch-llm.js";
@@ -38,6 +47,18 @@ import {
 // Resend sends per call.
 const MAX_INVITE_BATCH = 25;
 
+type OnboardingTierCapacityServices = {
+  companies: {
+    getById: (id: string) => Promise<{ planTier?: string | null } | null>;
+  };
+  access: {
+    listActiveUserMemberships: (companyId: string) => Promise<unknown[]>;
+  };
+  agents: {
+    list: (companyId: string) => Promise<unknown[]>;
+  };
+};
+
 // Cheap email shape check — not RFC-compliant, just enough to reject
 // obviously-malformed entries (no `@`, no domain, embedded whitespace,
 // length > 254). Resend rejects bad addresses anyway, but pre-filtering
@@ -56,9 +77,11 @@ export function onboardingV2Routes(db: Db) {
   const router = Router();
   const conversations = conversationService(db);
   const agents = agentService(db);
+  const access = accessService(db);
   // Hoisted out of the request handler so we don't re-instantiate the
   // service per call (fixes review feedback re: per-request churn).
   const companies = companyService(db);
+  const tierServices = tierCapacityServices(db);
 
   const users = {
     getById: async (id: string) => {
@@ -70,14 +93,73 @@ export function onboardingV2Routes(db: Db) {
     },
   };
 
+  function onboardingOrchestratorServices(dbOrTx: Db) {
+    return {
+      access: accessService(dbOrTx),
+      companies: companyService(dbOrTx),
+      agents: agentService(dbOrTx),
+      instructions: agentInstructionsService(),
+      conversations: conversationService(dbOrTx),
+      users,
+    };
+  }
+
   const orch = onboardingOrchestrator({
-    access: accessService(db),
-    companies: companyService(db),
-    agents,
-    instructions: agentInstructionsService(),
-    conversations,
-    users,
+    ...onboardingOrchestratorServices(db),
+    tierCapacity: {
+      withCompanyLock: (companyId, work) =>
+        withCompanyTierCapacityLock(db, companyId, (tx) =>
+          work(onboardingOrchestratorServices(tx)),
+        ),
+      capacityDepsFor: (services) =>
+        onboardingTierCapacityDeps({
+          companies: services.companies,
+          access: services.access,
+          agents: services.agents,
+        }),
+    },
   });
+
+  function onboardingTierCapacityDeps(
+    services: OnboardingTierCapacityServices = tierServices,
+  ): TierCapacityDeps {
+    return {
+      getCompany: async (id) => {
+        const company = await services.companies.getById(id);
+        return { planTier: company?.planTier ?? "free" };
+      },
+      counts: {
+        humans: async (companyId) =>
+          (await services.access.listActiveUserMemberships(companyId)).length,
+        agents: async (companyId) =>
+          (await services.agents.list(companyId)).length,
+      },
+    };
+  }
+
+  async function enforceFreeTierCapacity(
+    companyId: string,
+    adds: TierCapacityAdds,
+    res: import("express").Response,
+    services: OnboardingTierCapacityServices = tierServices,
+  ): Promise<boolean> {
+    const blockedAction = await exceededFreeTierCapacityAction(
+      onboardingTierCapacityDeps(services),
+      companyId,
+      adds,
+    );
+    if (!blockedAction) return true;
+    res.status(402).json(freeTierCapExceededPayload(blockedAction));
+    return false;
+  }
+
+  function tierCapacityServices(dbOrTx: Db): OnboardingTierCapacityServices {
+    return {
+      companies: companyService(dbOrTx),
+      access: accessService(dbOrTx),
+      agents: agentService(dbOrTx),
+    };
+  }
 
   // POST /api/onboarding/bootstrap
   // The orchestrator owns the welcome sequence end-to-end (posted atomically
@@ -100,6 +182,10 @@ export function onboardingV2Routes(db: Db) {
             (err.existingCompanyId ?? "existing workspace") +
             "'). AgentDash supports one workspace per self-hosted installation. To run multiple workspaces, use the cloud-hosted version (coming soon) or set AGENTDASH_ALLOW_MULTI_COMPANY=true if you're testing.",
         });
+        return;
+      }
+      if (err instanceof OnboardingTierCapacityExceededError) {
+        res.status(402).json(freeTierCapExceededPayload(err.action));
         return;
       }
       throw err;
@@ -161,23 +247,36 @@ export function onboardingV2Routes(db: Db) {
     // materialize an agent in someone else's company. Verify the actor has
     // active access to the target companyId before any side effect.
     assertCompanyAccess(req, companyId);
+    if (!(await enforceFreeTierCapacity(companyId, { agents: 1 }, res))) return;
     const transcript = await loadInterviewTranscript(db, conversationId);
     const proposal = await agentProposer({ llm: defaultStubProposer }).propose(
       transcript.length > 0 ? transcript : [{ role: "user", content: "stub", ts: new Date().toISOString() }],
     );
-    const result = await agentCreatorFromProposal({
-      agents,
-      instructions: agentInstructionsService(),
-    }).create({ companyId, reportsToAgentId, proposal, transcript });
-    // Append a CoS message announcing the hire as a proposal_card_v1.
-    await conversations.postMessage({
-      conversationId,
-      authorKind: "agent",
-      authorId: reportsToAgentId,
-      body: `${proposal.name} (${proposal.role}) is on your team. ${proposal.oneLineOkr}.`,
-      cardKind: "proposal_card_v1",
-      cardPayload: proposal as unknown as Record<string, unknown>,
-    });
+    const result = await withCompanyTierCapacityGuard(
+      db,
+      companyId,
+      { agents: 1 },
+      (dbOrTx) => onboardingTierCapacityDeps(tierCapacityServices(dbOrTx)),
+      (action) => res.status(402).json(freeTierCapExceededPayload(action)),
+      async (tx) => {
+        const txAgents = agentService(tx);
+        const created = await agentCreatorFromProposal({
+          agents: txAgents,
+          instructions: agentInstructionsService(),
+        }).create({ companyId, reportsToAgentId, proposal, transcript });
+        // Append a CoS message announcing the hire as a proposal_card_v1.
+        await conversationService(tx).postMessage({
+          conversationId,
+          authorKind: "agent",
+          authorId: reportsToAgentId,
+          body: `${proposal.name} (${proposal.role}) is on your team. ${proposal.oneLineOkr}.`,
+          cardKind: "proposal_card_v1",
+          cardPayload: proposal as unknown as Record<string, unknown>,
+        });
+        return created;
+      },
+    );
+    if (!result) return;
     res.status(201).json({
       agent: { id: result.agentId, name: proposal.name, title: proposal.role },
       apiKey: result.apiKey,
@@ -268,53 +367,42 @@ export function onboardingV2Routes(db: Db) {
     if (!payload || !Array.isArray(payload.agents) || payload.agents.length === 0) {
       throw badRequest("Plan card has no agents to materialize");
     }
+    if (!(await enforceFreeTierCapacity(companyId, { agents: payload.agents.length }, res))) return;
 
-    const cosState = cosOnboardingStateService(db);
-    await cosState.advancePhase(conversationId, "materializing");
+    const materialized = await withCompanyTierCapacityGuard(
+      db,
+      companyId,
+      { agents: payload.agents.length },
+      (dbOrTx) => onboardingTierCapacityDeps(tierCapacityServices(dbOrTx)),
+      (action) => res.status(402).json(freeTierCapExceededPayload(action)),
+      async (tx) => {
+        const txAgents = agentService(tx);
+        const txCosState = cosOnboardingStateService(tx);
+        const txConversations = conversationService(tx);
+        await txCosState.advancePhase(conversationId, "materializing");
 
-    // Find the CoS agent for this company so the new hires reportTo it.
-    const allAgents = await agents.list(companyId);
-    const cos = allAgents.find((a: any) => a.role === "chief_of_staff") ?? null;
-    const reportsToAgentId = cos?.id ?? null;
+        // Find the CoS agent for this company so the new hires reportTo it.
+        const allAgents = await txAgents.list(companyId);
+        const cos = allAgents.find((a: any) => a.role === "chief_of_staff") ?? null;
+        const reportsToAgentId = cos?.id ?? null;
 
-    // AgentDash (issue #174): materialize the captured onboarding goals
-    // ({shortTerm, longTerm}) into the goals table so the user sees them on
-    // /goals immediately. Idempotent on (conversationId, ownerAgentId), so
-    // a retry won't duplicate rows. Failures are logged but never block
-    // the materialization phase — the user's UX matters more than 100%
-    // goal materialization, and CoS can retry from the next turn.
-    if (cos) {
-      try {
-        await materializeOnboardingGoals({ db })({
-          conversationId,
-          companyId,
-          ownerAgentId: cos.id,
-        });
-      } catch (err) {
-        logger.error(
-          { err, conversationId, companyId, cosAgentId: cos.id },
-          "[onboarding-v2] materializeOnboardingGoals failed; continuing with agent materialization",
-        );
-      }
-    }
-
-    const instructions = agentInstructionsService();
-    const createdAgentIds: string[] = [];
-    for (const planAgent of payload.agents) {
-      const created = await agents.create(companyId, {
-        name: planAgent.name,
-        role: "general",
-        title: planAgent.role,
-        adapterType: planAgent.adapterType,
-        adapterConfig: {},
-        reportsTo: reportsToAgentId,
-        status: "idle",
-        spentMonthlyCents: 0,
-        lastHeartbeatAt: null,
-      });
-      const responsibilities = (planAgent.responsibilities ?? []).map((r) => `- ${r}`).join("\n");
-      const kpis = (planAgent.kpis ?? []).map((k) => `- ${k}`).join("\n");
-      const agentsMd = `# AGENTS.md — ${planAgent.name}
+        const instructions = agentInstructionsService();
+        const createdAgentIds: string[] = [];
+        for (const planAgent of payload.agents) {
+          const created = await txAgents.create(companyId, {
+            name: planAgent.name,
+            role: "general",
+            title: planAgent.role,
+            adapterType: planAgent.adapterType,
+            adapterConfig: {},
+            reportsTo: reportsToAgentId,
+            status: "idle",
+            spentMonthlyCents: 0,
+            lastHeartbeatAt: null,
+          });
+          const responsibilities = (planAgent.responsibilities ?? []).map((r) => `- ${r}`).join("\n");
+          const kpis = (planAgent.kpis ?? []).map((k) => `- ${k}`).join("\n");
+          const agentsMd = `# AGENTS.md — ${planAgent.name}
 
 ## Role
 ${planAgent.role}
@@ -336,26 +424,50 @@ ${kpis || "- (none captured)"}
 - Report status to your boss in the shared CoS thread.
 - Ask for clarification when requirements are ambiguous.
 `;
-      await instructions.materializeManagedBundle(
-        created,
-        { "AGENTS.md": agentsMd },
-        { entryFile: "AGENTS.md", replaceExisting: false },
-      );
-      createdAgentIds.push(created.id);
+          await instructions.materializeManagedBundle(
+            created,
+            { "AGENTS.md": agentsMd },
+            { entryFile: "AGENTS.md", replaceExisting: false },
+          );
+          createdAgentIds.push(created.id);
+        }
+
+        if (cos) {
+          await txConversations.postMessage({
+            conversationId,
+            authorKind: "agent",
+            authorId: cos.id,
+            body: "Done — your team's ready. You can talk to any of them via @mention, or stay here and route through me.",
+          });
+        }
+
+        await txCosState.advancePhase(conversationId, "ready");
+        return { createdAgentIds, cosAgentId: cos?.id ?? null };
+      },
+    );
+    if (!materialized) return;
+
+    // AgentDash (issue #174): materialize the captured onboarding goals
+    // ({shortTerm, longTerm}) into the goals table so the user sees them on
+    // /goals immediately. Idempotent on (conversationId, ownerAgentId), so
+    // a retry won't duplicate rows. Failures are logged but never block
+    // agent materialization.
+    if (materialized.cosAgentId) {
+      try {
+        await materializeOnboardingGoals({ db })({
+          conversationId,
+          companyId,
+          ownerAgentId: materialized.cosAgentId,
+        });
+      } catch (err) {
+        logger.error(
+          { err, conversationId, companyId, cosAgentId: materialized.cosAgentId },
+          "[onboarding-v2] materializeOnboardingGoals failed; continuing with agent materialization",
+        );
+      }
     }
 
-    if (cos) {
-      await conversations.postMessage({
-        conversationId,
-        authorKind: "agent",
-        authorId: cos.id,
-        body: "Done — your team's ready. You can talk to any of them via @mention, or stay here and route through me.",
-      });
-    }
-
-    await cosState.advancePhase(conversationId, "ready");
-
-    res.status(201).json({ companyId, createdAgentIds });
+    res.status(201).json({ companyId, createdAgentIds: materialized.createdAgentIds });
   });
 
   // POST /api/onboarding/finalize-assessment
@@ -596,7 +708,6 @@ No greetings. No markdown headings outside the JSON block.`;
       /* fall back to "your teammate" */
     }
 
-    const inviteSvc = inviteService(db);
     const inviteIds: string[] = [];
     const created: Array<{
       id: string;
@@ -608,6 +719,7 @@ No greetings. No markdown headings outside the JSON block.`;
     }> = [];
     const errors: Array<{ email: string; reason: string }> = [];
     const seen = new Set<string>(); // dedupe within the same batch
+    const validEmails: string[] = [];
 
     for (const email of emails) {
       const trimmed = typeof email === "string" ? email.trim() : "";
@@ -625,48 +737,86 @@ No greetings. No markdown headings outside the JSON block.`;
         continue;
       }
       seen.add(lower);
+      validEmails.push(trimmed);
+    }
 
-      try {
-        const row = await inviteSvc.createCompanyInvite({
-          companyId,
-          invitedByUserId: req.actor.userId ?? null,
-          email: trimmed,
-        });
-        const invitePath = `/invite/${row.token}`;
-        const inviteUrl = baseUrl ? `${baseUrl}${invitePath}` : invitePath;
+    if (validEmails.length > 0) {
+      if (!(await enforceFreeTierCapacity(companyId, { humans: validEmails.length }, res))) return;
+    }
 
-        // Fire the invite email. sendEmail returns {status} rather than
-        // throwing, so a missing RESEND_API_KEY (status:"skipped") or a
-        // Resend 4xx (status:"failed") never aborts the create — the
-        // inviter still has the URL to share by hand.
-        const { subject, html, text } = inviteEmailTemplate({
-          inviteUrl,
-          companyName,
-          inviterName,
-        });
-        const emailResult = await sendEmail({
-          to: trimmed,
-          subject,
-          html,
-          text,
-        });
+    const createdRows =
+      validEmails.length === 0
+        ? []
+        : await withCompanyTierCapacityGuard(
+            db,
+            companyId,
+            { humans: validEmails.length },
+            (dbOrTx) => onboardingTierCapacityDeps(tierCapacityServices(dbOrTx)),
+            (action) => res.status(402).json(freeTierCapExceededPayload(action)),
+            async (tx) => {
+              const txInviteSvc = inviteService(tx);
+              const rows: Array<{
+                id: string;
+                email: string;
+                invitePath: string;
+                inviteUrl: string;
+                expiresAt: Date;
+              }> = [];
+              for (const trimmed of validEmails) {
+                try {
+                  const row = await txInviteSvc.createCompanyInvite({
+                    companyId,
+                    invitedByUserId: req.actor.userId ?? null,
+                    email: trimmed,
+                  });
+                  const invitePath = `/invite/${row.token}`;
+                  const inviteUrl = baseUrl ? `${baseUrl}${invitePath}` : invitePath;
+                  inviteIds.push(row.id);
+                  rows.push({
+                    id: row.id,
+                    email: trimmed,
+                    invitePath,
+                    inviteUrl,
+                    expiresAt: row.expiresAt,
+                  });
+                } catch (err) {
+                  logger.warn(
+                    { err, companyId, email: trimmed },
+                    "onboarding_invite_create_failed",
+                  );
+                  errors.push({ email: trimmed, reason: "invite-create-failed" });
+                }
+              }
+              return rows;
+            },
+          );
+    if (createdRows === null) return;
 
-        inviteIds.push(row.id);
-        created.push({
-          id: row.id,
-          email: trimmed,
-          invitePath,
-          inviteUrl,
-          expiresAt: row.expiresAt.toISOString(),
-          emailStatus: emailResult.status,
-        });
-      } catch (err) {
-        logger.warn(
-          { err, companyId, email: trimmed },
-          "onboarding_invite_create_failed",
-        );
-        errors.push({ email: trimmed, reason: "invite-create-failed" });
-      }
+    for (const row of createdRows) {
+      // Fire the invite email after the invite rows commit. sendEmail returns
+      // {status} rather than throwing, so a missing RESEND_API_KEY
+      // (status:"skipped") or a Resend 4xx (status:"failed") never aborts
+      // the create — the inviter still has the URL to share by hand.
+      const { subject, html, text } = inviteEmailTemplate({
+        inviteUrl: row.inviteUrl,
+        companyName,
+        inviterName,
+      });
+      const emailResult = await sendEmail({
+        to: row.email,
+        subject,
+        html,
+        text,
+      });
+
+      created.push({
+        id: row.id,
+        email: row.email,
+        invitePath: row.invitePath,
+        inviteUrl: row.inviteUrl,
+        expiresAt: row.expiresAt.toISOString(),
+        emailStatus: emailResult.status,
+      });
     }
 
     res.json({ inviteIds, invites: created, errors });

--- a/server/src/services/agent-creator-from-proposal.ts
+++ b/server/src/services/agent-creator-from-proposal.ts
@@ -114,6 +114,12 @@ When you make HTTP calls to the AgentDash API (\`/api/...\` endpoints):
 
 The same key works for all \`/api/companies/:companyId/...\` endpoints under your company; cross-company access is rejected with HTTP 403.
 <!-- /AgentDash: agent-api-auth -->
+
+<!-- AgentDash: free-tier-capacity — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Free-tier capacity limits
+
+Free workspaces allow one human user and one agent, normally the Chief of Staff. If an API call returns HTTP 402 with \`seat_cap_exceeded\` or \`agent_cap_exceeded\`, do not retry through another endpoint or create a workaround. Comment on the Issue or CoS thread with the blocked action and ask the board to upgrade the workspace or remove existing capacity first. The API is the source of truth for current plan limits.
+<!-- /AgentDash: free-tier-capacity -->
 `;
 }
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -50,7 +50,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
 import { findServerAdapter } from "../adapters/index.js";
-import { forbidden, notFound, unprocessable } from "../errors.js";
+import { HttpError, forbidden, notFound, unprocessable } from "../errors.js";
 import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
 import { accessService } from "./access.js";
@@ -66,6 +66,13 @@ import { issueService } from "./issues.js";
 import { projectService } from "./projects.js";
 import { routineService } from "./routines.js";
 import { secretService } from "./secrets.js";
+import {
+  exceededFreeTierCapacityAction,
+  freeTierCapExceededPayload,
+  isBillingDisabled,
+  withCompanyTierCapacityGuard,
+  withCompanyTierCapacityLock,
+} from "./tier-policy.js";
 
 /** Build OrgNode tree from manifest agent list (slug + reportsToSlug). */
 function buildOrgTreeFromManifest(agents: CompanyPortabilityManifest["agents"]): OrgNode[] {
@@ -2769,6 +2776,29 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
   const secrets = secretService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
+  function tierCapacityDeps(dbOrTx: Db) {
+    const scopedCompanies = companyService(dbOrTx);
+    const scopedAccess = accessService(dbOrTx);
+    const scopedAgents = agentService(dbOrTx);
+    return {
+      getCompany: async (id: string) => {
+        const company = await scopedCompanies.getById(id);
+        return { planTier: company?.planTier ?? "free" };
+      },
+      counts: {
+        humans: async (companyId: string) =>
+          (await scopedAccess.listActiveUserMemberships(companyId)).length,
+        agents: async (companyId: string) =>
+          (await scopedAgents.list(companyId)).length,
+      },
+    };
+  }
+
+  function throwFreeTierCapExceeded(action: "invite" | "hire"): never {
+    const payload = freeTierCapExceededPayload(action);
+    throw new HttpError(402, payload.message, { code: payload.code }, payload.code);
+  }
+
   function assertKnownImportAdapterType(type: string | null | undefined): string {
     const adapterType = typeof type === "string" ? type.trim() : "";
     if (!adapterType) {
@@ -3963,576 +3993,683 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     const sourceManifest = plan.source.manifest;
     const warnings = [...plan.preview.warnings];
     const include = plan.include;
+    const plannedAgentCreates = include.agents
+      ? plan.preview.plan.agentPlans.filter((entry) => entry.action === "create").length
+      : 0;
 
-    let targetCompany: {
-      id: string;
-      name: string;
-      requireBoardApprovalForNewAgents?: boolean | null;
-      attachmentMaxBytes?: number | null;
-    } | null = null;
-    let companyAction: "created" | "updated" | "unchanged" = "unchanged";
+    if (
+      mode === "agent_safe"
+      && input.target.mode === "new_company"
+      && !options?.sourceCompanyId
+    ) {
+      throw unprocessable("Safe new-company imports require a source company context.");
+    }
 
-    if (input.target.mode === "new_company") {
-      if (mode === "agent_safe" && !options?.sourceCompanyId) {
-        throw unprocessable("Safe new-company imports require a source company context.");
+    if (
+      mode === "agent_safe"
+      && input.target.mode === "new_company"
+      && options?.sourceCompanyId
+    ) {
+      const sourceMemberships = await access.listActiveUserMemberships(options.sourceCompanyId);
+      if (sourceMemberships.length === 0) {
+        throw unprocessable("Safe new-company import requires at least one active user membership on the source company.");
       }
-      if (mode === "agent_safe" && options?.sourceCompanyId) {
-        const sourceMemberships = await access.listActiveUserMemberships(options.sourceCompanyId);
-        if (sourceMemberships.length === 0) {
-          throw unprocessable("Safe new-company import requires at least one active user membership on the source company.");
-        }
-      }
-      const companyName =
-        asString(input.target.newCompanyName) ??
-        sourceManifest.company?.name ??
-        sourceManifest.source?.companyName ??
-        "Imported Company";
-      const created = await companies.create({
-        name: companyName,
-        description: include.company ? (sourceManifest.company?.description ?? null) : null,
-        brandColor: include.company ? (sourceManifest.company?.brandColor ?? null) : null,
-        attachmentMaxBytes: include.company
-          ? (sourceManifest.company?.attachmentMaxBytes ?? undefined)
-          : undefined,
-        requireBoardApprovalForNewAgents: include.company
-          ? (sourceManifest.company?.requireBoardApprovalForNewAgents ?? false)
-          : false,
-        feedbackDataSharingEnabled: include.company
-          ? (sourceManifest.company?.feedbackDataSharingEnabled ?? false)
-          : false,
-        feedbackDataSharingConsentAt: include.company && sourceManifest.company?.feedbackDataSharingConsentAt
-          ? new Date(sourceManifest.company.feedbackDataSharingConsentAt)
-          : null,
-        feedbackDataSharingConsentByUserId: include.company
-          ? (sourceManifest.company?.feedbackDataSharingConsentByUserId ?? null)
-          : null,
-        feedbackDataSharingTermsVersion: include.company
-          ? (sourceManifest.company?.feedbackDataSharingTermsVersion ?? null)
-          : null,
-      });
-      if (mode === "agent_safe" && options?.sourceCompanyId) {
-        await access.copyActiveUserMemberships(options.sourceCompanyId, created.id);
-      } else {
-        await access.ensureMembership(created.id, "user", actorUserId ?? "board", "owner", "active");
-      }
-      targetCompany = created;
-      companyAction = "created";
-    } else {
-      targetCompany = await companies.getById(input.target.companyId);
-      if (!targetCompany) throw notFound("Target company not found");
-      if (include.company && sourceManifest.company && mode === "board_full") {
-        const updated = await companies.update(targetCompany.id, {
-          name: sourceManifest.company.name,
-          description: sourceManifest.company.description,
-          brandColor: sourceManifest.company.brandColor,
-          attachmentMaxBytes: sourceManifest.company.attachmentMaxBytes ?? undefined,
-          requireBoardApprovalForNewAgents: sourceManifest.company.requireBoardApprovalForNewAgents,
-          feedbackDataSharingEnabled: sourceManifest.company.feedbackDataSharingEnabled,
-          feedbackDataSharingConsentAt: sourceManifest.company.feedbackDataSharingConsentAt
-            ? new Date(sourceManifest.company.feedbackDataSharingConsentAt)
-            : null,
-          feedbackDataSharingConsentByUserId: sourceManifest.company.feedbackDataSharingConsentByUserId,
-          feedbackDataSharingTermsVersion: sourceManifest.company.feedbackDataSharingTermsVersion,
-        });
-        targetCompany = updated ?? targetCompany;
-        companyAction = "updated";
+      if (!isBillingDisabled() && sourceMemberships.length > 1) {
+        throwFreeTierCapExceeded("invite");
       }
     }
 
-    if (!targetCompany) throw notFound("Target company not found");
-
-    if (include.company) {
-      const logoPath = sourceManifest.company?.logoPath ?? null;
-      if (!logoPath) {
-        const cleared = await companies.update(targetCompany.id, { logoAssetId: null });
-        targetCompany = cleared ?? targetCompany;
+    if (!isBillingDisabled() && plannedAgentCreates > 0) {
+      if (input.target.mode === "new_company") {
+        if (plannedAgentCreates > 1) {
+          throwFreeTierCapExceeded("hire");
+        }
       } else {
-        const logoFile = plan.source.files[logoPath];
-        if (!logoFile) {
-          warnings.push(`Skipped company logo import because ${logoPath} is missing from the package.`);
-        } else if (!storage) {
-          warnings.push("Skipped company logo import because storage is unavailable.");
+        const blockedAction = await exceededFreeTierCapacityAction(
+          tierCapacityDeps(db),
+          input.target.companyId,
+          { agents: plannedAgentCreates },
+        );
+        if (blockedAction) throwFreeTierCapExceeded(blockedAction);
+      }
+    }
+
+    async function holdExistingImportAgentCapacityLock(
+      companyId: string,
+      plannedAgents: number,
+    ): Promise<() => Promise<void>> {
+      let releaseLock: (() => void) | null = null;
+      const releasePromise = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+      });
+      let signalReady!: () => void;
+      let signalFailure!: (err: unknown) => void;
+      const readyPromise = new Promise<void>((resolve, reject) => {
+        signalReady = resolve;
+        signalFailure = reject;
+      });
+      const lockPromise = withCompanyTierCapacityLock(db, companyId, async (tx) => {
+        try {
+          const blockedAction = await exceededFreeTierCapacityAction(
+            tierCapacityDeps(tx),
+            companyId,
+            { agents: plannedAgents },
+          );
+          if (blockedAction) throwFreeTierCapExceeded(blockedAction);
+          signalReady();
+          await releasePromise;
+        } catch (err) {
+          signalFailure(err);
+          throw err;
+        }
+      });
+      try {
+        await readyPromise;
+      } catch (err) {
+        await lockPromise.catch(() => undefined);
+        throw err;
+      }
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        releaseLock?.();
+        await lockPromise;
+      };
+    }
+
+    let releaseExistingImportTierLock: (() => Promise<void>) | null = null;
+    if (
+      !isBillingDisabled()
+      && input.target.mode === "existing_company"
+      && plannedAgentCreates > 0
+    ) {
+      releaseExistingImportTierLock = await holdExistingImportAgentCapacityLock(
+        input.target.companyId,
+        plannedAgentCreates,
+      );
+    }
+
+    try {
+      let targetCompany: {
+        id: string;
+        name: string;
+        requireBoardApprovalForNewAgents?: boolean | null;
+        attachmentMaxBytes?: number | null;
+      } | null = null;
+      let companyAction: "created" | "updated" | "unchanged" = "unchanged";
+
+      if (input.target.mode === "new_company") {
+        const companyName =
+          asString(input.target.newCompanyName) ??
+          sourceManifest.company?.name ??
+          sourceManifest.source?.companyName ??
+          "Imported Company";
+        const created = await companies.create({
+          name: companyName,
+          description: include.company ? (sourceManifest.company?.description ?? null) : null,
+          brandColor: include.company ? (sourceManifest.company?.brandColor ?? null) : null,
+          attachmentMaxBytes: include.company
+            ? (sourceManifest.company?.attachmentMaxBytes ?? undefined)
+            : undefined,
+          requireBoardApprovalForNewAgents: include.company
+            ? (sourceManifest.company?.requireBoardApprovalForNewAgents ?? false)
+            : false,
+          feedbackDataSharingEnabled: include.company
+            ? (sourceManifest.company?.feedbackDataSharingEnabled ?? false)
+            : false,
+          feedbackDataSharingConsentAt: include.company && sourceManifest.company?.feedbackDataSharingConsentAt
+            ? new Date(sourceManifest.company.feedbackDataSharingConsentAt)
+            : null,
+          feedbackDataSharingConsentByUserId: include.company
+            ? (sourceManifest.company?.feedbackDataSharingConsentByUserId ?? null)
+            : null,
+          feedbackDataSharingTermsVersion: include.company
+            ? (sourceManifest.company?.feedbackDataSharingTermsVersion ?? null)
+            : null,
+        });
+        if (mode === "agent_safe" && options?.sourceCompanyId) {
+          await access.copyActiveUserMemberships(options.sourceCompanyId, created.id);
         } else {
-          const contentType = isPortableBinaryFile(logoFile)
-            ? (logoFile.contentType ?? inferContentTypeFromPath(logoPath))
-            : inferContentTypeFromPath(logoPath);
-          if (!contentType || !COMPANY_LOGO_CONTENT_TYPE_EXTENSIONS[contentType]) {
-            warnings.push(`Skipped company logo import for ${logoPath} because the file type is unsupported.`);
+          await access.ensureMembership(created.id, "user", actorUserId ?? "board", "owner", "active");
+        }
+        targetCompany = created;
+        companyAction = "created";
+      } else {
+        targetCompany = await companies.getById(input.target.companyId);
+        if (!targetCompany) throw notFound("Target company not found");
+        if (include.company && sourceManifest.company && mode === "board_full") {
+          const updated = await companies.update(targetCompany.id, {
+            name: sourceManifest.company.name,
+            description: sourceManifest.company.description,
+            brandColor: sourceManifest.company.brandColor,
+            attachmentMaxBytes: sourceManifest.company.attachmentMaxBytes ?? undefined,
+            requireBoardApprovalForNewAgents: sourceManifest.company.requireBoardApprovalForNewAgents,
+            feedbackDataSharingEnabled: sourceManifest.company.feedbackDataSharingEnabled,
+            feedbackDataSharingConsentAt: sourceManifest.company.feedbackDataSharingConsentAt
+              ? new Date(sourceManifest.company.feedbackDataSharingConsentAt)
+              : null,
+            feedbackDataSharingConsentByUserId: sourceManifest.company.feedbackDataSharingConsentByUserId,
+            feedbackDataSharingTermsVersion: sourceManifest.company.feedbackDataSharingTermsVersion,
+          });
+          targetCompany = updated ?? targetCompany;
+          companyAction = "updated";
+        }
+      }
+
+      if (!targetCompany) throw notFound("Target company not found");
+
+      if (include.company) {
+        const logoPath = sourceManifest.company?.logoPath ?? null;
+        if (!logoPath) {
+          const cleared = await companies.update(targetCompany.id, { logoAssetId: null });
+          targetCompany = cleared ?? targetCompany;
+        } else {
+          const logoFile = plan.source.files[logoPath];
+          if (!logoFile) {
+            warnings.push(`Skipped company logo import because ${logoPath} is missing from the package.`);
+          } else if (!storage) {
+            warnings.push("Skipped company logo import because storage is unavailable.");
           } else {
-            try {
-              const body = portableFileToBuffer(logoFile, logoPath);
-              const stored = await storage.putFile({
-                companyId: targetCompany.id,
-                namespace: "assets/companies",
-                originalFilename: path.posix.basename(logoPath),
-                contentType,
-                body,
-              });
-              const createdAsset = await assetRecords.create(targetCompany.id, {
-                provider: stored.provider,
-                objectKey: stored.objectKey,
-                contentType: stored.contentType,
-                byteSize: stored.byteSize,
-                sha256: stored.sha256,
-                originalFilename: stored.originalFilename,
-                createdByAgentId: null,
-                createdByUserId: actorUserId ?? null,
-              });
-              const updated = await companies.update(targetCompany.id, {
-                logoAssetId: createdAsset.id,
-              });
-              targetCompany = updated ?? targetCompany;
-            } catch (err) {
-              warnings.push(`Failed to import company logo ${logoPath}: ${err instanceof Error ? err.message : String(err)}`);
+            const contentType = isPortableBinaryFile(logoFile)
+              ? (logoFile.contentType ?? inferContentTypeFromPath(logoPath))
+              : inferContentTypeFromPath(logoPath);
+            if (!contentType || !COMPANY_LOGO_CONTENT_TYPE_EXTENSIONS[contentType]) {
+              warnings.push(`Skipped company logo import for ${logoPath} because the file type is unsupported.`);
+            } else {
+              try {
+                const body = portableFileToBuffer(logoFile, logoPath);
+                const stored = await storage.putFile({
+                  companyId: targetCompany.id,
+                  namespace: "assets/companies",
+                  originalFilename: path.posix.basename(logoPath),
+                  contentType,
+                  body,
+                });
+                const createdAsset = await assetRecords.create(targetCompany.id, {
+                  provider: stored.provider,
+                  objectKey: stored.objectKey,
+                  contentType: stored.contentType,
+                  byteSize: stored.byteSize,
+                  sha256: stored.sha256,
+                  originalFilename: stored.originalFilename,
+                  createdByAgentId: null,
+                  createdByUserId: actorUserId ?? null,
+                });
+                const updated = await companies.update(targetCompany.id, {
+                  logoAssetId: createdAsset.id,
+                });
+                targetCompany = updated ?? targetCompany;
+              } catch (err) {
+                warnings.push(`Failed to import company logo ${logoPath}: ${err instanceof Error ? err.message : String(err)}`);
+              }
             }
           }
         }
       }
-    }
 
-    const resultAgents: CompanyPortabilityImportResult["agents"] = [];
-    const resultProjects: CompanyPortabilityImportResult["projects"] = [];
-    const importedSlugToAgentId = new Map<string, string>();
-    const existingSlugToAgentId = new Map<string, string>();
-    const agentStatusById = new Map<string, string | null | undefined>();
-    const existingAgents = await agents.list(targetCompany.id);
-    for (const existing of existingAgents) {
-      existingSlugToAgentId.set(normalizeAgentUrlKey(existing.name) ?? existing.id, existing.id);
-      agentStatusById.set(existing.id, existing.status);
-    }
-    const importedSlugToProjectId = new Map<string, string>();
-    const importedProjectWorkspaceIdByProjectSlug = new Map<string, Map<string, string>>();
-    const existingProjectSlugToId = new Map<string, string>();
-    const existingProjects = await projects.list(targetCompany.id);
-    for (const existing of existingProjects) {
-      existingProjectSlugToId.set(existing.urlKey, existing.id);
-    }
-
-    const importedSkills = include.skills || include.agents
-      ? await companySkills.importPackageFiles(targetCompany.id, pickTextFiles(plan.source.files), {
-          onConflict: resolveSkillConflictStrategy(mode, plan.collisionStrategy),
-        })
-      : [];
-    const desiredSkillRefMap = new Map<string, string>();
-    for (const importedSkill of importedSkills) {
-      desiredSkillRefMap.set(importedSkill.originalKey, importedSkill.skill.key);
-      desiredSkillRefMap.set(importedSkill.originalSlug, importedSkill.skill.key);
-      if (importedSkill.action === "skipped") {
-        warnings.push(`Skipped skill ${importedSkill.originalSlug}; existing skill ${importedSkill.skill.slug} was kept.`);
-      } else if (importedSkill.originalKey !== importedSkill.skill.key) {
-        warnings.push(`Imported skill ${importedSkill.originalSlug} as ${importedSkill.skill.slug} to avoid overwriting an existing skill.`);
+      const resultAgents: CompanyPortabilityImportResult["agents"] = [];
+      const resultProjects: CompanyPortabilityImportResult["projects"] = [];
+      const importedSlugToAgentId = new Map<string, string>();
+      const existingSlugToAgentId = new Map<string, string>();
+      const agentStatusById = new Map<string, string | null | undefined>();
+      const existingAgents = await agents.list(targetCompany.id);
+      for (const existing of existingAgents) {
+        existingSlugToAgentId.set(normalizeAgentUrlKey(existing.name) ?? existing.id, existing.id);
+        agentStatusById.set(existing.id, existing.status);
       }
-    }
+      const importedSlugToProjectId = new Map<string, string>();
+      const importedProjectWorkspaceIdByProjectSlug = new Map<string, Map<string, string>>();
+      const existingProjectSlugToId = new Map<string, string>();
+      const existingProjects = await projects.list(targetCompany.id);
+      for (const existing of existingProjects) {
+        existingProjectSlugToId.set(existing.urlKey, existing.id);
+      }
 
-    if (include.agents) {
-      for (const planAgent of plan.preview.plan.agentPlans) {
-        const manifestAgent = plan.selectedAgents.find((agent) => agent.slug === planAgent.slug);
-        if (!manifestAgent) continue;
-        if (planAgent.action === "skip") {
-          resultAgents.push({
-            slug: planAgent.slug,
-            id: planAgent.existingAgentId,
-            action: "skipped",
-            name: planAgent.plannedName,
-            reason: planAgent.reason,
-          });
-          continue;
+      const importedSkills = include.skills || include.agents
+        ? await companySkills.importPackageFiles(targetCompany.id, pickTextFiles(plan.source.files), {
+            onConflict: resolveSkillConflictStrategy(mode, plan.collisionStrategy),
+          })
+        : [];
+      const desiredSkillRefMap = new Map<string, string>();
+      for (const importedSkill of importedSkills) {
+        desiredSkillRefMap.set(importedSkill.originalKey, importedSkill.skill.key);
+        desiredSkillRefMap.set(importedSkill.originalSlug, importedSkill.skill.key);
+        if (importedSkill.action === "skipped") {
+          warnings.push(`Skipped skill ${importedSkill.originalSlug}; existing skill ${importedSkill.skill.slug} was kept.`);
+        } else if (importedSkill.originalKey !== importedSkill.skill.key) {
+          warnings.push(`Imported skill ${importedSkill.originalSlug} as ${importedSkill.skill.slug} to avoid overwriting an existing skill.`);
         }
+      }
 
-        const bundlePrefix = `agents/${manifestAgent.slug}/`;
-        const bundleFiles = Object.fromEntries(
-          Object.entries(plan.source.files)
-            .filter(([filePath]) => filePath.startsWith(bundlePrefix))
-            .flatMap(([filePath, content]) => typeof content === "string"
-              ? [[normalizePortablePath(filePath.slice(bundlePrefix.length)), content] as const]
-              : []),
-        );
-        const markdownRaw = bundleFiles["AGENTS.md"] ?? readPortableTextFile(plan.source.files, manifestAgent.path);
-        const entryRelativePath = normalizePortablePath(manifestAgent.path).startsWith(bundlePrefix)
-          ? normalizePortablePath(manifestAgent.path).slice(bundlePrefix.length)
-          : "AGENTS.md";
-        if (typeof markdownRaw === "string") {
-          const importedInstructionsBody = parseFrontmatterMarkdown(markdownRaw).body;
-          bundleFiles[entryRelativePath] = importedInstructionsBody;
-          if (entryRelativePath !== "AGENTS.md") {
-            bundleFiles["AGENTS.md"] = importedInstructionsBody;
-          }
-        }
-        const fallbackPromptTemplate = asString((manifestAgent.adapterConfig as Record<string, unknown>).promptTemplate) || "";
-        if (!markdownRaw && fallbackPromptTemplate) {
-          bundleFiles["AGENTS.md"] = fallbackPromptTemplate;
-        }
-        if (!markdownRaw && !fallbackPromptTemplate) {
-          warnings.push(`Missing AGENTS markdown for ${manifestAgent.slug}; imported with an empty managed bundle.`);
-        }
-
-        // Apply adapter overrides from request if present
-        const adapterOverride = input.adapterOverrides?.[planAgent.slug];
-        const baseAdapterConfig = adapterOverride?.adapterConfig
-          ? { ...adapterOverride.adapterConfig }
-          : { ...manifestAgent.adapterConfig } as Record<string, unknown>;
-
-        const desiredSkills = (manifestAgent.skills ?? []).map((skillRef) => desiredSkillRefMap.get(skillRef) ?? skillRef);
-        const normalizedAdapter = await prepareImportedAgentAdapter(
-          targetCompany.id,
-          adapterOverride?.adapterType ?? manifestAgent.adapterType,
-          baseAdapterConfig,
-          desiredSkills,
-          mode,
-        );
-        const patch = {
-          name: planAgent.plannedName,
-          role: manifestAgent.role,
-          title: manifestAgent.title,
-          icon: manifestAgent.icon,
-          capabilities: manifestAgent.capabilities,
-          reportsTo: null,
-          adapterType: normalizedAdapter.adapterType,
-          adapterConfig: normalizedAdapter.adapterConfig,
-          runtimeConfig: disableImportedTimerHeartbeat(manifestAgent.runtimeConfig),
-          budgetMonthlyCents: manifestAgent.budgetMonthlyCents,
-          permissions: manifestAgent.permissions,
-          metadata: manifestAgent.metadata,
-        };
-
-        if (planAgent.action === "update" && planAgent.existingAgentId) {
-          let updated = await agents.update(planAgent.existingAgentId, patch);
-          if (!updated) {
-            warnings.push(`Skipped update for missing agent ${planAgent.existingAgentId}.`);
+      if (include.agents) {
+        for (const planAgent of plan.preview.plan.agentPlans) {
+          const manifestAgent = plan.selectedAgents.find((agent) => agent.slug === planAgent.slug);
+          if (!manifestAgent) continue;
+          if (planAgent.action === "skip") {
             resultAgents.push({
               slug: planAgent.slug,
-              id: null,
+              id: planAgent.existingAgentId,
               action: "skipped",
               name: planAgent.plannedName,
-              reason: "Existing target agent not found.",
+              reason: planAgent.reason,
             });
             continue;
           }
-          try {
-            const materialized = await instructions.materializeManagedBundle(updated, bundleFiles, {
-              clearLegacyPromptTemplate: true,
-              replaceExisting: true,
-            });
-            updated = await agents.update(updated.id, { adapterConfig: materialized.adapterConfig }) ?? updated;
-          } catch (err) {
-            warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
+
+          const bundlePrefix = `agents/${manifestAgent.slug}/`;
+          const bundleFiles = Object.fromEntries(
+            Object.entries(plan.source.files)
+              .filter(([filePath]) => filePath.startsWith(bundlePrefix))
+              .flatMap(([filePath, content]) => typeof content === "string"
+                ? [[normalizePortablePath(filePath.slice(bundlePrefix.length)), content] as const]
+                : []),
+          );
+          const markdownRaw = bundleFiles["AGENTS.md"] ?? readPortableTextFile(plan.source.files, manifestAgent.path);
+          const entryRelativePath = normalizePortablePath(manifestAgent.path).startsWith(bundlePrefix)
+            ? normalizePortablePath(manifestAgent.path).slice(bundlePrefix.length)
+            : "AGENTS.md";
+          if (typeof markdownRaw === "string") {
+            const importedInstructionsBody = parseFrontmatterMarkdown(markdownRaw).body;
+            bundleFiles[entryRelativePath] = importedInstructionsBody;
+            if (entryRelativePath !== "AGENTS.md") {
+              bundleFiles["AGENTS.md"] = importedInstructionsBody;
+            }
           }
-          agentStatusById.set(updated.id, updated.status ?? agentStatusById.get(updated.id) ?? null);
-          importedSlugToAgentId.set(planAgent.slug, updated.id);
-          existingSlugToAgentId.set(normalizeAgentUrlKey(updated.name) ?? updated.id, updated.id);
+          const fallbackPromptTemplate = asString((manifestAgent.adapterConfig as Record<string, unknown>).promptTemplate) || "";
+          if (!markdownRaw && fallbackPromptTemplate) {
+            bundleFiles["AGENTS.md"] = fallbackPromptTemplate;
+          }
+          if (!markdownRaw && !fallbackPromptTemplate) {
+            warnings.push(`Missing AGENTS markdown for ${manifestAgent.slug}; imported with an empty managed bundle.`);
+          }
+
+          // Apply adapter overrides from request if present
+          const adapterOverride = input.adapterOverrides?.[planAgent.slug];
+          const baseAdapterConfig = adapterOverride?.adapterConfig
+            ? { ...adapterOverride.adapterConfig }
+            : { ...manifestAgent.adapterConfig } as Record<string, unknown>;
+
+          const desiredSkills = (manifestAgent.skills ?? []).map((skillRef) => desiredSkillRefMap.get(skillRef) ?? skillRef);
+          const normalizedAdapter = await prepareImportedAgentAdapter(
+            targetCompany.id,
+            adapterOverride?.adapterType ?? manifestAgent.adapterType,
+            baseAdapterConfig,
+            desiredSkills,
+            mode,
+          );
+          const patch = {
+            name: planAgent.plannedName,
+            role: manifestAgent.role,
+            title: manifestAgent.title,
+            icon: manifestAgent.icon,
+            capabilities: manifestAgent.capabilities,
+            reportsTo: null,
+            adapterType: normalizedAdapter.adapterType,
+            adapterConfig: normalizedAdapter.adapterConfig,
+            runtimeConfig: disableImportedTimerHeartbeat(manifestAgent.runtimeConfig),
+            budgetMonthlyCents: manifestAgent.budgetMonthlyCents,
+            permissions: manifestAgent.permissions,
+            metadata: manifestAgent.metadata,
+          };
+
+          if (planAgent.action === "update" && planAgent.existingAgentId) {
+            let updated = await agents.update(planAgent.existingAgentId, patch);
+            if (!updated) {
+              warnings.push(`Skipped update for missing agent ${planAgent.existingAgentId}.`);
+              resultAgents.push({
+                slug: planAgent.slug,
+                id: null,
+                action: "skipped",
+                name: planAgent.plannedName,
+                reason: "Existing target agent not found.",
+              });
+              continue;
+            }
+            try {
+              const materialized = await instructions.materializeManagedBundle(updated, bundleFiles, {
+                clearLegacyPromptTemplate: true,
+                replaceExisting: true,
+              });
+              updated = await agents.update(updated.id, { adapterConfig: materialized.adapterConfig }) ?? updated;
+            } catch (err) {
+              warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
+            }
+            agentStatusById.set(updated.id, updated.status ?? agentStatusById.get(updated.id) ?? null);
+            importedSlugToAgentId.set(planAgent.slug, updated.id);
+            existingSlugToAgentId.set(normalizeAgentUrlKey(updated.name) ?? updated.id, updated.id);
+            resultAgents.push({
+              slug: planAgent.slug,
+              id: updated.id,
+              action: "updated",
+              name: updated.name,
+              reason: planAgent.reason,
+            });
+            continue;
+          }
+
+            const createdStatus = "idle";
+            const createImportedAgent = async (dbOrTx: Db) => {
+              const txAgents = agentService(dbOrTx);
+              const txAccess = accessService(dbOrTx);
+              let scopedCreated = await txAgents.create(targetCompany.id, {
+                ...patch,
+                status: createdStatus,
+              });
+              await txAccess.ensureMembership(targetCompany.id, "agent", scopedCreated.id, "member", "active");
+              await txAccess.setPrincipalPermission(
+                targetCompany.id,
+                "agent",
+                scopedCreated.id,
+                "tasks:assign",
+                true,
+                actorUserId ?? null,
+              );
+              try {
+                const materialized = await instructions.materializeManagedBundle(scopedCreated, bundleFiles, {
+                  clearLegacyPromptTemplate: true,
+                  replaceExisting: true,
+                });
+                scopedCreated = await txAgents.update(scopedCreated.id, { adapterConfig: materialized.adapterConfig }) ?? scopedCreated;
+              } catch (err) {
+                warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
+              }
+              return scopedCreated;
+            };
+            const created = releaseExistingImportTierLock
+              ? await createImportedAgent(db)
+              : await withCompanyTierCapacityGuard(
+                db,
+                targetCompany.id,
+                { agents: 1 },
+                tierCapacityDeps,
+                throwFreeTierCapExceeded,
+                createImportedAgent,
+              );
+          if (!created) continue;
+          agentStatusById.set(created.id, created.status ?? createdStatus);
+          importedSlugToAgentId.set(planAgent.slug, created.id);
+          existingSlugToAgentId.set(normalizeAgentUrlKey(created.name) ?? created.id, created.id);
           resultAgents.push({
             slug: planAgent.slug,
-            id: updated.id,
-            action: "updated",
-            name: updated.name,
-            reason: planAgent.reason,
-          });
-          continue;
-        }
-
-        const createdStatus = "idle";
-        let created = await agents.create(targetCompany.id, {
-          ...patch,
-          status: createdStatus,
-        });
-        await access.ensureMembership(targetCompany.id, "agent", created.id, "member", "active");
-        await access.setPrincipalPermission(
-          targetCompany.id,
-          "agent",
-          created.id,
-          "tasks:assign",
-          true,
-          actorUserId ?? null,
-        );
-        try {
-          const materialized = await instructions.materializeManagedBundle(created, bundleFiles, {
-            clearLegacyPromptTemplate: true,
-            replaceExisting: true,
-          });
-          created = await agents.update(created.id, { adapterConfig: materialized.adapterConfig }) ?? created;
-        } catch (err) {
-          warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-        agentStatusById.set(created.id, created.status ?? createdStatus);
-        importedSlugToAgentId.set(planAgent.slug, created.id);
-        existingSlugToAgentId.set(normalizeAgentUrlKey(created.name) ?? created.id, created.id);
-        resultAgents.push({
-          slug: planAgent.slug,
-          id: created.id,
-          action: "created",
-          name: created.name,
-          reason: planAgent.reason,
-        });
-      }
-
-      // Apply reporting links once all imported agent ids are available.
-      for (const manifestAgent of plan.selectedAgents) {
-        const agentId = importedSlugToAgentId.get(manifestAgent.slug);
-        if (!agentId) continue;
-        const managerSlug = manifestAgent.reportsToSlug;
-        if (!managerSlug) continue;
-        const managerId = importedSlugToAgentId.get(managerSlug) ?? existingSlugToAgentId.get(managerSlug) ?? null;
-        if (!managerId || managerId === agentId) continue;
-        try {
-          await agents.update(agentId, { reportsTo: managerId });
-        } catch {
-          warnings.push(`Could not assign manager ${managerSlug} for imported agent ${manifestAgent.slug}.`);
-        }
-      }
-    }
-
-    if (include.projects) {
-      for (const planProject of plan.preview.plan.projectPlans) {
-        const manifestProject = sourceManifest.projects.find((project) => project.slug === planProject.slug);
-        if (!manifestProject) continue;
-        if (planProject.action === "skip") {
-          resultProjects.push({
-            slug: planProject.slug,
-            id: planProject.existingProjectId,
-            action: "skipped",
-            name: planProject.plannedName,
-            reason: planProject.reason,
-          });
-          continue;
-        }
-
-        const projectLeadAgentId = manifestProject.leadAgentSlug
-          ? importedSlugToAgentId.get(manifestProject.leadAgentSlug)
-            ?? existingSlugToAgentId.get(manifestProject.leadAgentSlug)
-            ?? null
-          : null;
-        const projectWorkspaceIdByKey = new Map<string, string>();
-        const projectPatch = {
-          name: planProject.plannedName,
-          description: manifestProject.description,
-          leadAgentId: projectLeadAgentId,
-          targetDate: manifestProject.targetDate,
-          color: manifestProject.color,
-          status: manifestProject.status && PROJECT_STATUSES.includes(manifestProject.status as any)
-            ? manifestProject.status as typeof PROJECT_STATUSES[number]
-            : "backlog",
-          env: manifestProject.env,
-          executionWorkspacePolicy: stripPortableProjectExecutionWorkspaceRefs(manifestProject.executionWorkspacePolicy),
-        };
-
-        let projectId: string | null = null;
-        if (planProject.action === "update" && planProject.existingProjectId) {
-          const updated = await projects.update(planProject.existingProjectId, projectPatch);
-          if (!updated) {
-            warnings.push(`Skipped update for missing project ${planProject.existingProjectId}.`);
-            resultProjects.push({
-              slug: planProject.slug,
-              id: null,
-              action: "skipped",
-              name: planProject.plannedName,
-              reason: "Existing target project not found.",
-            });
-            continue;
-          }
-          projectId = updated.id;
-          importedSlugToProjectId.set(planProject.slug, updated.id);
-          existingProjectSlugToId.set(updated.urlKey, updated.id);
-          resultProjects.push({
-            slug: planProject.slug,
-            id: updated.id,
-            action: "updated",
-            name: updated.name,
-            reason: planProject.reason,
-          });
-        } else {
-          const created = await projects.create(targetCompany.id, projectPatch);
-          projectId = created.id;
-          importedSlugToProjectId.set(planProject.slug, created.id);
-          existingProjectSlugToId.set(created.urlKey, created.id);
-          resultProjects.push({
-            slug: planProject.slug,
             id: created.id,
             action: "created",
             name: created.name,
-            reason: planProject.reason,
+            reason: planAgent.reason,
           });
         }
 
-        if (!projectId) continue;
-
-        for (const workspace of manifestProject.workspaces) {
-          const createdWorkspace = await projects.createWorkspace(projectId, {
-            name: workspace.name,
-            sourceType: workspace.sourceType ?? undefined,
-            repoUrl: workspace.repoUrl ?? undefined,
-            repoRef: workspace.repoRef ?? undefined,
-            defaultRef: workspace.defaultRef ?? undefined,
-            visibility: workspace.visibility ?? undefined,
-            setupCommand: workspace.setupCommand ?? undefined,
-            cleanupCommand: workspace.cleanupCommand ?? undefined,
-            metadata: workspace.metadata ?? undefined,
-            isPrimary: workspace.isPrimary,
-          });
-          if (!createdWorkspace) {
-            warnings.push(`Project ${planProject.slug} workspace ${workspace.key} could not be created during import.`);
-            continue;
+        // Apply reporting links once all imported agent ids are available.
+        for (const manifestAgent of plan.selectedAgents) {
+          const agentId = importedSlugToAgentId.get(manifestAgent.slug);
+          if (!agentId) continue;
+          const managerSlug = manifestAgent.reportsToSlug;
+          if (!managerSlug) continue;
+          const managerId = importedSlugToAgentId.get(managerSlug) ?? existingSlugToAgentId.get(managerSlug) ?? null;
+          if (!managerId || managerId === agentId) continue;
+          try {
+            await agents.update(agentId, { reportsTo: managerId });
+          } catch {
+            warnings.push(`Could not assign manager ${managerSlug} for imported agent ${manifestAgent.slug}.`);
           }
-          projectWorkspaceIdByKey.set(workspace.key, createdWorkspace.id);
-        }
-        importedProjectWorkspaceIdByProjectSlug.set(planProject.slug, projectWorkspaceIdByKey);
-
-        const hydratedProjectExecutionWorkspacePolicy = importPortableProjectExecutionWorkspacePolicy(
-          planProject.slug,
-          manifestProject.executionWorkspacePolicy,
-          projectWorkspaceIdByKey,
-          warnings,
-        );
-        if (hydratedProjectExecutionWorkspacePolicy) {
-          await projects.update(projectId, {
-            executionWorkspacePolicy: hydratedProjectExecutionWorkspacePolicy,
-          });
         }
       }
-    }
 
-    if (include.issues) {
-      const routines = routineService(db);
-      for (const manifestIssue of sourceManifest.issues) {
-        const markdownRaw = readPortableTextFile(plan.source.files, manifestIssue.path);
-        const parsed = markdownRaw ? parseFrontmatterMarkdown(markdownRaw) : null;
-        const description = parsed?.body || manifestIssue.description || null;
-        const assigneeAgentId = resolveImportedAssigneeAgentId(
-          manifestIssue.assigneeAgentSlug,
-          importedSlugToAgentId,
-          existingSlugToAgentId,
-          agentStatusById,
-          warnings,
-          `Task ${manifestIssue.slug}`,
-        );
-        const projectId = manifestIssue.projectSlug
-          ? importedSlugToProjectId.get(manifestIssue.projectSlug)
-            ?? existingProjectSlugToId.get(manifestIssue.projectSlug)
-            ?? null
-          : null;
-        const projectWorkspaceId = manifestIssue.projectSlug && manifestIssue.projectWorkspaceKey
-          ? importedProjectWorkspaceIdByProjectSlug.get(manifestIssue.projectSlug)?.get(manifestIssue.projectWorkspaceKey) ?? null
-          : null;
-        if (manifestIssue.projectWorkspaceKey && !projectWorkspaceId) {
-          warnings.push(`Task ${manifestIssue.slug} references workspace key ${manifestIssue.projectWorkspaceKey}, but that workspace was not imported.`);
-        }
-        if (manifestIssue.recurring) {
-          if (!projectId) {
-            throw unprocessable(`Recurring task ${manifestIssue.slug} is missing the project required to create a routine.`);
+      if (include.projects) {
+        for (const planProject of plan.preview.plan.projectPlans) {
+          const manifestProject = sourceManifest.projects.find((project) => project.slug === planProject.slug);
+          if (!manifestProject) continue;
+          if (planProject.action === "skip") {
+            resultProjects.push({
+              slug: planProject.slug,
+              id: planProject.existingProjectId,
+              action: "skipped",
+              name: planProject.plannedName,
+              reason: planProject.reason,
+            });
+            continue;
           }
-          const resolvedRoutine = resolvePortableRoutineDefinition(manifestIssue, parsed?.frontmatter.schedule);
-          if (resolvedRoutine.errors.length > 0) {
-            throw unprocessable(`Recurring task ${manifestIssue.slug} could not be imported as a routine: ${resolvedRoutine.errors.join("; ")}`);
-          }
-          warnings.push(...resolvedRoutine.warnings);
-          const routineDefinition = resolvedRoutine.routine ?? {
-            concurrencyPolicy: null,
-            catchUpPolicy: null,
-            variables: null,
-            triggers: [],
+
+          const projectLeadAgentId = manifestProject.leadAgentSlug
+            ? importedSlugToAgentId.get(manifestProject.leadAgentSlug)
+              ?? existingSlugToAgentId.get(manifestProject.leadAgentSlug)
+              ?? null
+            : null;
+          const projectWorkspaceIdByKey = new Map<string, string>();
+          const projectPatch = {
+            name: planProject.plannedName,
+            description: manifestProject.description,
+            leadAgentId: projectLeadAgentId,
+            targetDate: manifestProject.targetDate,
+            color: manifestProject.color,
+            status: manifestProject.status && PROJECT_STATUSES.includes(manifestProject.status as any)
+              ? manifestProject.status as typeof PROJECT_STATUSES[number]
+              : "backlog",
+            env: manifestProject.env,
+            executionWorkspacePolicy: stripPortableProjectExecutionWorkspaceRefs(manifestProject.executionWorkspacePolicy),
           };
-          const createdRoutine = await routines.create(targetCompany.id, {
-            projectId,
-            goalId: null,
-            parentIssueId: null,
-            title: manifestIssue.title,
-            description,
-            assigneeAgentId,
-            priority: manifestIssue.priority && ISSUE_PRIORITIES.includes(manifestIssue.priority as any)
-              ? manifestIssue.priority as typeof ISSUE_PRIORITIES[number]
-              : "medium",
-            status: manifestIssue.status && ROUTINE_STATUSES.includes(manifestIssue.status as any)
-              ? manifestIssue.status as typeof ROUTINE_STATUSES[number]
-              : "active",
-            concurrencyPolicy:
-              routineDefinition.concurrencyPolicy && ROUTINE_CONCURRENCY_POLICIES.includes(routineDefinition.concurrencyPolicy as any)
-                ? routineDefinition.concurrencyPolicy as typeof ROUTINE_CONCURRENCY_POLICIES[number]
-                : "coalesce_if_active",
-            catchUpPolicy:
-              routineDefinition.catchUpPolicy && ROUTINE_CATCH_UP_POLICIES.includes(routineDefinition.catchUpPolicy as any)
-                ? routineDefinition.catchUpPolicy as typeof ROUTINE_CATCH_UP_POLICIES[number]
-                : "skip_missed",
-            variables: routineDefinition.variables ?? [],
-          }, {
-            agentId: null,
-            userId: actorUserId ?? null,
-          });
-          for (const trigger of routineDefinition.triggers) {
-            if (trigger.kind === "schedule") {
-              await routines.createTrigger(createdRoutine.id, {
-                kind: "schedule",
-                label: trigger.label,
-                enabled: trigger.enabled,
-                cronExpression: trigger.cronExpression!,
-                timezone: trigger.timezone!,
-              }, {
-                agentId: null,
-                userId: actorUserId ?? null,
+
+          let projectId: string | null = null;
+          if (planProject.action === "update" && planProject.existingProjectId) {
+            const updated = await projects.update(planProject.existingProjectId, projectPatch);
+            if (!updated) {
+              warnings.push(`Skipped update for missing project ${planProject.existingProjectId}.`);
+              resultProjects.push({
+                slug: planProject.slug,
+                id: null,
+                action: "skipped",
+                name: planProject.plannedName,
+                reason: "Existing target project not found.",
               });
               continue;
             }
-            if (trigger.kind === "webhook") {
-              await routines.createTrigger(createdRoutine.id, {
-                kind: "webhook",
-                label: trigger.label,
-                enabled: trigger.enabled,
-                signingMode:
-                  trigger.signingMode && ROUTINE_TRIGGER_SIGNING_MODES.includes(trigger.signingMode as any)
-                    ? trigger.signingMode as typeof ROUTINE_TRIGGER_SIGNING_MODES[number]
-                    : "bearer",
-                replayWindowSec: trigger.replayWindowSec ?? 300,
-              }, {
-                agentId: null,
-                userId: actorUserId ?? null,
-              });
+            projectId = updated.id;
+            importedSlugToProjectId.set(planProject.slug, updated.id);
+            existingProjectSlugToId.set(updated.urlKey, updated.id);
+            resultProjects.push({
+              slug: planProject.slug,
+              id: updated.id,
+              action: "updated",
+              name: updated.name,
+              reason: planProject.reason,
+            });
+          } else {
+            const created = await projects.create(targetCompany.id, projectPatch);
+            projectId = created.id;
+            importedSlugToProjectId.set(planProject.slug, created.id);
+            existingProjectSlugToId.set(created.urlKey, created.id);
+            resultProjects.push({
+              slug: planProject.slug,
+              id: created.id,
+              action: "created",
+              name: created.name,
+              reason: planProject.reason,
+            });
+          }
+
+          if (!projectId) continue;
+
+          for (const workspace of manifestProject.workspaces) {
+            const createdWorkspace = await projects.createWorkspace(projectId, {
+              name: workspace.name,
+              sourceType: workspace.sourceType ?? undefined,
+              repoUrl: workspace.repoUrl ?? undefined,
+              repoRef: workspace.repoRef ?? undefined,
+              defaultRef: workspace.defaultRef ?? undefined,
+              visibility: workspace.visibility ?? undefined,
+              setupCommand: workspace.setupCommand ?? undefined,
+              cleanupCommand: workspace.cleanupCommand ?? undefined,
+              metadata: workspace.metadata ?? undefined,
+              isPrimary: workspace.isPrimary,
+            });
+            if (!createdWorkspace) {
+              warnings.push(`Project ${planProject.slug} workspace ${workspace.key} could not be created during import.`);
               continue;
             }
-            await routines.createTrigger(createdRoutine.id, {
-              kind: "api",
-              label: trigger.label,
-              enabled: trigger.enabled,
+            projectWorkspaceIdByKey.set(workspace.key, createdWorkspace.id);
+          }
+          importedProjectWorkspaceIdByProjectSlug.set(planProject.slug, projectWorkspaceIdByKey);
+
+          const hydratedProjectExecutionWorkspacePolicy = importPortableProjectExecutionWorkspacePolicy(
+            planProject.slug,
+            manifestProject.executionWorkspacePolicy,
+            projectWorkspaceIdByKey,
+            warnings,
+          );
+          if (hydratedProjectExecutionWorkspacePolicy) {
+            await projects.update(projectId, {
+              executionWorkspacePolicy: hydratedProjectExecutionWorkspacePolicy,
+            });
+          }
+        }
+      }
+
+      if (include.issues) {
+        const routines = routineService(db);
+        for (const manifestIssue of sourceManifest.issues) {
+          const markdownRaw = readPortableTextFile(plan.source.files, manifestIssue.path);
+          const parsed = markdownRaw ? parseFrontmatterMarkdown(markdownRaw) : null;
+          const description = parsed?.body || manifestIssue.description || null;
+          const assigneeAgentId = resolveImportedAssigneeAgentId(
+            manifestIssue.assigneeAgentSlug,
+            importedSlugToAgentId,
+            existingSlugToAgentId,
+            agentStatusById,
+            warnings,
+            `Task ${manifestIssue.slug}`,
+          );
+          const projectId = manifestIssue.projectSlug
+            ? importedSlugToProjectId.get(manifestIssue.projectSlug)
+              ?? existingProjectSlugToId.get(manifestIssue.projectSlug)
+              ?? null
+            : null;
+          const projectWorkspaceId = manifestIssue.projectSlug && manifestIssue.projectWorkspaceKey
+            ? importedProjectWorkspaceIdByProjectSlug.get(manifestIssue.projectSlug)?.get(manifestIssue.projectWorkspaceKey) ?? null
+            : null;
+          if (manifestIssue.projectWorkspaceKey && !projectWorkspaceId) {
+            warnings.push(`Task ${manifestIssue.slug} references workspace key ${manifestIssue.projectWorkspaceKey}, but that workspace was not imported.`);
+          }
+          if (manifestIssue.recurring) {
+            if (!projectId) {
+              throw unprocessable(`Recurring task ${manifestIssue.slug} is missing the project required to create a routine.`);
+            }
+            const resolvedRoutine = resolvePortableRoutineDefinition(manifestIssue, parsed?.frontmatter.schedule);
+            if (resolvedRoutine.errors.length > 0) {
+              throw unprocessable(`Recurring task ${manifestIssue.slug} could not be imported as a routine: ${resolvedRoutine.errors.join("; ")}`);
+            }
+            warnings.push(...resolvedRoutine.warnings);
+            const routineDefinition = resolvedRoutine.routine ?? {
+              concurrencyPolicy: null,
+              catchUpPolicy: null,
+              variables: null,
+              triggers: [],
+            };
+            const createdRoutine = await routines.create(targetCompany.id, {
+              projectId,
+              goalId: null,
+              parentIssueId: null,
+              title: manifestIssue.title,
+              description,
+              assigneeAgentId,
+              priority: manifestIssue.priority && ISSUE_PRIORITIES.includes(manifestIssue.priority as any)
+                ? manifestIssue.priority as typeof ISSUE_PRIORITIES[number]
+                : "medium",
+              status: manifestIssue.status && ROUTINE_STATUSES.includes(manifestIssue.status as any)
+                ? manifestIssue.status as typeof ROUTINE_STATUSES[number]
+                : "active",
+              concurrencyPolicy:
+                routineDefinition.concurrencyPolicy && ROUTINE_CONCURRENCY_POLICIES.includes(routineDefinition.concurrencyPolicy as any)
+                  ? routineDefinition.concurrencyPolicy as typeof ROUTINE_CONCURRENCY_POLICIES[number]
+                  : "coalesce_if_active",
+              catchUpPolicy:
+                routineDefinition.catchUpPolicy && ROUTINE_CATCH_UP_POLICIES.includes(routineDefinition.catchUpPolicy as any)
+                  ? routineDefinition.catchUpPolicy as typeof ROUTINE_CATCH_UP_POLICIES[number]
+                  : "skip_missed",
+              variables: routineDefinition.variables ?? [],
             }, {
               agentId: null,
               userId: actorUserId ?? null,
             });
+            for (const trigger of routineDefinition.triggers) {
+              if (trigger.kind === "schedule") {
+                await routines.createTrigger(createdRoutine.id, {
+                  kind: "schedule",
+                  label: trigger.label,
+                  enabled: trigger.enabled,
+                  cronExpression: trigger.cronExpression!,
+                  timezone: trigger.timezone!,
+                }, {
+                  agentId: null,
+                  userId: actorUserId ?? null,
+                });
+                continue;
+              }
+              if (trigger.kind === "webhook") {
+                await routines.createTrigger(createdRoutine.id, {
+                  kind: "webhook",
+                  label: trigger.label,
+                  enabled: trigger.enabled,
+                  signingMode:
+                    trigger.signingMode && ROUTINE_TRIGGER_SIGNING_MODES.includes(trigger.signingMode as any)
+                      ? trigger.signingMode as typeof ROUTINE_TRIGGER_SIGNING_MODES[number]
+                      : "bearer",
+                  replayWindowSec: trigger.replayWindowSec ?? 300,
+                }, {
+                  agentId: null,
+                  userId: actorUserId ?? null,
+                });
+                continue;
+              }
+              await routines.createTrigger(createdRoutine.id, {
+                kind: "api",
+                label: trigger.label,
+                enabled: trigger.enabled,
+              }, {
+                agentId: null,
+                userId: actorUserId ?? null,
+              });
+            }
+            continue;
           }
-          continue;
+          let issueStatus = manifestIssue.status && ISSUE_STATUSES.includes(manifestIssue.status as any)
+            ? manifestIssue.status as typeof ISSUE_STATUSES[number]
+            : "backlog";
+          if (!assigneeAgentId && issueStatus === "in_progress") {
+            warnings.push(`Task ${manifestIssue.slug} was downgraded to todo because its assignee could not be imported as assignable work.`);
+            issueStatus = "todo";
+          }
+          await issues.create(targetCompany.id, {
+            projectId,
+            projectWorkspaceId,
+            title: manifestIssue.title,
+            description,
+            assigneeAgentId,
+            status: issueStatus,
+            priority: manifestIssue.priority && ISSUE_PRIORITIES.includes(manifestIssue.priority as any)
+              ? manifestIssue.priority as typeof ISSUE_PRIORITIES[number]
+              : "medium",
+            billingCode: manifestIssue.billingCode,
+            assigneeAdapterOverrides: manifestIssue.assigneeAdapterOverrides,
+            executionWorkspaceSettings: manifestIssue.executionWorkspaceSettings,
+            labelIds: manifestIssue.labelIds ?? [],
+          });
         }
-        let issueStatus = manifestIssue.status && ISSUE_STATUSES.includes(manifestIssue.status as any)
-          ? manifestIssue.status as typeof ISSUE_STATUSES[number]
-          : "backlog";
-        if (!assigneeAgentId && issueStatus === "in_progress") {
-          warnings.push(`Task ${manifestIssue.slug} was downgraded to todo because its assignee could not be imported as assignable work.`);
-          issueStatus = "todo";
-        }
-        await issues.create(targetCompany.id, {
-          projectId,
-          projectWorkspaceId,
-          title: manifestIssue.title,
-          description,
-          assigneeAgentId,
-          status: issueStatus,
-          priority: manifestIssue.priority && ISSUE_PRIORITIES.includes(manifestIssue.priority as any)
-            ? manifestIssue.priority as typeof ISSUE_PRIORITIES[number]
-            : "medium",
-          billingCode: manifestIssue.billingCode,
-          assigneeAdapterOverrides: manifestIssue.assigneeAdapterOverrides,
-          executionWorkspaceSettings: manifestIssue.executionWorkspaceSettings,
-          labelIds: manifestIssue.labelIds ?? [],
-        });
       }
-    }
 
-    return {
-      company: {
-        id: targetCompany.id,
-        name: targetCompany.name,
-        action: companyAction,
-      },
-      agents: resultAgents,
-      projects: resultProjects,
-      envInputs: sourceManifest.envInputs ?? [],
-      warnings,
-    };
+      return {
+        company: {
+          id: targetCompany.id,
+          name: targetCompany.name,
+          action: companyAction,
+        },
+        agents: resultAgents,
+        projects: resultProjects,
+        envInputs: sourceManifest.envInputs ?? [],
+        warnings,
+      };
+    } finally {
+      if (releaseExistingImportTierLock) await releaseExistingImportTierLock();
+    }
   }
 
   return {

--- a/server/src/services/cos-reviewer-auto-hire.ts
+++ b/server/src/services/cos-reviewer-auto-hire.ts
@@ -8,6 +8,12 @@ import {
 import { COS_REVIEW_DEFAULTS } from "@paperclipai/shared";
 import { logActivity } from "./activity-log.js";
 import { agentService } from "./agents.js";
+import { companyService } from "./companies.js";
+import {
+  exceededFreeTierCapacityAction,
+  isBillingDisabled,
+  lockCompanyTierCapacity,
+} from "./tier-policy.js";
 
 export type AutoHireReason = "queue_depth" | "neutrality_conflict";
 
@@ -159,7 +165,41 @@ export function cosReviewerAutoHire(db: Db, deps: AutoHireDeps = {}) {
         }
       }
 
-      // 4. Hire path. System-initiated: programmatic, no approval gate.
+      // 4. Tier-cap gate. This service has its own transaction for reviewer
+      // convergence; take the shared tier advisory lock inside that same
+      // transaction so auto-hire cannot race other agent-creation paths.
+      const txDb = tx as unknown as Db;
+      if (!isBillingDisabled()) {
+        await lockCompanyTierCapacity(txDb, companyId);
+        const blockedTierAction = await exceededFreeTierCapacityAction(
+          {
+            getCompany: async (id) => {
+              const company = await companyService(txDb).getById(id);
+              return { planTier: company?.planTier ?? "free" };
+            },
+            counts: {
+              humans: async () => 0,
+              agents: async (id) => (await agentService(txDb).list(id)).length,
+            },
+          },
+          companyId,
+          { agents: 1 },
+        );
+        if (blockedTierAction) {
+          await logActivity(txDb, {
+            companyId,
+            actorType: "system",
+            actorId: "cos_reviewer_auto_hire",
+            action: "reviewer_hire_throttled",
+            entityType: "company",
+            entityId: companyId,
+            details: { reason, activeCount, tierCapAction: blockedTierAction },
+          });
+          return { hired: false, reason: "cap_reached", activeCount };
+        }
+      }
+
+      // 5. Hire path. System-initiated: programmatic, no approval gate.
       const reviewerName = `CoS Reviewer ${new Date().toISOString().slice(0, 19)}`;
       const created = deps.createAgent
         ? await deps.createAgent(companyId, "reviewer", reviewerName)

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -75,7 +75,10 @@ export { cosOnboardingStateService } from "./cos-onboarding-state.js";
 export { agentSummoner } from "./agent-summoner.js";
 export { activityRouter } from "./activity-router.js";
 export { cosProactive } from "./cos-proactive.js";
-export { onboardingOrchestrator } from "./onboarding-orchestrator.js";
+export {
+  onboardingOrchestrator,
+  OnboardingTierCapacityExceededError,
+} from "./onboarding-orchestrator.js";
 export { cosInterview } from "./cos-interview.js";
 export { agentProposer } from "./agent-proposer.js";
 export { agentCreatorFromProposal } from "./agent-creator-from-proposal.js";

--- a/server/src/services/onboarding-orchestrator.ts
+++ b/server/src/services/onboarding-orchestrator.ts
@@ -1,6 +1,13 @@
 import { logger } from "../middleware/logger.js";
 import { deriveCompanyEmailDomain } from "@paperclipai/shared";
 import { SingleCompanyInstallationError } from "./companies.js";
+import {
+  exceededFreeTierCapacityAction,
+  freeTierCapExceededPayload,
+  type TierCapAction,
+  type TierCapacityAdds,
+  type TierCapacityDeps,
+} from "./tier-policy.js";
 
 // AgentDash (#102): true when the single-company-installation constraint should
 // be bypassed. Mirrors the same check in server/src/routes/companies.ts.
@@ -47,7 +54,7 @@ async function postWelcomeSequence(
   });
 }
 
-interface Deps {
+interface BootstrapServices {
   access: any;          // accessService(db)
   companies: any;       // companyService(db)
   agents: any;          // agentService(db)
@@ -56,10 +63,32 @@ interface Deps {
   users: any;           // user lookup (auth-users service or direct query)
 }
 
+interface Deps extends BootstrapServices {
+  tierCapacity?: {
+    withCompanyLock<T>(
+      companyId: string,
+      work: (services: BootstrapServices) => Promise<T>,
+    ): Promise<T>;
+    capacityDepsFor(services: BootstrapServices): TierCapacityDeps;
+  };
+}
+
 interface BootstrapResult {
   companyId: string;
   cosAgentId: string;
   conversationId: string;
+}
+
+export class OnboardingTierCapacityExceededError extends Error {
+  readonly action: TierCapAction;
+  readonly code: string;
+
+  constructor(action: TierCapAction) {
+    const payload = freeTierCapExceededPayload(action);
+    super(payload.message);
+    this.action = action;
+    this.code = payload.code;
+  }
 }
 
 // In `local_trusted` deployment mode, the synthetic actor has userId="local-board"
@@ -77,6 +106,105 @@ function resolveLocalUser(userId: string): { id: string; email: string | null } 
 }
 
 export function onboardingOrchestrator(deps: Deps) {
+  async function assertBootstrapTierCapacity(
+    services: BootstrapServices,
+    companyId: string,
+    adds: TierCapacityAdds,
+  ) {
+    if (!deps.tierCapacity) return;
+    const blockedAction = await exceededFreeTierCapacityAction(
+      deps.tierCapacity.capacityDepsFor(services),
+      companyId,
+      adds,
+    );
+    if (blockedAction) throw new OnboardingTierCapacityExceededError(blockedAction);
+  }
+
+  async function finalizeBootstrap(
+    services: BootstrapServices,
+    company: { id: string; name?: string; emailDomain?: string | null },
+    user: { id: string; email: string | null; name?: string | null },
+  ): Promise<BootstrapResult> {
+    const currentMemberships = await services.access.listUserCompanyAccess(user.id);
+    const hasActiveMembership = currentMemberships.some(
+      (m: any) => m.companyId === company.id && m.status === "active",
+    );
+
+    // Step 3 needs the current agent list under the same capacity lock. That
+    // makes concurrent bootstrap calls observe any CoS created by the previous
+    // transaction before deciding whether this request consumes the free agent
+    // slot.
+    const existing = (await services.agents.list?.(company.id)) ?? [];
+    let cos = existing.find((a: any) => a.role === "chief_of_staff");
+
+    await assertBootstrapTierCapacity(services, company.id, {
+      humans: hasActiveMembership ? 0 : 1,
+      agents: cos ? 0 : 1,
+    });
+
+    // Step 2: grant agents:create FIRST (before owner promotion — see GH #72).
+    await services.access.setPrincipalPermission(
+      company.id,
+      "user",
+      user.id,
+      "agents:create",
+      true,
+      user.id,
+    );
+    await services.access.ensureMembership(company.id, "user", user.id, "owner", "active");
+
+    // Step 3: ensure a Chief of Staff agent exists.
+    if (!cos) {
+      const created = await services.agents.create(company.id, {
+        name: "Chief of Staff",
+        role: "chief_of_staff",
+        adapterType: (process.env.AGENTDASH_DEFAULT_ADAPTER ?? "claude_local").trim() || "claude_local",
+        adapterConfig: {},
+        status: "idle",
+        spentMonthlyCents: 0,
+        lastHeartbeatAt: null,
+      });
+      // Materialize the default chief_of_staff bundle.
+      const bundleFiles = await loadCosBundleFiles();
+      const materialized = await services.instructions.materializeManagedBundle(
+        created,
+        bundleFiles,
+        { entryFile: "AGENTS.md", replaceExisting: false },
+      );
+      cos = { ...created, adapterConfig: materialized.adapterConfig };
+    }
+
+    // Step 4: ensure CoS has an API key (carry from GH #71 — but POST handler creates it; here we
+    // need to make sure it exists if the agent was created by another path).
+    // For idempotency simplicity: just always ensure one key exists.
+    const existingKeys = (await services.agents.listKeys?.(cos.id)) ?? [];
+    if (existingKeys.length === 0) {
+      await services.agents.createApiKey(cos.id, "default");
+    }
+
+    // Step 5: ensure a conversation exists for this company; add the user as participant.
+    // The fresh-conversation branch is the atomic point: conversations.create only
+    // succeeds once per workspace, so we post the welcome sequence here. This
+    // eliminates the read-then-write race that the old route-handler check had.
+    let conversation = await services.conversations.findByCompany(company.id);
+    const isFreshConversation = !conversation;
+    if (!conversation) {
+      conversation = await services.conversations.create({ companyId: company.id, userId: user.id });
+    }
+    await services.conversations.addParticipant(conversation.id, user.id, "owner");
+    if (isFreshConversation) {
+      await postWelcomeSequence(services.conversations, conversation.id, cos.id, user.name);
+    }
+
+    logger.info({ userId: user.id, companyId: company.id, cosAgentId: cos.id, conversationId: conversation.id }, "onboarding bootstrap complete");
+
+    return {
+      companyId: company.id,
+      cosAgentId: cos.id,
+      conversationId: conversation.id,
+    };
+  }
+
   return {
     bootstrap: async (userId: string): Promise<BootstrapResult> => {
       // Try the real auth_users lookup first; fall back to local-trusted sentinel.
@@ -163,69 +291,10 @@ export function onboardingOrchestrator(deps: Deps) {
         }
       }
 
-      // Step 2: grant agents:create FIRST (before owner promotion — see GH #72).
-      await deps.access.setPrincipalPermission(
-        company.id,
-        "user",
-        userId,
-        "agents:create",
-        true,
-        userId,
+      if (!deps.tierCapacity) return finalizeBootstrap(deps, company, user);
+      return deps.tierCapacity.withCompanyLock(company.id, (services) =>
+        finalizeBootstrap(services, company, user),
       );
-      await deps.access.ensureMembership(company.id, "user", userId, "owner", "active");
-
-      // Step 3: ensure a Chief of Staff agent exists.
-      const existing = (await deps.agents.list?.(company.id)) ?? [];
-      let cos = existing.find((a: any) => a.role === "chief_of_staff");
-      if (!cos) {
-        const created = await deps.agents.create(company.id, {
-          name: "Chief of Staff",
-          role: "chief_of_staff",
-          adapterType: (process.env.AGENTDASH_DEFAULT_ADAPTER ?? "claude_local").trim() || "claude_local",
-          adapterConfig: {},
-          status: "idle",
-          spentMonthlyCents: 0,
-          lastHeartbeatAt: null,
-        });
-        // Materialize the default chief_of_staff bundle.
-        const bundleFiles = await loadCosBundleFiles();
-        const materialized = await deps.instructions.materializeManagedBundle(
-          created,
-          bundleFiles,
-          { entryFile: "AGENTS.md", replaceExisting: false },
-        );
-        cos = { ...created, adapterConfig: materialized.adapterConfig };
-      }
-
-      // Step 4: ensure CoS has an API key (carry from GH #71 — but POST handler creates it; here we
-      // need to make sure it exists if the agent was created by another path).
-      // For idempotency simplicity: just always ensure one key exists.
-      const existingKeys = (await deps.agents.listKeys?.(cos.id)) ?? [];
-      if (existingKeys.length === 0) {
-        await deps.agents.createApiKey(cos.id, "default");
-      }
-
-      // Step 5: ensure a conversation exists for this company; add the user as participant.
-      // The fresh-conversation branch is the atomic point: conversations.create only
-      // succeeds once per workspace, so we post the welcome sequence here. This
-      // eliminates the read-then-write race that the old route-handler check had.
-      let conversation = await deps.conversations.findByCompany(company.id);
-      const isFreshConversation = !conversation;
-      if (!conversation) {
-        conversation = await deps.conversations.create({ companyId: company.id, userId });
-      }
-      await deps.conversations.addParticipant(conversation.id, userId, "owner");
-      if (isFreshConversation) {
-        await postWelcomeSequence(deps.conversations, conversation.id, cos.id, user.name);
-      }
-
-      logger.info({ userId, companyId: company.id, cosAgentId: cos.id, conversationId: conversation.id }, "onboarding bootstrap complete");
-
-      return {
-        companyId: company.id,
-        cosAgentId: cos.id,
-        conversationId: conversation.id,
-      };
     },
   };
 }

--- a/server/src/services/tier-policy.ts
+++ b/server/src/services/tier-policy.ts
@@ -1,0 +1,176 @@
+import { createHash } from "node:crypto";
+import { sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+
+export type TierCapAction = "invite" | "hire";
+export type TierInviteJoinType = "human" | "agent" | "both";
+
+export interface TierCapacityDeps {
+  getCompany: (id: string) => Promise<{ planTier: string }>;
+  counts: {
+    humans: (companyId: string) => Promise<number>;
+    agents: (companyId: string) => Promise<number>;
+  };
+}
+
+export interface TierCapacityAdds {
+  humans?: number;
+  agents?: number;
+}
+
+// AgentDash (#157): pro_past_due is intentionally excluded. Past-due
+// customers do not get Pro features until they resolve the payment issue.
+const PRO_LIVE = new Set(["pro_trial", "pro_active"]);
+
+export function isProLivePlanTier(planTier: string | null | undefined): boolean {
+  return PRO_LIVE.has(planTier ?? "free");
+}
+
+/**
+ * Billing is "disabled" and all caps bypass when the operator explicitly opts
+ * out via AGENTDASH_BILLING_DISABLED=true, or when no Stripe key is configured.
+ * Production deployments set STRIPE_SECRET_KEY, so caps are enforced there.
+ */
+export function isBillingDisabled(): boolean {
+  if (process.env.AGENTDASH_BILLING_DISABLED === "true") return true;
+  if (!process.env.STRIPE_SECRET_KEY) return true;
+  return false;
+}
+
+export function freeTierCapExceededPayload(action: TierCapAction) {
+  if (action === "invite") {
+    return {
+      code: "seat_cap_exceeded",
+      message: "Free workspaces are limited to 1 user. Upgrade to Pro to invite teammates.",
+    } as const;
+  }
+  return {
+    code: "agent_cap_exceeded",
+    message: "Free workspaces include only the Chief of Staff. Upgrade to Pro to hire more agents.",
+  } as const;
+}
+
+export async function exceededFreeTierCapacityAction(
+  deps: TierCapacityDeps,
+  companyId: string,
+  adds: TierCapacityAdds,
+): Promise<TierCapAction | null> {
+  if (isBillingDisabled()) return null;
+
+  const company = await deps.getCompany(companyId);
+  if (isProLivePlanTier(company.planTier)) return null;
+
+  const humansToAdd = adds.humans ?? 0;
+  if (humansToAdd > 0) {
+    const humans = await deps.counts.humans(companyId);
+    if (humans + humansToAdd > 1) return "invite";
+  }
+
+  const agentsToAdd = adds.agents ?? 0;
+  if (agentsToAdd > 0) {
+    const agents = await deps.counts.agents(companyId);
+    if (agents + agentsToAdd > 1) return "hire";
+  }
+
+  return null;
+}
+
+export async function exceededFreeTierInviteCapacityAction(
+  deps: TierCapacityDeps,
+  companyId: string,
+  allowedJoinTypes: TierInviteJoinType,
+): Promise<TierCapAction | null> {
+  if (allowedJoinTypes === "human") {
+    return exceededFreeTierCapacityAction(deps, companyId, { humans: 1 });
+  }
+  if (allowedJoinTypes === "agent") {
+    return exceededFreeTierCapacityAction(deps, companyId, { agents: 1 });
+  }
+
+  // A "both" invite is usable when at least one accepted join type still has
+  // room. Approval remains the authoritative capacity-consuming write.
+  const humanBlocked = await exceededFreeTierCapacityAction(deps, companyId, {
+    humans: 1,
+  });
+  if (!humanBlocked) return null;
+
+  const agentBlocked = await exceededFreeTierCapacityAction(deps, companyId, {
+    agents: 1,
+  });
+  return agentBlocked ? humanBlocked : null;
+}
+
+function companyTierCapacityLockKey(companyId: string): number {
+  return Number.parseInt(
+    createHash("sha256").update(`tier-cap:${companyId}`).digest("hex").slice(0, 12),
+    16,
+  );
+}
+
+export async function withCompanyTierCapacityLock<T>(
+  db: Db,
+  companyId: string,
+  work: (tx: Db) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    await lockCompanyTierCapacity(tx as unknown as Db, companyId);
+    return work(tx as unknown as Db);
+  });
+}
+
+export async function lockCompanyTierCapacity(
+  dbOrTx: Pick<Db, "execute">,
+  companyId: string,
+): Promise<void> {
+  await dbOrTx.execute(
+    sql`SELECT pg_advisory_xact_lock(${companyTierCapacityLockKey(companyId)})`,
+  );
+}
+
+export async function withCompanyTierCapacityGuard<T>(
+  db: Db,
+  companyId: string,
+  adds: TierCapacityAdds,
+  depsFor: (dbOrTx: Db) => TierCapacityDeps,
+  onExceeded: (action: TierCapAction) => void,
+  work: (dbOrTx: Db) => Promise<T>,
+): Promise<T | null> {
+  if (isBillingDisabled()) return work(db);
+
+  return withCompanyTierCapacityLock(db, companyId, async (tx) => {
+    const blockedAction = await exceededFreeTierCapacityAction(
+      depsFor(tx),
+      companyId,
+      adds,
+    );
+    if (blockedAction) {
+      onExceeded(blockedAction);
+      return null;
+    }
+    return work(tx);
+  });
+}
+
+export async function withCompanyTierInviteCapacityGuard<T>(
+  db: Db,
+  companyId: string,
+  allowedJoinTypes: TierInviteJoinType,
+  depsFor: (dbOrTx: Db) => TierCapacityDeps,
+  onExceeded: (action: TierCapAction) => void,
+  work: (dbOrTx: Db) => Promise<T>,
+): Promise<T | null> {
+  if (isBillingDisabled()) return work(db);
+
+  return withCompanyTierCapacityLock(db, companyId, async (tx) => {
+    const blockedAction = await exceededFreeTierInviteCapacityAction(
+      depsFor(tx),
+      companyId,
+      allowedJoinTypes,
+    );
+    if (blockedAction) {
+      onExceeded(blockedAction);
+      return null;
+    }
+    return work(tx);
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @paperclipai/ui build",
+  "outputDirectory": "ui/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "outputDirectory": "ui/dist",
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/:path((?!api/|api$).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Thinking Path

> - Paperclip/AgentDash is a control plane for AI-agent companies, with billing tiers governing how much human and agent capacity a company can use.
> - The Free launch path is supposed to support one human user and one agent, normally the Chief of Staff, while Pro removes those caps.
> - Existing checks were mostly route preflights, which left several capacity-consuming writes able to create a second human or agent through onboarding, approvals, admin grants, auto-hire, and company import paths.
> - A target-machine Free-tier UAT needs the product to fail closed in production billing mode before asking real users to upgrade.
> - This pull request centralizes tier capacity policy, applies locked rechecks around every capacity write found in the audit, and updates agent prompt surfaces so worker agents escalate plan-limit 402s instead of retrying through alternate paths.
> - After opening the PR, the Vercel preview check also exposed that the project was configured to look for a `public` output directory after a successful build; this PR adds a minimal root `vercel.json` so previews serve the built Vite UI from `ui/dist`.
> - The benefit is a Free single-seat tier that is enforceable, race-aware, regression-covered, and deployable to the preview surface used for launch review.

## What Changed

- Added `server/src/services/tier-policy.ts` with shared Free-tier policy, production billing enablement checks, cap-exceeded payloads, and advisory-lock guarded capacity helpers.
- Rewired `requireTierFor` and direct write paths to use the shared policy: agent creation/hiring, invites, OpenClaw invite prompts, join approvals, approval-driven hires, instance-admin company access grants, onboarding v2, onboarding orchestration, CoS reviewer auto-hire, and billing reconciliation preflights.
- Hardened company import so new Free companies reject multi-human/multi-agent packages before state writes, and existing-company imports recheck capacity under lock before importing skills or creating agents.
- Preserved idempotent retry behavior for already-resolved approvals/join requests so a resolved retry does not become a new 402.
- Added regression coverage for every audited Free-tier capacity path, including the existing-company import race/no-partial-skill-import case.
- Updated the four required AgentDash agent prompt surfaces with `free-tier-capacity` guidance for `seat_cap_exceeded` and `agent_cap_exceeded` responses.
- Added `vercel.json` so Vercel previews run the UI build and publish `ui/dist` instead of failing on a missing `public` directory.

## Verification

- `pnpm exec vitest run server/src/__tests__/company-portability.test.ts server/src/__tests__/admin-company-access-tier-route.test.ts server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/approval-routes-idempotency.test.ts server/src/__tests__/cos-reviewer-auto-hire.test.ts server/src/__tests__/onboarding-orchestrator.test.ts server/src/__tests__/onboarding-v2-routes.test.ts server/src/__tests__/join-approval-tier-route.test.ts server/src/__tests__/invite-create-route.test.ts server/src/__tests__/openclaw-invite-prompt-route.test.ts server/src/__tests__/require-tier.test.ts server/src/__tests__/build-tier-deps.test.ts`
- `pnpm exec vitest run server/src/__tests__/agent-creator-from-proposal.test.ts`
- `pnpm exec vitest run server/src/__tests__/agent-instruction-refresh.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run`
- `pnpm --filter @paperclipai/ui build`
- `jq . vercel.json`
- `npx vercel inspect dpl_2jTax4KhPXyQnacNJY7Gs97bDXxP --logs` confirmed the prior Vercel failure was a missing `public` output directory after a successful build.
- `git diff --check`
- AI slop cleanup pass over changed files: no masking fallback slop found. Existing fallback-like matches were classified as grounded compatibility/fail-safe behavior: billing-disabled local dev bypass, adapter-environment compatibility probes, company import skip strategies, and email-send skipped status.
- Independent reviews before the final prompt/deploy-config amendments: code review recommendation `APPROVE`; architecture review `CLEAR`.

## Risks

- Broad diff: 27 files and more than the usual 500 LOC budget. This stayed as one PR because the bug is cross-cutting: splitting policy from write-path guards would leave launch-blocking bypasses in place.
- Production behavior changes only when billing is configured (`STRIPE_SECRET_KEY`) and not explicitly disabled. Local dev and CI without Stripe continue to bypass caps unless tests opt into billing.
- Company portability has the largest mechanical diff because the existing-company import mutation body now holds a pre-mutation capacity lock until import completion to avoid partial skill imports under a race.
- Vercel previews are configured as static UI previews. Server/API deployment on Vercel remains out of scope for this PR.
- `pnpm test:run` emits existing noisy test logs and warnings from unrelated suites, but completed successfully.
- Target-machine Hermes/browser UAT is in progress against this PR branch and will complete before the ultragoal is marked complete.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex in the Codex desktop app, GPT-5 class model with tool use, local shell execution, GitHub CLI, and Codex subagents for review/architecture verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
