### PR TITLE
fix(ui): connection-loss and rate-limit resilience

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -3,13 +3,20 @@ const BASE = "/api";
 export class ApiError extends Error {
   status: number;
   body: unknown;
+  retryAfterMs: number | null;
 
-  constructor(message: string, status: number, body: unknown) {
+  constructor(message: string, status: number, body: unknown, retryAfterMs: number | null = null) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.body = body;
+    this.retryAfterMs = retryAfterMs;
   }
+}
+
+export function isRetryableError(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  return error.status === 0 || error.status === 429 || error.status >= 500;
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -56,10 +63,19 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
         }
       }
     }
+    let retryAfterMs: number | null = null;
+    if (res.status === 429) {
+      const retryAfter = res.headers.get("Retry-After");
+      if (retryAfter) {
+        const seconds = parseInt(retryAfter, 10);
+        retryAfterMs = Number.isFinite(seconds) ? seconds * 1000 : null;
+      }
+    }
     throw new ApiError(
       (errorBody as { error?: string } | null)?.error ?? `Request failed: ${res.status}`,
       res.status,
       errorBody,
+      retryAfterMs,
     );
   }
   if (res.status === 204) return undefined as T;

--- a/ui/src/components/ServerUnreachableOverlay.tsx
+++ b/ui/src/components/ServerUnreachableOverlay.tsx
@@ -1,19 +1,10 @@
 import { useServerHealth } from "@/hooks/useServerHealth";
+import { useQueryClient } from "@tanstack/react-query";
 
 export function ServerUnreachableOverlay() {
-  const { reachability, isOnline } = useServerHealth();
+  const { reachability, isOnline, recheck } = useServerHealth();
+  const queryClient = useQueryClient();
 
-  // Closes #233: previously this only short-circuited on "reachable", so
-  // on first mount react-query was "checking" → the full-screen overlay
-  // flashed for 50ms–2s before the first /api/health response landed,
-  // regressing cold-load UX vs. having no overlay at all. The hook now
-  // only flips to "unreachable" after UNREACHABLE_THRESHOLD consecutive
-  // failures (per #229), so "checking" no longer warrants the full-screen
-  // takeover — at most a quiet indicator (which ConnectionStatus handles).
-  //
-  // The browser-offline branch is independent: if navigator says we have
-  // no network, we still want to surface the overlay regardless of the
-  // health-check state.
   const isBrowserOffline = !isOnline;
   if (!isBrowserOffline && reachability !== "unreachable") return null;
   const message = isBrowserOffline
@@ -51,8 +42,8 @@ export function ServerUnreachableOverlay() {
           {reachability === "unreachable" && (
             <button
               onClick={() => {
-                // Force refetch all queries to trigger a retry
-                window.location.reload();
+                recheck();
+                queryClient.invalidateQueries();
               }}
               className="px-4 py-2 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors text-sm"
             >
@@ -63,7 +54,8 @@ export function ServerUnreachableOverlay() {
 
         {reachability === "unreachable" && (
           <p className="text-xs text-muted-foreground">
-            If this persists, the server may be restarting. Try again in a moment.
+            Automatically retrying every few seconds.
+            If this persists, the server may be restarting.
           </p>
         )}
       </div>

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -982,6 +982,7 @@ export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
         }
         if (reconnectAttempt > 0) {
           gateRef.current.suppressUntil = Date.now() + RECONNECT_SUPPRESS_MS;
+          queryClient.invalidateQueries({ queryKey: ["serverHealth"] });
         }
         reconnectAttempt = 0;
       };

--- a/ui/src/hooks/useServerHealth.ts
+++ b/ui/src/hooks/useServerHealth.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 const HEALTH_POLL_INTERVAL_MS = 30_000;
+const HEALTH_POLL_FAST_MS = 5_000;
 // Number of consecutive failed polls before reachability flips to
 // "unreachable" (and the overlay shows). One failure = "checking" only —
 // avoids spurious overlays on transient blips.
@@ -13,6 +14,7 @@ interface ServerHealth {
   reachability: ServerReachability;
   lastCheck: Date | null;
   isOnline: boolean; // browser navigator.onLine
+  recheck: () => void;
 }
 
 async function checkHealth(): Promise<boolean> {
@@ -44,10 +46,13 @@ async function checkHealth(): Promise<boolean> {
 //      Now sourced from react-query's `dataUpdatedAt` (the timestamp of
 //      the most recently completed fetch).
 export function useServerHealth(): ServerHealth {
+  const queryClient = useQueryClient();
   const [isOnline, setIsOnline] = useState(
     typeof navigator !== "undefined" ? navigator.onLine : true,
   );
   const [unreachableConsecutive, setUnreachableConsecutive] = useState(0);
+
+  const isHealthy = unreachableConsecutive === 0;
 
   const {
     data: isReachable,
@@ -56,9 +61,9 @@ export function useServerHealth(): ServerHealth {
   } = useQuery({
     queryKey: ["serverHealth"],
     queryFn: checkHealth,
-    refetchInterval: HEALTH_POLL_INTERVAL_MS,
+    refetchInterval: isHealthy ? HEALTH_POLL_INTERVAL_MS : HEALTH_POLL_FAST_MS,
     retry: false,
-    staleTime: HEALTH_POLL_INTERVAL_MS - 1_000,
+    staleTime: (isHealthy ? HEALTH_POLL_INTERVAL_MS : HEALTH_POLL_FAST_MS) - 1_000,
   });
 
   // Track consecutive unreachable results — drives the "checking" badge
@@ -101,9 +106,21 @@ export function useServerHealth(): ServerHealth {
     };
   }, []);
 
+  const recheck = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["serverHealth"] });
+  }, [queryClient]);
+
+  // When the browser comes back online, immediately recheck
+  useEffect(() => {
+    if (isOnline && unreachableConsecutive > 0) {
+      recheck();
+    }
+  }, [isOnline, unreachableConsecutive, recheck]);
+
   return {
     reachability,
     lastCheck: dataUpdatedAt > 0 ? new Date(dataUpdatedAt) : null,
     isOnline,
+    recheck,
   };
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from "@/lib/router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { ApiError, isRetryableError } from "./api/client";
 import { CompanyProvider } from "./context/CompanyContext";
 import { LiveUpdatesProvider } from "./context/LiveUpdatesProvider";
 import { BreadcrumbProvider } from "./context/BreadcrumbContext";
@@ -43,6 +44,16 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 30_000,
       refetchOnWindowFocus: true,
+      retry(failureCount, error) {
+        if (!isRetryableError(error)) return false;
+        return failureCount < 3;
+      },
+      retryDelay(attemptIndex, error) {
+        if (error instanceof ApiError && error.retryAfterMs) {
+          return Math.min(error.retryAfterMs, 30_000);
+        }
+        return Math.min(1000 * 2 ** attemptIndex, 15_000);
+      },
     },
   },
 });


### PR DESCRIPTION
## Problem
The "Connection Lost" overlay appeared on transient network blips and lingered 30–60s after the server recovered. Rate-limited (429) requests retried immediately without respecting `Retry-After`, hammering an already-throttled server.

## Fixes
- **`client.ts`** — `ApiError` parses `Retry-After` into `retryAfterMs`; new `isRetryableError()` (network / 429 / 5xx only).
- **`main.tsx`** — global React Query retry policy: exponential backoff that respects `Retry-After` (cap 30s); skips retries on 4xx client errors.
- **`useServerHealth.ts`** — polls every 5s during failure (was 30s) for fast recovery; exposes `recheck()`; auto-rechecks when the browser comes back online.
- **`ServerUnreachableOverlay.tsx`** — "Retry" now actually retries (health recheck + query invalidation) instead of reloading the page.
- **`LiveUpdatesProvider.tsx`** — WebSocket reconnect triggers an immediate health recheck so the overlay clears without waiting for the next poll.

## Verification
- `pnpm -r typecheck` ✅
- `pnpm test:run` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)