### PR TITLE
feat(agent-creator): avatar studio Phase 0 + feature-flag-gated treatments

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { DashboardLive } from "./pages/DashboardLive";
 import { Companies } from "./pages/Companies";
 import { Agents } from "./pages/Agents";
 import { AgentDetail } from "./pages/AgentDetail";
+import { AgentCreatorStudio } from "./pages/AgentCreatorStudio";
 import { Projects } from "./pages/Projects";
 import { ProjectDetail } from "./pages/ProjectDetail";
 import { ProjectWorkspaceDetail } from "./pages/ProjectWorkspaceDetail";
@@ -104,6 +105,7 @@ function boardRoutes() {
       <Route path="agents/paused" element={<Agents />} />
       <Route path="agents/error" element={<Agents />} />
       <Route path="agents/new" element={<NewAgent />} />
+      <Route path="agents/new/studio" element={<AgentCreatorStudio />} />
       <Route path="agents/:agentId" element={<AgentDetail />} />
       <Route path="agents/:agentId/:tab" element={<AgentDetail />} />
       <Route path="agents/:agentId/runs/:runId" element={<AgentDetail />} />

--- a/ui/src/components/agent-creator/avatar/AgentAvatar.tsx
+++ b/ui/src/components/agent-creator/avatar/AgentAvatar.tsx
@@ -1,0 +1,35 @@
+// AgentDash: avatar figure for the agent creator. Delegates to one of two
+// aesthetic treatments behind a shared prop contract so they can be compared.
+import type {
+  AvatarSlotId,
+  AvatarVariant,
+  EquippedAvatarItem,
+} from "./avatar-geometry";
+import { AvatarRestrained } from "./AvatarRestrained";
+import { AvatarPlayful } from "./AvatarPlayful";
+
+export interface AgentAvatarProps {
+  variant: AvatarVariant;
+  /** Lucide icon name shown at the head node (reuses AGENT_ICON_NAMES). */
+  iconName?: string | null;
+  /** Agent accent color — a CSS color value or custom-property reference. */
+  colorToken?: string;
+  name?: string;
+  equipped: readonly EquippedAvatarItem[];
+  securityOn?: boolean;
+  /** Capability coverage 0..100. */
+  coverage?: number;
+  /** Slot currently hovered during a drag (wired in Phase 3). */
+  dndOverSlot?: AvatarSlotId | null;
+  /** Rendered pixel width; height scales with the viewBox. */
+  size?: number;
+  className?: string;
+}
+
+export function AgentAvatar(props: AgentAvatarProps) {
+  return props.variant === "playful" ? (
+    <AvatarPlayful {...props} />
+  ) : (
+    <AvatarRestrained {...props} />
+  );
+}

--- a/ui/src/components/agent-creator/avatar/AvatarPlayful.tsx
+++ b/ui/src/components/agent-creator/avatar/AvatarPlayful.tsx
@@ -1,0 +1,179 @@
+// AgentDash: avatar treatment (b) — game-creator energy (emoji-free).
+// Equipped slots fill as solid "plates" with a soft drop-shadow, and a
+// restrained capability aura intensifies with coverage. Power-up feel comes
+// from timing + shadow, not neon or RPG armor.
+import { useId } from "react";
+import { getAgentIcon } from "../../../lib/agent-icons";
+import type { AgentAvatarProps } from "./AgentAvatar";
+import {
+  AVATAR_VIEWBOX,
+  RISK_TOKEN,
+  getSlot,
+  itemsBySlot,
+  slotRisk,
+} from "./avatar-geometry";
+
+export function AvatarPlayful({
+  iconName,
+  colorToken = "var(--accent-500)",
+  name,
+  equipped,
+  securityOn = false,
+  coverage = 0,
+  dndOverSlot = null,
+  size = 220,
+}: AgentAvatarProps) {
+  const HeadIcon = getAgentIcon(iconName);
+  const bySlot = itemsBySlot(equipped);
+  const head = getSlot("head");
+  const { w, h } = AVATAR_VIEWBOX;
+  const height = (size * h) / w;
+  const uid = useId().replace(/:/g, "");
+  const auraId = `aura-${uid}`;
+  const shadowId = `plate-shadow-${uid}`;
+  const auraOpacity = coverage > 60 ? 0.5 : coverage > 30 ? 0.34 : coverage > 0 ? 0.2 : 0;
+
+  return (
+    <svg
+      width={size}
+      height={height}
+      viewBox={`0 0 ${w} ${h}`}
+      role="img"
+      aria-label={`${name || "Agent"} avatar with ${equipped.length} equipped capabilities`}
+      style={{ display: "block" }}
+    >
+      <defs>
+        <radialGradient id={auraId} cx="50%" cy="42%" r="55%">
+          <stop offset="0%" stopColor={colorToken} stopOpacity={0.45} />
+          <stop offset="100%" stopColor={colorToken} stopOpacity={0} />
+        </radialGradient>
+        <filter id={shadowId} x="-40%" y="-40%" width="180%" height="180%">
+          <feDropShadow dx="0" dy="1.5" stdDeviation="2" floodColor="#1F1B16" floodOpacity="0.18" />
+        </filter>
+      </defs>
+
+      {/* capability aura */}
+      <ellipse
+        cx={w / 2}
+        cy={h * 0.45}
+        rx={w * 0.46}
+        ry={h * 0.4}
+        fill={`url(#${auraId})`}
+        opacity={auraOpacity}
+        style={{ transition: "opacity 260ms ease" }}
+      />
+
+      {/* spine */}
+      <line
+        x1={head.cx}
+        y1={head.cy}
+        x2={head.cx}
+        y2={getSlot("shield").cy}
+        stroke="var(--border-strong)"
+        strokeWidth={1.5}
+      />
+
+      {/* head plate */}
+      <circle
+        cx={head.cx}
+        cy={head.cy}
+        r={head.r}
+        fill="var(--surface-raised)"
+        stroke={colorToken}
+        strokeWidth={2}
+        filter={`url(#${shadowId})`}
+      />
+      <g transform={`translate(${head.cx - 14} ${head.cy - 14})`}>
+        <HeadIcon width={28} height={28} color={colorToken} strokeWidth={2} />
+      </g>
+
+      {/* body core */}
+      {(() => {
+        const body = getSlot("body");
+        const risk = slotRisk(bySlot.body);
+        const filled = bySlot.body.length > 0;
+        return (
+          <circle
+            cx={body.cx}
+            cy={body.cy}
+            r={body.r}
+            fill={filled ? RISK_TOKEN[risk] : "var(--surface-sunken)"}
+            fillOpacity={filled ? 0.9 : 1}
+            stroke={filled ? RISK_TOKEN[risk] : "var(--border-strong)"}
+            strokeWidth={filled ? 2 : 1.25}
+            filter={filled ? `url(#${shadowId})` : undefined}
+            style={{ transition: "all 200ms cubic-bezier(0.34, 1.4, 0.64, 1)" }}
+          />
+        );
+      })()}
+
+      {/* peripheral plates */}
+      {(["tools", "environment"] as const).map((id) => {
+        const slot = getSlot(id);
+        const items = bySlot[id];
+        const filled = items.length > 0;
+        const risk = slotRisk(items);
+        const isOver = dndOverSlot === id;
+        return (
+          <g key={id} aria-label={`${slot.label}${filled ? `: ${items.map((i) => i.label).join(", ")}` : " (empty)"}`}>
+            <circle
+              cx={slot.cx}
+              cy={slot.cy}
+              r={isOver ? slot.r + 2 : slot.r}
+              fill={filled ? RISK_TOKEN[risk] : "var(--surface-sunken)"}
+              fillOpacity={filled ? 0.92 : 1}
+              stroke={isOver ? colorToken : filled ? RISK_TOKEN[risk] : "var(--border-soft)"}
+              strokeWidth={filled || isOver ? 2 : 1.25}
+              filter={filled ? `url(#${shadowId})` : undefined}
+              style={{ transition: "all 200ms cubic-bezier(0.34, 1.4, 0.64, 1)" }}
+            />
+            {items.length > 1 ? (
+              <text
+                x={slot.cx}
+                y={slot.cy + 4}
+                textAnchor="middle"
+                fontSize={11}
+                fontWeight={600}
+                fontFamily="var(--font-mono, monospace)"
+                fill="var(--text-inverse)"
+              >
+                {items.length}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+
+      {/* guardrail shield plate */}
+      {(() => {
+        const slot = getSlot("shield");
+        return (
+          <path
+            aria-label={`Guardrails ${securityOn ? "on" : "off"}`}
+            d={shieldPath(slot.cx, slot.cy, slot.r)}
+            fill={securityOn ? "var(--success-500)" : "var(--surface-sunken)"}
+            fillOpacity={securityOn ? 0.92 : 1}
+            stroke={securityOn ? "var(--success-500)" : "var(--border-strong)"}
+            strokeWidth={securityOn ? 2 : 1.25}
+            filter={securityOn ? `url(#${shadowId})` : undefined}
+            style={{ transition: "all 200ms cubic-bezier(0.34, 1.4, 0.64, 1)" }}
+          />
+        );
+      })()}
+    </svg>
+  );
+}
+
+function shieldPath(cx: number, cy: number, r: number): string {
+  const top = cy - r;
+  const bottom = cy + r;
+  const half = r * 0.85;
+  return [
+    `M ${cx - half} ${top}`,
+    `L ${cx + half} ${top}`,
+    `L ${cx + half} ${cy + r * 0.2}`,
+    `Q ${cx + half} ${bottom} ${cx} ${bottom}`,
+    `Q ${cx - half} ${bottom} ${cx - half} ${cy + r * 0.2}`,
+    "Z",
+  ].join(" ");
+}

--- a/ui/src/components/agent-creator/avatar/AvatarRestrained.tsx
+++ b/ui/src/components/agent-creator/avatar/AvatarRestrained.tsx
@@ -1,0 +1,153 @@
+// AgentDash: avatar treatment (a) — restrained / on-brand.
+// Hairline geometry, tone-based slot fills, no glow / armor / rank badges.
+// Motion is opacity/position fades only (respects prefers-reduced-motion).
+import { getAgentIcon } from "../../../lib/agent-icons";
+import type { AgentAvatarProps } from "./AgentAvatar";
+import {
+  AVATAR_VIEWBOX,
+  RISK_TOKEN,
+  getSlot,
+  itemsBySlot,
+  slotRisk,
+} from "./avatar-geometry";
+
+export function AvatarRestrained({
+  iconName,
+  colorToken = "var(--accent-500)",
+  name,
+  equipped,
+  securityOn = false,
+  dndOverSlot = null,
+  size = 220,
+}: AgentAvatarProps) {
+  const HeadIcon = getAgentIcon(iconName);
+  const bySlot = itemsBySlot(equipped);
+  const head = getSlot("head");
+  const { w, h } = AVATAR_VIEWBOX;
+  const height = (size * h) / w;
+
+  return (
+    <svg
+      width={size}
+      height={height}
+      viewBox={`0 0 ${w} ${h}`}
+      role="img"
+      aria-label={`${name || "Agent"} avatar with ${equipped.length} equipped capabilities`}
+      style={{ display: "block" }}
+    >
+      {/* connective spine — hairline */}
+      <line
+        x1={head.cx}
+        y1={head.cy}
+        x2={head.cx}
+        y2={getSlot("shield").cy}
+        stroke="var(--border-strong)"
+        strokeWidth={1}
+      />
+
+      {/* head */}
+      <circle
+        cx={head.cx}
+        cy={head.cy}
+        r={head.r}
+        fill="var(--surface-raised)"
+        stroke="var(--border-strong)"
+        strokeWidth={1.25}
+      />
+      <g
+        transform={`translate(${head.cx - 13} ${head.cy - 13})`}
+        style={{ color: colorToken }}
+      >
+        <HeadIcon width={26} height={26} color={colorToken} strokeWidth={1.5} />
+      </g>
+
+      {/* body core */}
+      {(() => {
+        const body = getSlot("body");
+        const risk = slotRisk(bySlot.body);
+        const filled = bySlot.body.length > 0;
+        return (
+          <circle
+            cx={body.cx}
+            cy={body.cy}
+            r={body.r}
+            fill={filled ? RISK_TOKEN[risk] : "var(--surface-raised)"}
+            fillOpacity={filled ? 0.12 : 1}
+            stroke={filled ? RISK_TOKEN[risk] : "var(--border-strong)"}
+            strokeWidth={1.25}
+            style={{ transition: "fill-opacity 200ms ease, stroke 200ms ease" }}
+          />
+        );
+      })()}
+
+      {/* peripheral sockets: tools, environment */}
+      {(["tools", "environment"] as const).map((id) => {
+        const slot = getSlot(id);
+        const items = bySlot[id];
+        const filled = items.length > 0;
+        const risk = slotRisk(items);
+        const isOver = dndOverSlot === id;
+        return (
+          <g key={id} aria-label={`${slot.label}${filled ? `: ${items.map((i) => i.label).join(", ")}` : " (empty)"}`}>
+            <circle
+              cx={slot.cx}
+              cy={slot.cy}
+              r={slot.r}
+              fill={filled ? RISK_TOKEN[risk] : "var(--surface-sunken)"}
+              fillOpacity={filled ? 0.14 : 1}
+              stroke={isOver ? colorToken : filled ? RISK_TOKEN[risk] : "var(--border-soft)"}
+              strokeWidth={isOver ? 1.75 : 1}
+              strokeDasharray={filled ? undefined : "2 3"}
+              style={{ transition: "all 200ms ease" }}
+            />
+            {items.length > 1 ? (
+              <text
+                x={slot.cx}
+                y={slot.cy + 3.5}
+                textAnchor="middle"
+                fontSize={10}
+                fontFamily="var(--font-mono, monospace)"
+                fill="var(--text-secondary)"
+              >
+                {items.length}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+
+      {/* guardrail shield */}
+      {(() => {
+        const slot = getSlot("shield");
+        return (
+          <g aria-label={`Guardrails ${securityOn ? "on" : "off"}`}>
+            <path
+              d={shieldPath(slot.cx, slot.cy, slot.r)}
+              fill={securityOn ? "var(--success-500)" : "var(--surface-sunken)"}
+              fillOpacity={securityOn ? 0.12 : 1}
+              stroke={securityOn ? "var(--success-500)" : "var(--border-strong)"}
+              strokeWidth={1.25}
+              strokeDasharray={securityOn ? undefined : "2 3"}
+              style={{ transition: "all 200ms ease" }}
+            />
+          </g>
+        );
+      })()}
+    </svg>
+  );
+}
+
+/** A small heraldic shield centered on (cx, cy). */
+function shieldPath(cx: number, cy: number, r: number): string {
+  const top = cy - r;
+  const bottom = cy + r;
+  const half = r * 0.85;
+  return [
+    `M ${cx - half} ${top}`,
+    `L ${cx + half} ${top}`,
+    `L ${cx + half} ${cy + r * 0.2}`,
+    `Q ${cx + half} ${bottom} ${cx} ${bottom}`,
+    `Q ${cx - half} ${bottom} ${cx - half} ${cy + r * 0.2}`,
+    "Z",
+  ].join(" ");
+}

--- a/ui/src/components/agent-creator/avatar/AvatarVariantSwitch.tsx
+++ b/ui/src/components/agent-creator/avatar/AvatarVariantSwitch.tsx
@@ -1,0 +1,55 @@
+// AgentDash: dev/review-only segmented control to flip avatar treatments.
+import type { AvatarVariant } from "./avatar-geometry";
+
+const OPTIONS: { value: AvatarVariant; label: string }[] = [
+  { value: "restrained", label: "Restrained" },
+  { value: "playful", label: "Game energy" },
+];
+
+export function AvatarVariantSwitch({
+  value,
+  onChange,
+}: {
+  value: AvatarVariant;
+  onChange: (v: AvatarVariant) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Avatar treatment"
+      style={{
+        display: "inline-flex",
+        padding: 2,
+        gap: 2,
+        background: "var(--surface-sunken)",
+        border: "1px solid var(--border-soft)",
+        borderRadius: "var(--radius-pill)",
+      }}
+    >
+      {OPTIONS.map((opt) => {
+        const active = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(opt.value)}
+            style={{
+              padding: "4px 14px",
+              fontSize: "var(--text-sm)",
+              fontWeight: active ? 600 : 500,
+              borderRadius: "var(--radius-pill)",
+              border: "none",
+              cursor: "pointer",
+              color: active ? "var(--text-inverse)" : "var(--text-secondary)",
+              background: active ? "var(--accent-500)" : "transparent",
+              transition: "all 140ms ease",
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/agent-creator/avatar/avatar-geometry.ts
+++ b/ui/src/components/agent-creator/avatar/avatar-geometry.ts
@@ -1,0 +1,81 @@
+// AgentDash: shared geometry + types for the agent-creator avatar.
+// Single source of truth so both aesthetic treatments (restrained / playful)
+// render identical slot positions and can be compared 1:1.
+
+export type AvatarSlotId = "head" | "tools" | "body" | "environment" | "shield";
+
+export type AvatarRiskLevel = "none" | "low" | "medium" | "high";
+
+export type AvatarVariant = "restrained" | "playful";
+
+export interface AvatarSlot {
+  id: AvatarSlotId;
+  /** plain-english label, used for aria + tooltips */
+  label: string;
+  /** SVG coordinates within AVATAR_VIEWBOX */
+  cx: number;
+  cy: number;
+  /** socket radius */
+  r: number;
+}
+
+/** A capability/skill module currently equipped onto a slot. */
+export interface EquippedAvatarItem {
+  slotId: AvatarSlotId;
+  moduleId: string;
+  label: string;
+  risk: AvatarRiskLevel;
+}
+
+export const AVATAR_VIEWBOX = { w: 132, h: 158 } as const;
+
+/**
+ * Slot layout. The figure is a calm, geometric "operator":
+ * head (reasoning) on top, a body core, tools on the left, reach/data on the
+ * right, and the guardrail shield anchored below.
+ */
+export const AVATAR_SLOTS: readonly AvatarSlot[] = [
+  { id: "head", label: "Reasoning", cx: 66, cy: 34, r: 24 },
+  { id: "tools", label: "Tools", cx: 30, cy: 92, r: 13 },
+  { id: "body", label: "Operations", cx: 66, cy: 96, r: 20 },
+  { id: "environment", label: "Reach & data", cx: 102, cy: 92, r: 13 },
+  { id: "shield", label: "Guardrails", cx: 66, cy: 138, r: 15 },
+] as const;
+
+export function getSlot(id: AvatarSlotId): AvatarSlot {
+  const slot = AVATAR_SLOTS.find((s) => s.id === id);
+  if (!slot) throw new Error(`Unknown avatar slot: ${id}`);
+  return slot;
+}
+
+/** Risk → design-token color (CSS custom property reference). */
+export const RISK_TOKEN: Record<AvatarRiskLevel, string> = {
+  none: "var(--success-500)",
+  low: "var(--accent-300)",
+  medium: "var(--warn-500)",
+  high: "var(--danger-500)",
+};
+
+/** Group equipped items by slot for rendering. */
+export function itemsBySlot(
+  equipped: readonly EquippedAvatarItem[],
+): Record<AvatarSlotId, EquippedAvatarItem[]> {
+  const out: Record<AvatarSlotId, EquippedAvatarItem[]> = {
+    head: [],
+    tools: [],
+    body: [],
+    environment: [],
+    shield: [],
+  };
+  for (const item of equipped) out[item.slotId].push(item);
+  return out;
+}
+
+/** Highest risk present in a slot, for tone selection. */
+export function slotRisk(items: readonly EquippedAvatarItem[]): AvatarRiskLevel {
+  const order: AvatarRiskLevel[] = ["high", "medium", "low", "none"];
+  for (const level of order) {
+    if (items.some((i) => i.risk === level)) return level;
+  }
+  return "none";
+}

--- a/ui/src/hooks/useFeatureFlag.ts
+++ b/ui/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,42 @@
+// AgentDash: per-company feature-flag hooks.
+// Thin react-query wrapper over the existing feature-flag API + the selected
+// company from context. One fetch per company; individual flags read from the map.
+import { useQuery } from "@tanstack/react-query";
+import { goalsEvalHitlApi, goalsEvalHitlQueryKeys } from "../api/goals-eval-hitl";
+import { useCompany } from "../context/CompanyContext";
+
+export interface FeatureFlagState {
+  /** Whether the flag list has loaded yet. */
+  isLoading: boolean;
+  /** enabled flag keys → true. Unknown keys are treated as disabled. */
+  flags: Record<string, boolean>;
+  isEnabled: (flagKey: string) => boolean;
+}
+
+export function useFeatureFlags(): FeatureFlagState {
+  const { selectedCompanyId } = useCompany();
+
+  const query = useQuery({
+    queryKey: goalsEvalHitlQueryKeys.featureFlags(selectedCompanyId ?? "none"),
+    queryFn: () => goalsEvalHitlApi.listFeatureFlags(selectedCompanyId as string),
+    enabled: Boolean(selectedCompanyId),
+    staleTime: 60_000,
+  });
+
+  const flags: Record<string, boolean> = {};
+  for (const row of query.data ?? []) {
+    flags[row.flagKey] = row.enabled;
+  }
+
+  return {
+    isLoading: query.isLoading,
+    flags,
+    isEnabled: (flagKey: string) => flags[flagKey] === true,
+  };
+}
+
+/** Convenience: read a single flag. */
+export function useFeatureFlag(flagKey: string): { isLoading: boolean; enabled: boolean } {
+  const { isLoading, isEnabled } = useFeatureFlags();
+  return { isLoading, enabled: isEnabled(flagKey) };
+}

--- a/ui/src/lib/feature-flags.ts
+++ b/ui/src/lib/feature-flags.ts
@@ -1,0 +1,17 @@
+// AgentDash: client-side feature-flag keys + helpers.
+// Flags are stored per-company in the `feature_flags` table and read via
+// goalsEvalHitlApi.listFeatureFlags. Keys are plain strings (mirrors the
+// existing `dod_guard_enabled` convention).
+import type { AvatarVariant } from "../components/agent-creator/avatar/avatar-geometry";
+
+/**
+ * The two avatar treatments are each gated by their own flag, so they can be
+ * rolled out / compared independently per company. Disabled by default;
+ * enable via PUT /companies/:companyId/feature-flags/:flagKey { enabled: true }.
+ */
+export const AVATAR_VARIANT_FLAG_KEYS: Record<AvatarVariant, string> = {
+  restrained: "agent_avatar_restrained",
+  playful: "agent_avatar_playful",
+};
+
+export const ALL_AVATAR_VARIANTS: AvatarVariant[] = ["restrained", "playful"];

--- a/ui/src/pages/AgentCreatorStudio.tsx
+++ b/ui/src/pages/AgentCreatorStudio.tsx
@@ -1,0 +1,385 @@
+// AgentDash: agent-creator studio.
+// Phase 0 — avatar A/B spike. Renders both aesthetic treatments side-by-side
+// over interactive sample equip state so we can pick the default treatment
+// before building the full wizard. No backend.
+import { useState, type CSSProperties } from "react";
+import { AgentAvatar } from "../components/agent-creator/avatar/AgentAvatar";
+import { AvatarVariantSwitch } from "../components/agent-creator/avatar/AvatarVariantSwitch";
+import type {
+  AvatarRiskLevel,
+  AvatarSlotId,
+  AvatarVariant,
+  EquippedAvatarItem,
+} from "../components/agent-creator/avatar/avatar-geometry";
+import { getAgentIcon } from "../lib/agent-icons";
+import { useFeatureFlags } from "../hooks/useFeatureFlag";
+import { ALL_AVATAR_VARIANTS, AVATAR_VARIANT_FLAG_KEYS } from "../lib/feature-flags";
+
+interface SampleModule {
+  id: string;
+  label: string;
+  slot: AvatarSlotId;
+  risk: AvatarRiskLevel;
+}
+
+// Illustrative catalog for the spike — real catalog (bound to connectors /
+// skills / budget) lands in Phase 2.
+const SAMPLE_MODULES: SampleModule[] = [
+  { id: "eng", label: "Engineering", slot: "head", risk: "high" },
+  { id: "strategy", label: "Strategy", slot: "head", risk: "low" },
+  { id: "finance", label: "Finance", slot: "tools", risk: "high" },
+  { id: "comms", label: "Comms", slot: "tools", risk: "medium" },
+  { id: "data", label: "Data & web", slot: "environment", risk: "medium" },
+  { id: "crm", label: "CRM", slot: "environment", risk: "low" },
+  { id: "ops", label: "Operations", slot: "body", risk: "low" },
+  { id: "support", label: "Support", slot: "body", risk: "none" },
+];
+
+const ICON_CHOICES = ["bot", "brain", "rocket", "telescope", "shield", "gem"];
+
+const RISK_LABEL: Record<AvatarRiskLevel, string> = {
+  none: "safe",
+  low: "low",
+  medium: "medium",
+  high: "high",
+};
+const RISK_COLOR: Record<AvatarRiskLevel, string> = {
+  none: "var(--success-500)",
+  low: "var(--info-500)",
+  medium: "var(--warn-500)",
+  high: "var(--danger-500)",
+};
+
+export function AgentCreatorStudio() {
+  const [equippedIds, setEquippedIds] = useState<string[]>(["strategy", "ops"]);
+  const [securityOn, setSecurityOn] = useState(true);
+  const [iconName, setIconName] = useState("bot");
+  const [focusVariant, setFocusVariant] = useState<AvatarVariant | null>(null);
+
+  // Each avatar treatment is gated by its own per-company feature flag.
+  const { isLoading: flagsLoading, isEnabled } = useFeatureFlags();
+  const availableVariants = ALL_AVATAR_VARIANTS.filter((v) =>
+    isEnabled(AVATAR_VARIANT_FLAG_KEYS[v]),
+  );
+
+  const equipped: EquippedAvatarItem[] = SAMPLE_MODULES.filter((m) =>
+    equippedIds.includes(m.id),
+  ).map((m) => ({ slotId: m.slot, moduleId: m.id, label: m.label, risk: m.risk }));
+
+  const coverage = Math.min(100, equipped.length * 16 + (securityOn ? 8 : 0));
+
+  const toggle = (id: string) =>
+    setEquippedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+
+  // Render the focused variant if it is enabled, else all enabled variants.
+  const variants: AvatarVariant[] =
+    focusVariant && availableVariants.includes(focusVariant)
+      ? [focusVariant]
+      : availableVariants;
+
+  if (flagsLoading) {
+    return <div style={{ padding: "var(--space-8)", color: "var(--text-secondary)" }}>Loading…</div>;
+  }
+
+  if (availableVariants.length === 0) {
+    return <AvatarFlagsEmptyState />;
+  }
+
+  return (
+    <div
+      style={{
+        padding: "var(--space-8)",
+        maxWidth: 1100,
+        margin: "0 auto",
+        color: "var(--text-primary)",
+      }}
+    >
+      <div style={{ marginBottom: "var(--space-2)" }}>
+        <div
+          style={{
+            fontFamily: "var(--font-mono, monospace)",
+            fontSize: 10,
+            letterSpacing: "0.16em",
+            textTransform: "uppercase",
+            color: "var(--text-tertiary)",
+          }}
+        >
+          Agent creator · avatar spike
+        </div>
+        <h1
+          style={{
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "var(--text-3xl)",
+            margin: "var(--space-1) 0 0",
+            fontWeight: 400,
+          }}
+        >
+          Two treatments, one figure
+        </h1>
+        <p style={{ color: "var(--text-secondary)", maxWidth: 620, marginTop: "var(--space-2)" }}>
+          Equip sample capabilities below and compare the restrained, on-brand
+          treatment against the game-energy treatment. Both share identical slot
+          geometry. Pick the one to take forward.
+        </p>
+      </div>
+
+      {availableVariants.length === 2 ? (
+        <div style={{ display: "flex", gap: "var(--space-3)", alignItems: "center", margin: "var(--space-6) 0 var(--space-4)" }}>
+          <AvatarVariantSwitch
+            value={focusVariant ?? "restrained"}
+            onChange={(v) => setFocusVariant(v)}
+          />
+          <button
+            onClick={() => setFocusVariant(null)}
+            style={ghostBtn(focusVariant === null)}
+          >
+            Show both
+          </button>
+        </div>
+      ) : (
+        <div style={{ margin: "var(--space-6) 0 var(--space-4)", fontSize: "var(--text-sm)", color: "var(--text-tertiary)" }}>
+          One treatment enabled via feature flag. Enable the other flag to compare both.
+        </div>
+      )}
+
+      {/* avatars */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: variants.length === 2 ? "1fr 1fr" : "1fr",
+          gap: "var(--space-6)",
+          marginBottom: "var(--space-8)",
+        }}
+      >
+        {variants.map((variant) => (
+          <div key={variant} style={card()}>
+            <div style={cardEyebrow()}>
+              {variant === "restrained" ? "Restrained · on-brand" : "Game-creator energy"}
+            </div>
+            <div style={{ display: "grid", placeItems: "center", padding: "var(--space-6) 0" }}>
+              <AgentAvatar
+                variant={variant}
+                iconName={iconName}
+                equipped={equipped}
+                securityOn={securityOn}
+                coverage={coverage}
+                size={240}
+              />
+            </div>
+            <CapabilityBar coverage={coverage} />
+          </div>
+        ))}
+      </div>
+
+      {/* controls */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-6)" }}>
+        <div style={card()}>
+          <div style={cardEyebrow()}>Equip capabilities</div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+            {SAMPLE_MODULES.map((m) => {
+              const on = equippedIds.includes(m.id);
+              return (
+                <button
+                  key={m.id}
+                  onClick={() => toggle(m.id)}
+                  aria-pressed={on}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "6px 12px",
+                    borderRadius: "var(--radius-pill)",
+                    fontSize: "var(--text-sm)",
+                    cursor: "pointer",
+                    border: `1px solid ${on ? "var(--accent-500)" : "var(--border-soft)"}`,
+                    background: on ? "var(--accent-50)" : "var(--surface-raised)",
+                    color: "var(--text-primary)",
+                    transition: "all 140ms ease",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: RISK_COLOR[m.risk],
+                    }}
+                  />
+                  {m.label}
+                  <span style={{ fontSize: 10, color: "var(--text-tertiary)" }}>
+                    {RISK_LABEL[m.risk]}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div style={card()}>
+          <div style={cardEyebrow()}>Identity & guardrails</div>
+          <div style={{ marginTop: "var(--space-3)" }}>
+            <div style={fieldLabel()}>Head glyph</div>
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              {ICON_CHOICES.map((name) => {
+                const Icon = getAgentIcon(name);
+                const on = iconName === name;
+                return (
+                  <button
+                    key={name}
+                    onClick={() => setIconName(name)}
+                    aria-pressed={on}
+                    aria-label={name}
+                    style={{
+                      display: "grid",
+                      placeItems: "center",
+                      width: 36,
+                      height: 36,
+                      borderRadius: "var(--radius-md)",
+                      cursor: "pointer",
+                      border: `1px solid ${on ? "var(--accent-500)" : "var(--border-soft)"}`,
+                      background: on ? "var(--accent-50)" : "var(--surface-raised)",
+                    }}
+                  >
+                    <Icon width={18} height={18} color="var(--text-primary)" />
+                  </button>
+                );
+              })}
+            </div>
+
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-2)",
+                marginTop: "var(--space-4)",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={securityOn}
+                onChange={(e) => setSecurityOn(e.target.checked)}
+              />
+              <span style={{ fontSize: "var(--text-sm)" }}>
+                Guardrails on (the shield)
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AvatarFlagsEmptyState() {
+  return (
+    <div style={{ padding: "var(--space-8)", maxWidth: 720, margin: "0 auto", color: "var(--text-primary)" }}>
+      <div style={cardEyebrow()}>Agent creator · avatar spike</div>
+      <h1
+        style={{
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "var(--text-2xl)",
+          fontWeight: 400,
+          margin: "var(--space-1) 0 var(--space-3)",
+        }}
+      >
+        No avatar treatment is enabled
+      </h1>
+      <p style={{ color: "var(--text-secondary)", marginBottom: "var(--space-4)" }}>
+        Both avatar treatments are behind per-company feature flags and are off by
+        default. Enable one or both to preview them here:
+      </p>
+      <div style={{ ...card(), padding: "var(--space-4)" }}>
+        {ALL_AVATAR_VARIANTS.map((v) => (
+          <div
+            key={v}
+            style={{
+              fontFamily: "var(--font-mono, monospace)",
+              fontSize: "var(--text-sm)",
+              color: "var(--text-secondary)",
+              padding: "2px 0",
+            }}
+          >
+            {AVATAR_VARIANT_FLAG_KEYS[v]}{" "}
+            <span style={{ color: "var(--text-tertiary)" }}>· {v}</span>
+          </div>
+        ))}
+      </div>
+      <p style={{ color: "var(--text-tertiary)", fontSize: "var(--text-xs)", marginTop: "var(--space-3)" }}>
+        PUT /api/companies/&lt;companyId&gt;/feature-flags/&lt;flagKey&gt; with{" "}
+        <code>{`{ "enabled": true }`}</code>
+      </p>
+    </div>
+  );
+}
+
+function CapabilityBar({ coverage }: { coverage: number }) {
+  return (
+    <div style={{ marginTop: "var(--space-2)" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: "var(--text-xs)",
+          color: "var(--text-tertiary)",
+          marginBottom: 4,
+        }}
+      >
+        <span>Capability coverage</span>
+        <span style={{ fontFamily: "var(--font-mono, monospace)" }}>{coverage}%</span>
+      </div>
+      <div
+        style={{
+          height: 6,
+          borderRadius: "var(--radius-pill)",
+          background: "var(--surface-sunken)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${coverage}%`,
+            height: "100%",
+            background: "var(--accent-500)",
+            transition: "width 220ms ease",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function card(): CSSProperties {
+  return {
+    background: "var(--surface-raised)",
+    border: "1px solid var(--border-soft)",
+    borderRadius: "var(--radius-lg)",
+    padding: "var(--space-6)",
+    boxShadow: "var(--shadow-sm)",
+  };
+}
+function cardEyebrow(): CSSProperties {
+  return {
+    fontFamily: "var(--font-mono, monospace)",
+    fontSize: 10,
+    letterSpacing: "0.16em",
+    textTransform: "uppercase",
+    color: "var(--text-tertiary)",
+  };
+}
+function fieldLabel(): CSSProperties {
+  return { fontSize: "var(--text-sm)", color: "var(--text-secondary)", marginBottom: "var(--space-2)" };
+}
+function ghostBtn(active: boolean): CSSProperties {
+  return {
+    padding: "4px 12px",
+    fontSize: "var(--text-sm)",
+    borderRadius: "var(--radius-pill)",
+    cursor: "pointer",
+    border: `1px solid ${active ? "var(--accent-500)" : "var(--border-soft)"}`,
+    background: active ? "var(--accent-50)" : "transparent",
+    color: "var(--text-secondary)",
+  };
+}


### PR DESCRIPTION
## Summary
Phase 0 of the approved **Visual Agent-Creator (Avatar)** plan — the avatar figure, built as **two aesthetic treatments behind per-company feature flags** so they can be rolled out / compared independently.

This is **part 1 of N** (additive UI only). The deeper backend phases (data model, connector/skill/budget binding, audit ledger, composability-conflict engine) will land as their own reviewed PRs.

## What's in this PR
- **Two SVG avatar treatments** sharing one geometry source (`avatar-geometry.ts`):
  - `AvatarRestrained` — on-brand: hairline geometry, tone-fill slots, no glow/armor/ranks.
  - `AvatarPlayful` — emoji-free: filled plates, soft drop-shadow, capability aura keyed to coverage.
- **Feature-flag gating** (per user request): each treatment gated by its own per-company flag — `agent_avatar_restrained`, `agent_avatar_playful` — via the existing `feature_flags` table + `goalsEvalHitlApi`. New `useFeatureFlags` hook (`ui/src/hooks/useFeatureFlag.ts`) + keys (`ui/src/lib/feature-flags.ts`). **Off by default.**
- **Comparison studio** at `/agents/new/studio`: renders whichever treatments are enabled (both → side-by-side + switch; one → that one; none → empty state listing the flag keys + how to enable). Sample equip / guardrail / head-glyph controls + capability bar.

## How to test
1. Enable a flag for your company:
   `PUT /api/companies/<companyId>/feature-flags/agent_avatar_restrained` with `{ "enabled": true }` (and/or `agent_avatar_playful`).
2. Visit `/agents/new/studio` — equip sample modules, toggle guardrails, change the head glyph, compare treatments.

## Scope / safety
- Additive UI only — **no schema or server changes**.
- Reuses the existing feature-flag system (`feature_flags`, `featureFlagsService`, `goalsEvalHitlApi`).

## Verification
- `pnpm -r typecheck` ✓ (all packages)
- `pnpm test:run` — 1 pre-existing flake (`companies-email-domain-route.test.ts` `socket hang up`, unrelated server test; passes 11/11 on re-run)
- `pnpm build` ✓ (all packages)
- e2e: not run in this Conductor worktree (app not bootstrapped here); flag-gated studio flow to be covered in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)