### PR TITLE
Keep test suites isolated from host billing env

### DIFF
--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -3,6 +3,9 @@ import request from "supertest";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { ServerAdapterModule } from "../adapters/index.js";
 
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
+
 const mockAgentService = vi.hoisted(() => ({
   create: vi.fn(),
   getById: vi.fn(),
@@ -194,6 +197,7 @@ async function unregisterTestAdapter(type: string) {
 
 describe("agent routes adapter validation", () => {
   beforeEach(async () => {
+    process.env.AGENTDASH_BILLING_DISABLED = "true";
     vi.resetModules();
     vi.doUnmock("../routes/agents.js");
     vi.doUnmock("../routes/authz.js");
@@ -239,6 +243,10 @@ describe("agent routes adapter validation", () => {
   afterEach(async () => {
     await unregisterTestAdapter("external_test");
     await unregisterTestAdapter(missingAdapterType);
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("creates agents for dynamically registered external adapter types", async () => {

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -1,6 +1,9 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const originalBillingDisabled = process.env.AGENTDASH_BILLING_DISABLED;
 
 const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
@@ -245,6 +248,7 @@ function makeAgent(adapterType: string) {
 
 describe.sequential("agent skill routes", () => {
   beforeEach(() => {
+    process.env.AGENTDASH_BILLING_DISABLED = "true";
     vi.resetModules();
     vi.doUnmock("../routes/agents.js");
     vi.doUnmock("../routes/authz.js");
@@ -358,6 +362,13 @@ describe.sequential("agent skill routes", () => {
       token: "agk_test_token",
       createdAt: new Date("2026-05-02T00:00:00.000Z"),
     });
+  });
+
+  afterEach(() => {
+    if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
+    else process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    if (originalBillingDisabled === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+    else process.env.AGENTDASH_BILLING_DISABLED = originalBillingDisabled;
   });
 
   it("skips runtime materialization when listing Claude skills", async () => {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -7,6 +7,8 @@ const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
 const ORIGINAL_RUN_HEALER_ENABLED = process.env.RUN_HEALER_ENABLED;
 const ORIGINAL_RUN_HEALER_SCAN_INTERVAL_MS = process.env.RUN_HEALER_SCAN_INTERVAL_MS;
+const ORIGINAL_STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+const ORIGINAL_AGENTDASH_BILLING_DISABLED = process.env.AGENTDASH_BILLING_DISABLED;
 
 const {
   createAppMock,
@@ -219,6 +221,17 @@ vi.mock("../auth/better-auth.js", () => ({
 }));
 
 import { startServer } from "../index.ts";
+
+beforeEach(() => {
+  process.env.AGENTDASH_BILLING_DISABLED = "true";
+});
+
+afterEach(() => {
+  if (ORIGINAL_STRIPE_SECRET_KEY === undefined) delete process.env.STRIPE_SECRET_KEY;
+  else process.env.STRIPE_SECRET_KEY = ORIGINAL_STRIPE_SECRET_KEY;
+  if (ORIGINAL_AGENTDASH_BILLING_DISABLED === undefined) delete process.env.AGENTDASH_BILLING_DISABLED;
+  else process.env.AGENTDASH_BILLING_DISABLED = ORIGINAL_AGENTDASH_BILLING_DISABLED;
+});
 
 function restoreRunHealerEnv() {
   if (ORIGINAL_RUN_HEALER_ENABLED === undefined) delete process.env.RUN_HEALER_ENABLED;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - AgentDash's Free-tier launch path now runs target-machine validation with dummy Stripe credentials so cap enforcement is exercised.
> - Several existing route/startup test suites are not billing-cap suites, but they inherited `STRIPE_SECRET_KEY` from the host test process.
> - That made mocked route/startup tests enter billing-enabled code paths and fail on infrastructure they were not meant to cover.
> - This pull request isolates those tests from host billing state by explicitly disabling billing inside the affected suites and restoring the caller environment afterward.
> - The benefit is deterministic regression testing on target machines that intentionally set Stripe env vars for Free-tier UAT.

## What Changed

- Set `AGENTDASH_BILLING_DISABLED=true` during `agent-skills-routes`, `agent-adapter-validation-routes`, and `server-startup-feedback-export` tests.
- Restore `STRIPE_SECRET_KEY` and `AGENTDASH_BILLING_DISABLED` after each affected test so other billing-cap suites remain free to opt in.
- Filed and addresses target-machine issue #374.

## Verification

- `STRIPE_SECRET_KEY=sk_test_fake STRIPE_WEBHOOK_SECRET=whsec_fake pnpm exec vitest run server/src/__tests__/agent-skills-routes.test.ts server/src/__tests__/agent-adapter-validation-routes.test.ts server/src/__tests__/server-startup-feedback-export.test.ts`
- `pnpm -r typecheck`
- `pnpm build`

## Risks

- Low risk. This changes only test setup for suites that do not assert billing-cap behavior.
- Billing-cap behavior remains covered by dedicated Free-tier suites that explicitly enable Stripe test env.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.5, high reasoning, with shell/tool execution and target-machine Hermes supervision.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge