### PR TITLE
feat(fre): invite auto-approve + first-user self-serve bootstrap [no-prompt-update]

### DIFF
--- a/packages/db/src/migrations/0084_invite_auto_approve.sql
+++ b/packages/db/src/migrations/0084_invite_auto_approve.sql
@@ -1,0 +1,5 @@
+-- AgentDash: auto-approve-invites — when a company_join invite has
+-- auto_approve = true and a human accepts it, membership is granted
+-- immediately (join request created already-approved) instead of waiting
+-- for admin approval. Defaults to false so existing invites are unchanged.
+ALTER TABLE "invites" ADD COLUMN "auto_approve" boolean DEFAULT false NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1779408000000,
       "tag": "0083_connectors",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1779840000000,
+      "tag": "0084_invite_auto_approve",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/invites.ts
+++ b/packages/db/src/schema/invites.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, jsonb, boolean, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 
 export const invites = pgTable(
@@ -9,6 +9,10 @@ export const invites = pgTable(
     inviteType: text("invite_type").notNull().default("company_join"),
     tokenHash: text("token_hash").notNull(),
     allowedJoinTypes: text("allowed_join_types").notNull().default("both"),
+    // AgentDash: auto-approve-invites — when true and a human accepts a
+    // company_join invite, membership is granted immediately (the join request
+    // is created already-approved) instead of going through admin approval.
+    autoApprove: boolean("auto_approve").notNull().default(false),
     defaultsPayload: jsonb("defaults_payload").$type<Record<string, unknown> | null>(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     invitedByUserId: text("invited_by_user_id"),

--- a/packages/shared/src/validators/access.ts
+++ b/packages/shared/src/validators/access.ts
@@ -14,6 +14,9 @@ export const createCompanyInviteSchema = z.object({
   humanRole: z.enum(HUMAN_COMPANY_MEMBERSHIP_ROLES).optional().nullable(),
   defaultsPayload: z.record(z.string(), z.unknown()).optional().nullable(),
   agentMessage: z.string().max(4000).optional().nullable(),
+  // AgentDash: auto-approve-invites — grant active membership immediately on
+  // human accept instead of creating a pending_approval join request.
+  autoApprove: z.boolean().optional().default(false),
 });
 
 export type CreateCompanyInvite = z.infer<typeof createCompanyInviteSchema>;

--- a/server/src/__tests__/access-validators.test.ts
+++ b/server/src/__tests__/access-validators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createCompanyInviteSchema,
   updateCompanyMemberWithPermissionsSchema,
   updateCurrentUserProfileSchema,
 } from "@paperclipai/shared";
@@ -29,5 +30,17 @@ describe("access validators", () => {
     });
 
     expect(result.grants).toEqual([]);
+  });
+
+  // AgentDash: auto-approve-invites — autoApprove defaults to false and is
+  // accepted when explicitly provided.
+  it("defaults createCompanyInvite autoApprove to false when omitted", () => {
+    const result = createCompanyInviteSchema.parse({});
+    expect(result.autoApprove).toBe(false);
+  });
+
+  it("accepts an explicit autoApprove flag on createCompanyInvite", () => {
+    const result = createCompanyInviteSchema.parse({ autoApprove: true });
+    expect(result.autoApprove).toBe(true);
   });
 });

--- a/server/src/__tests__/companies-routes-self-serve-bootstrap.test.ts
+++ b/server/src/__tests__/companies-routes-self-serve-bootstrap.test.ts
@@ -1,0 +1,160 @@
+// AgentDash: self-serve-bootstrap — POST /api/companies promotes the first
+// real authenticated user of a fresh instance (no instance_admin, no company)
+// to instance_admin, but ONLY when AGENTDASH_SELF_SERVE_BOOTSTRAP === "true".
+// When the flag is off, behavior is unchanged (no promotion).
+
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { companyRoutes } from "../routes/companies.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+// fakeDb.select().from().where() resolves to [] so the instance_admin count
+// query (the route's eligibility pre-check) returns 0 — a fresh instance with
+// no admins. authUsers email lookups also resolve to [] here, which is fine for
+// a local_implicit-free actor. The atomic, advisory-locked promotion lives in
+// the access service (promoteFirstInstanceAdmin), which is mocked below — so the
+// route never opens a real transaction in this unit test.
+const fakeDb = {
+  select: vi.fn(() => ({
+    from: () => ({
+      where: () => Promise.resolve([]),
+    }),
+  })),
+} as any;
+
+let createMock: ReturnType<typeof vi.fn>;
+let ensureMembershipMock: ReturnType<typeof vi.fn>;
+let setPrincipalPermissionMock: ReturnType<typeof vi.fn>;
+let promoteFirstInstanceAdminMock: ReturnType<typeof vi.fn>;
+let hasActiveCompanyMock: ReturnType<typeof vi.fn>;
+
+vi.mock("../services/index.js", () => ({
+  agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
+  ISSUE_LIST_DEFAULT_LIMIT: 50,
+  companyService: () => ({
+    hasActiveCompany: (...args: unknown[]) => hasActiveCompanyMock(...args),
+    list: vi.fn().mockResolvedValue([]),
+    stats: vi.fn().mockResolvedValue({}),
+    getById: vi.fn(),
+    create: (...args: unknown[]) => createMock(...args),
+    findByEmailDomain: vi.fn().mockResolvedValue(null),
+    update: vi.fn(),
+    archive: vi.fn(),
+    remove: vi.fn(),
+  }),
+  companyPortabilityService: () => ({
+    exportBundle: vi.fn(),
+    previewExport: vi.fn(),
+    previewImport: vi.fn(),
+    importBundle: vi.fn(),
+  }),
+  accessService: () => ({
+    canUser: vi.fn(),
+    ensureMembership: (...args: unknown[]) => ensureMembershipMock(...args),
+    setPrincipalPermission: (...args: unknown[]) => setPrincipalPermissionMock(...args),
+    promoteFirstInstanceAdmin: (...args: unknown[]) => promoteFirstInstanceAdminMock(...args),
+  }),
+  budgetService: () => ({ upsertPolicy: vi.fn() }),
+  agentService: () => ({ getById: vi.fn() }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(),
+    listFeedbackTraces: vi.fn(),
+    getFeedbackTraceById: vi.fn(),
+    saveIssueVote: vi.fn(),
+  }),
+  logActivity: vi.fn(),
+}));
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: [],
+      isInstanceAdmin: false,
+      source: "session",
+    };
+    next();
+  });
+  app.use("/api/companies", companyRoutes(fakeDb, undefined, {}));
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  createMock = vi.fn().mockResolvedValue({
+    id: "company-1",
+    name: "Acme",
+    budgetMonthlyCents: 0,
+    emailDomain: null,
+  });
+  ensureMembershipMock = vi.fn().mockResolvedValue({});
+  setPrincipalPermissionMock = vi.fn().mockResolvedValue(undefined);
+  promoteFirstInstanceAdminMock = vi.fn().mockResolvedValue(true);
+  hasActiveCompanyMock = vi.fn().mockResolvedValue(false);
+});
+
+afterEach(() => {
+  delete process.env.AGENTDASH_SELF_SERVE_BOOTSTRAP;
+  delete process.env.AGENTDASH_ALLOW_MULTI_COMPANY;
+  vi.clearAllMocks();
+});
+
+describe("POST /api/companies — self-serve-bootstrap instance admin promotion", () => {
+  it("promotes the first user to instance_admin when the flag is on and the instance is fresh", async () => {
+    process.env.AGENTDASH_SELF_SERVE_BOOTSTRAP = "true";
+    const app = buildApp();
+
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+    expect(promoteFirstInstanceAdminMock).toHaveBeenCalledWith("user-1");
+  });
+
+  it("does NOT promote when the flag is off (default behavior)", async () => {
+    // Flag intentionally unset.
+    const app = buildApp();
+
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+    expect(promoteFirstInstanceAdminMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT promote when the flag is on but a company already exists", async () => {
+    process.env.AGENTDASH_SELF_SERVE_BOOTSTRAP = "true";
+    hasActiveCompanyMock = vi.fn().mockResolvedValue(true);
+    const app = buildApp();
+
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    // With an existing company the single-company guard returns 409 before
+    // creation — the key assertion is that no promotion occurs.
+    expect(promoteFirstInstanceAdminMock).not.toHaveBeenCalled();
+    expect([201, 409]).toContain(res.status);
+  });
+
+  it("does NOT promote when a company exists even if creation proceeds (eligibility gate, not the 409 guard)", async () => {
+    // Override the single-company guard so creation succeeds (201) WITH a
+    // company already present. This isolates the `!hasExistingCompany`
+    // eligibility term: promotion must be suppressed because a company exists,
+    // not merely because the guard short-circuited with a 409.
+    process.env.AGENTDASH_SELF_SERVE_BOOTSTRAP = "true";
+    process.env.AGENTDASH_ALLOW_MULTI_COMPANY = "true";
+    hasActiveCompanyMock = vi.fn().mockResolvedValue(true);
+    const app = buildApp();
+
+    const res = await request(app).post("/api/companies").send({ name: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalled();
+    expect(promoteFirstInstanceAdminMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/health-dev-server-token.test.ts
+++ b/server/src/__tests__/health-dev-server-token.test.ts
@@ -98,6 +98,8 @@ describe("GET /health dev-server supervisor access", () => {
         deploymentMode: "authenticated",
         bootstrapStatus: "ready",
         bootstrapInviteActive: false,
+        selfServeBootstrap: false,
+        instanceHasCompany: false,
         devServer: {
           enabled: true,
           restartRequired: true,

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -99,6 +99,8 @@ describe("GET /health", () => {
       deploymentMode: "authenticated",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      selfServeBootstrap: false,
+      instanceHasCompany: true,
     });
   });
 
@@ -133,6 +135,8 @@ describe("GET /health", () => {
       deploymentMode: "authenticated",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      selfServeBootstrap: false,
+      instanceHasCompany: true,
     });
   });
 

--- a/server/src/__tests__/invite-accept-auto-approve.test.ts
+++ b/server/src/__tests__/invite-accept-auto-approve.test.ts
@@ -1,0 +1,199 @@
+// AgentDash: auto-approve-invites — route-level integration coverage for the
+// auto_approve invite flow against an embedded Postgres.
+//
+// Asserts the two contracts the feature introduces:
+//   (a) auto_approve = true  -> human accept grants ACTIVE membership
+//       immediately and the join_request is created already "approved"
+//       (no pending state ever exists).
+//   (b) auto_approve = false -> human accept produces a "pending_approval"
+//       join_request and NO membership (the unchanged legacy flow).
+import express from "express";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  companyMemberships,
+  createDb,
+  invites,
+  joinRequests,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import { accessRoutes } from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+import { hashToken, createInviteToken } from "../lib/invite-tokens.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe
+  : describe.skip;
+
+describeEmbeddedPostgres("POST /invites/:token/accept (auto_approve)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-invite-auto-approve-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(joinRequests);
+    await db.delete(invites);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(userId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (req as any).actor = {
+        type: "board",
+        source: "session",
+        userId,
+        companyIds: [],
+        memberships: [],
+      };
+      next();
+    });
+    app.use(
+      "/api",
+      accessRoutes(db, {
+        deploymentMode: "authenticated",
+        deploymentExposure: "private",
+        bindHost: "127.0.0.1",
+        allowedHostnames: [],
+      }),
+    );
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Auto Approve Co",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedInvite(companyId: string, autoApprove: boolean) {
+    const token = createInviteToken();
+    await db.insert(invites).values({
+      companyId,
+      inviteType: "company_join",
+      allowedJoinTypes: "human",
+      autoApprove,
+      defaultsPayload: { humanRole: "operator" },
+      tokenHash: hashToken(token),
+      expiresAt: new Date(Date.now() + 72 * 60 * 60 * 1000),
+      invitedByUserId: "inviter-1",
+    });
+    return token;
+  }
+
+  it("grants active membership immediately and approves the join request when auto_approve is true", async () => {
+    const companyId = await seedCompany();
+    const token = await seedInvite(companyId, true);
+    const userId = `user-${randomUUID()}`;
+    const app = createApp(userId);
+
+    const res = await request(app)
+      .post(`/api/invites/${token}/accept`)
+      .send({ requestType: "human" });
+
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe("approved");
+    expect(res.body.requestType).toBe("human");
+
+    // Active membership exists for the accepting user.
+    const membership = await db
+      .select()
+      .from(companyMemberships)
+      .where(
+        and(
+          eq(companyMemberships.companyId, companyId),
+          eq(companyMemberships.principalType, "user"),
+          eq(companyMemberships.principalId, userId),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(membership).not.toBeNull();
+    expect(membership?.status).toBe("active");
+    expect(membership?.membershipRole).toBe("operator");
+
+    // Join request is already approved — never pending.
+    const allRequests = await db
+      .select()
+      .from(joinRequests)
+      .where(eq(joinRequests.companyId, companyId));
+    expect(allRequests).toHaveLength(1);
+    expect(allRequests[0]?.status).toBe("approved");
+    expect(allRequests[0]?.approvedAt).not.toBeNull();
+    expect(
+      allRequests.some((row) => row.status === "pending_approval"),
+    ).toBe(false);
+
+    // The invite is consumed.
+    const consumed = await db
+      .select()
+      .from(invites)
+      .where(eq(invites.companyId, companyId))
+      .then((rows) => rows[0] ?? null);
+    expect(consumed?.acceptedAt).not.toBeNull();
+  });
+
+  it("creates a pending_approval join request with no membership when auto_approve is false", async () => {
+    const companyId = await seedCompany();
+    const token = await seedInvite(companyId, false);
+    const userId = `user-${randomUUID()}`;
+    const app = createApp(userId);
+
+    const res = await request(app)
+      .post(`/api/invites/${token}/accept`)
+      .send({ requestType: "human" });
+
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe("pending_approval");
+
+    // No membership granted yet.
+    const membership = await db
+      .select()
+      .from(companyMemberships)
+      .where(
+        and(
+          eq(companyMemberships.companyId, companyId),
+          eq(companyMemberships.principalType, "user"),
+          eq(companyMemberships.principalId, userId),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(membership).toBeNull();
+
+    // Join request is pending.
+    const joinRequest = await db
+      .select()
+      .from(joinRequests)
+      .where(eq(joinRequests.companyId, companyId))
+      .then((rows) => rows[0] ?? null);
+    expect(joinRequest?.status).toBe("pending_approval");
+    expect(joinRequest?.approvedAt).toBeNull();
+  });
+});

--- a/server/src/__tests__/onboarding-v2-routes.test.ts
+++ b/server/src/__tests__/onboarding-v2-routes.test.ts
@@ -544,6 +544,7 @@ describe("POST /api/onboarding/invites", () => {
       companyId: "c1",
       invitedByUserId: "u1",
       email: "bob@acme.com",
+      autoApprove: false,
     });
     // sendEmail invoked per invite, with the URL we just minted.
     expect(mockSendEmail).toHaveBeenCalledTimes(2);

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -2801,6 +2801,8 @@ export function accessRoutes(
     humanRole?: "owner" | "admin" | "operator" | "viewer" | null;
     defaultsPayload?: Record<string, unknown> | null;
     agentMessage?: string | null;
+    // AgentDash: auto-approve-invites — grant human membership immediately on accept.
+    autoApprove?: boolean;
   }) {
     const writeDb = input.db ?? db;
     const normalizedAgentMessage =
@@ -2820,6 +2822,7 @@ export function accessRoutes(
         normalizedAgentMessage,
         effectiveHumanRole,
       ),
+      autoApprove: input.autoApprove ?? false,
       expiresAt: companyInviteExpiresAt(),
       invitedByUserId: input.req.actor.userId ?? null
     };
@@ -2991,7 +2994,8 @@ export function accessRoutes(
             allowedJoinTypes,
             humanRole: req.body.humanRole ?? null,
             defaultsPayload: req.body.defaultsPayload ?? null,
-            agentMessage: req.body.agentMessage ?? null
+            agentMessage: req.body.agentMessage ?? null,
+            autoApprove: req.body.autoApprove ?? false
           }),
       );
       if (!inviteResult) return;
@@ -3419,6 +3423,116 @@ export function accessRoutes(
         : null;
       if (inviteAlreadyAccepted && !replayJoinRequestId) {
         throw conflict("Join request not found");
+      }
+
+      // AgentDash: auto-approve-invites — when a human accepts an invite that
+      // was created with auto_approve = true, grant active membership
+      // immediately instead of creating a pending_approval join request. This
+      // mirrors the human branch of the approve endpoint
+      // (POST /companies/:companyId/join-requests/:requestId/approve): in one
+      // transaction we mark the invite accepted, ensure an active membership +
+      // role grants, and persist the join request already in "approved" status.
+      // The returned join request row carries status:"approved", which the
+      // invite landing UI (isApprovedHumanJoinPayload) recognizes to navigate
+      // the user straight home. When auto_approve is false the original
+      // pending_approval flow below is unchanged.
+      if (
+        requestType === "human" &&
+        invite.autoApprove === true &&
+        !inviteAlreadyAccepted
+      ) {
+        const requestingUserId = req.actor.userId ?? "local-board";
+        const autoApproved = await withTierCapacityForJoinWrite(
+          companyId,
+          async (dbOrTx) => {
+            const txAccess = accessService(dbOrTx);
+
+            // AgentDash: billing-trio (#151) — Free workspaces enforce 1 human.
+            // Re-check capacity inside the lock before consuming a seat.
+            const blockedAction = await exceededFreeTierCapacityAction(
+              buildRequireTierDeps(dbOrTx),
+              companyId,
+              { humans: 1 },
+            );
+            if (blockedAction) {
+              res.status(402).json(freeTierCapExceededPayload(blockedAction));
+              return null;
+            }
+
+            await dbOrTx
+              .update(invites)
+              .set({ acceptedAt: new Date(), updatedAt: new Date() })
+              .where(
+                and(
+                  eq(invites.id, invite.id),
+                  isNull(invites.acceptedAt),
+                  isNull(invites.revokedAt),
+                ),
+              );
+
+            const membershipRole = resolveHumanInviteRole(
+              invite.defaultsPayload as Record<string, unknown> | null,
+            );
+            await txAccess.ensureMembership(
+              companyId,
+              "user",
+              requestingUserId,
+              membershipRole,
+              "active",
+            );
+            await txAccess.setPrincipalGrants(
+              companyId,
+              "user",
+              requestingUserId,
+              humanJoinGrantsFromDefaults(
+                invite.defaultsPayload as Record<string, unknown> | null,
+                membershipRole,
+              ),
+              req.actor.userId ?? null,
+            );
+
+            const approved = await dbOrTx
+              .insert(joinRequests)
+              .values({
+                inviteId: invite.id,
+                companyId,
+                requestType: "human",
+                status: "approved",
+                requestIp: requestIp(req),
+                requestingUserId,
+                requestEmailSnapshot: await resolveActorEmail(db, req),
+                approvedByUserId:
+                  req.actor.userId ?? (isLocalImplicit(req) ? "local-board" : null),
+                approvedAt: new Date(),
+              })
+              .returning()
+              .then((rows) => rows[0]);
+            return approved ?? null;
+          },
+        );
+        if (!autoApproved) return;
+
+        // AgentDash: billing-trio (#153) — sync Stripe seat quantity after the
+        // membership lands. Failures must not block the membership write.
+        seatSyncer.onMembershipChanged(companyId).catch((err) => {
+          logger.error(
+            { err, companyId },
+            "seat-quantity sync after auto-approved invite failed",
+          );
+        });
+
+        await logActivity(db, {
+          companyId,
+          actorType: "user",
+          actorId: req.actor.userId ?? "board",
+          action: "join.auto_approved",
+          entityType: "join_request",
+          entityId: autoApproved.id,
+          details: { requestType: "human", inviteId: invite.id },
+        });
+
+        res.status(202).json(toJoinRequestResponse(autoApproved));
+        return;
       }
 
       const replayMergedDefaults = inviteAlreadyAccepted

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -1,7 +1,7 @@
 import { Router, type Request } from "express";
-import { eq } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { authUsers } from "@paperclipai/db";
+import { authUsers, instanceUserRoles } from "@paperclipai/db";
 import {
   DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION,
   companyPortabilityExportSchema,
@@ -420,6 +420,28 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
       }
     }
 
+    // AgentDash: self-serve-bootstrap — when AGENTDASH_SELF_SERVE_BOOTSTRAP is
+    // on, a fresh instance (no instance_admin, no company) lets the first real
+    // authenticated user self-serve: they create the first company AND get
+    // promoted to instance_admin below. Compute eligibility BEFORE creating the
+    // company (so the "no company yet" check reflects the pre-create state).
+    // Gated entirely behind the env flag so existing deployments are unaffected.
+    const selfServeBootstrapEnabled =
+      process.env.AGENTDASH_SELF_SERVE_BOOTSTRAP === "true";
+    const isRealAuthenticatedUser =
+      req.actor.source !== "local_implicit" && Boolean(req.actor.userId);
+    let shouldPromoteFirstUserToInstanceAdmin = false;
+    if (selfServeBootstrapEnabled && isRealAuthenticatedUser) {
+      const adminCount = await db
+        .select({ count: count() })
+        .from(instanceUserRoles)
+        .where(eq(instanceUserRoles.role, "instance_admin"))
+        .then((rows) => Number(rows[0]?.count ?? 0));
+      const hasExistingCompany = await svc.hasActiveCompany();
+      shouldPromoteFirstUserToInstanceAdmin =
+        adminCount === 0 && !hasExistingCompany;
+    }
+
     let company: Awaited<ReturnType<typeof svc.create>>;
     try {
       company = await svc.create({
@@ -461,6 +483,29 @@ export function companyRoutes(db: Db, storage?: StorageService, options: Company
       ownerPrincipalId,
     );
     await access.ensureMembership(company.id, "user", ownerPrincipalId, "owner", "active");
+
+    // AgentDash: self-serve-bootstrap — promote the first user of a fresh
+    // instance to instance_admin so they own the instance without the CLI
+    // `auth bootstrap-ceo` step. promoteFirstInstanceAdmin serializes concurrent
+    // first-creates under an advisory lock and re-checks the admin count inside
+    // it, so at most one user wins the bootstrap; it returns true only when this
+    // call performed the promotion.
+    if (shouldPromoteFirstUserToInstanceAdmin && req.actor.userId) {
+      const promoterUserId = req.actor.userId;
+      const promoted = await access.promoteFirstInstanceAdmin(promoterUserId);
+      if (promoted) {
+        await logActivity(db, {
+          companyId: company.id,
+          actorType: "user",
+          actorId: promoterUserId,
+          action: "instance.admin_self_serve_bootstrap",
+          entityType: "instance",
+          entityId: promoterUserId,
+          details: { companyId: company.id },
+        });
+      }
+    }
+
     await logActivity(db, {
       companyId: company.id,
       actorType: "user",

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,7 +7,15 @@ import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { readPersistedDevServerStatus, toDevServerHealthStatus } from "../dev-server-status.js";
 import { logger } from "../middleware/logger.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
+import { companyService } from "../services/companies.js";
 import { serverVersion } from "../version.js";
+
+// AgentDash: self-serve-bootstrap — gate the first-user self-serve company
+// creation + instance-admin promotion behind an env flag so existing
+// deployments are unaffected. Default OFF.
+function isSelfServeBootstrapEnabled(): boolean {
+  return process.env.AGENTDASH_SELF_SERVE_BOOTSTRAP === "true";
+}
 
 function shouldExposeFullHealthDetails(
   actorType: "none" | "board" | "agent" | null | undefined,
@@ -102,6 +110,13 @@ export function healthRoutes(
       }
     }
 
+    // AgentDash: self-serve-bootstrap — expose whether the flag is on and
+    // whether any non-archived company already exists, so the CloudAccessGate
+    // UI can route the first user to the onboarding wizard instead of the CLI
+    // bootstrap page or a dead-end "No company access" screen.
+    const selfServeBootstrap = isSelfServeBootstrapEnabled();
+    const instanceHasCompany = await companyService(db).hasActiveCompany();
+
     const persistedDevServerStatus = readPersistedDevServerStatus();
     let devServer: ReturnType<typeof toDevServerHealthStatus> | undefined;
     if (exposeDevServerDetails && persistedDevServerStatus && typeof (db as { select?: unknown }).select === "function") {
@@ -125,6 +140,8 @@ export function healthRoutes(
         deploymentMode: opts.deploymentMode,
         bootstrapStatus,
         bootstrapInviteActive,
+        selfServeBootstrap,
+        instanceHasCompany,
         ...(devServer ? { devServer } : {}),
       });
       return;
@@ -138,6 +155,8 @@ export function healthRoutes(
       authReady: opts.authReady,
       bootstrapStatus,
       bootstrapInviteActive,
+      selfServeBootstrap,
+      instanceHasCompany,
       features: {
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -110,13 +110,6 @@ export function healthRoutes(
       }
     }
 
-    // AgentDash: self-serve-bootstrap — expose whether the flag is on and
-    // whether any non-archived company already exists, so the CloudAccessGate
-    // UI can route the first user to the onboarding wizard instead of the CLI
-    // bootstrap page or a dead-end "No company access" screen.
-    const selfServeBootstrap = isSelfServeBootstrapEnabled();
-    const instanceHasCompany = await companyService(db).hasActiveCompany();
-
     const persistedDevServerStatus = readPersistedDevServerStatus();
     let devServer: ReturnType<typeof toDevServerHealthStatus> | undefined;
     if (exposeDevServerDetails && persistedDevServerStatus && typeof (db as { select?: unknown }).select === "function") {
@@ -133,6 +126,18 @@ export function healthRoutes(
         activeRunCount,
       });
     }
+
+    // AgentDash: self-serve-bootstrap — expose whether the flag is on and
+    // whether any non-archived company already exists, so the CloudAccessGate
+    // UI can route the first user to the onboarding wizard instead of the CLI
+    // bootstrap page or a dead-end "No company access" screen. Computed AFTER
+    // the bootstrap + dev-server queries above so it doesn't perturb their
+    // (order-sensitive) DB access.
+    const selfServeBootstrap = isSelfServeBootstrapEnabled();
+    const instanceHasCompany =
+      typeof (db as { select?: unknown }).select === "function"
+        ? await companyService(db).hasActiveCompany()
+        : false;
 
     if (!exposeFullDetails) {
       res.json({

--- a/server/src/routes/onboarding-v2.ts
+++ b/server/src/routes/onboarding-v2.ts
@@ -658,10 +658,13 @@ No greetings. No markdown headings outside the JSON block.`;
     if (req.actor.type !== "board" || !req.actor.userId) {
       throw unauthorized("Sign-in required");
     }
-    const { companyId, emails } = req.body as {
+    const { companyId, emails, autoApprove } = req.body as {
       conversationId: string;
       companyId: string;
       emails: string[];
+      // AgentDash: auto-approve-invites — default false; when true, invited
+      // humans are granted membership immediately on accept.
+      autoApprove?: boolean;
     };
     if (!companyId || typeof companyId !== "string") {
       throw badRequest("companyId is required");
@@ -768,6 +771,7 @@ No greetings. No markdown headings outside the JSON block.`;
                     companyId,
                     invitedByUserId: req.actor.userId ?? null,
                     email: trimmed,
+                    autoApprove: autoApprove ?? false,
                   });
                   const invitePath = `/invite/${row.token}`;
                   const inviteUrl = baseUrl ? `${baseUrl}${invitePath}` : invitePath;

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -447,6 +447,26 @@ export function accessService(db: Db) {
       .then((rows) => rows[0]);
   }
 
+  // AgentDash: self-serve-bootstrap — atomically promote the FIRST instance
+  // admin of a fresh instance. Serializes concurrent first-creates under a
+  // transaction-scoped advisory lock and re-checks the admin count inside the
+  // lock, so at most one user wins the bootstrap even under a race. Returns
+  // true only when this call performed the promotion. Lock key 4017 is an
+  // arbitrary fixed constant scoped to this bootstrap path.
+  async function promoteFirstInstanceAdmin(userId: string): Promise<boolean> {
+    return db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(4017)`);
+      const adminCount = await tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(instanceUserRoles)
+        .where(eq(instanceUserRoles.role, "instance_admin"))
+        .then((rows) => Number(rows[0]?.count ?? 0));
+      if (adminCount > 0) return false;
+      await tx.insert(instanceUserRoles).values({ userId, role: "instance_admin" });
+      return true;
+    });
+  }
+
   async function demoteInstanceAdmin(userId: string) {
     return db
       .delete(instanceUserRoles)
@@ -792,6 +812,7 @@ export function accessService(db: Db) {
     setMemberPermissions,
     updateMemberAndPermissions,
     promoteInstanceAdmin,
+    promoteFirstInstanceAdmin,
     demoteInstanceAdmin,
     listUserCompanyAccess,
     setUserCompanyAccess,

--- a/server/src/services/invites.ts
+++ b/server/src/services/invites.ts
@@ -36,6 +36,11 @@ export type CreateCompanyInviteInput = {
   email?: string | null;
   /** Defaults to "both" (humans + agents may redeem). */
   allowedJoinTypes?: "human" | "agent" | "both";
+  /**
+   * AgentDash: auto-approve-invites — when true, a human accepting this invite
+   * is granted active membership immediately (no admin approval). Defaults false.
+   */
+  autoApprove?: boolean;
 };
 
 export type CreateCompanyInviteOutput = {
@@ -68,6 +73,7 @@ export function inviteService(db: Db) {
               companyId: input.companyId,
               inviteType: "company_join",
               allowedJoinTypes: input.allowedJoinTypes ?? "both",
+              autoApprove: input.autoApprove ?? false,
               defaultsPayload,
               expiresAt,
               invitedByUserId: input.invitedByUserId,

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -106,6 +106,145 @@ describe("CloudAccessGate", () => {
     });
   });
 
+  // AgentDash: self-serve-bootstrap — when the env flag is on, a fresh
+  // instance routes the first signed-in user to the onboarding wizard instead
+  // of the CLI bootstrap page or a dead-end "No company access".
+  it("routes the first user to onboarding when selfServeBootstrap is on and no company exists", async () => {
+    mockHealthApi.get.mockResolvedValue({
+      status: "ok",
+      deploymentMode: "authenticated",
+      bootstrapStatus: "ready",
+      selfServeBootstrap: true,
+      instanceHasCompany: false,
+    });
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+    });
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+      userId: "user-1",
+      isInstanceAdmin: false,
+      companyIds: [],
+      source: "session",
+      keyId: null,
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CloudAccessGate />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Navigate:/onboarding");
+    expect(container.textContent).not.toContain("No company access");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("shows No company access when selfServeBootstrap is on but a company already exists", async () => {
+    mockHealthApi.get.mockResolvedValue({
+      status: "ok",
+      deploymentMode: "authenticated",
+      bootstrapStatus: "ready",
+      selfServeBootstrap: true,
+      instanceHasCompany: true,
+    });
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+    });
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+      userId: "user-1",
+      isInstanceAdmin: false,
+      companyIds: [],
+      source: "session",
+      keyId: null,
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CloudAccessGate />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("No company access");
+    expect(container.textContent).not.toContain("Navigate:/onboarding");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("shows the CLI bootstrap page when selfServeBootstrap is off and bootstrap is pending", async () => {
+    mockHealthApi.get.mockResolvedValue({
+      status: "ok",
+      deploymentMode: "authenticated",
+      bootstrapStatus: "bootstrap_pending",
+      bootstrapInviteActive: false,
+      selfServeBootstrap: false,
+      instanceHasCompany: false,
+    });
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+    });
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+      userId: "user-1",
+      isInstanceAdmin: false,
+      companyIds: [],
+      source: "session",
+      keyId: null,
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CloudAccessGate />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Instance setup required");
+    expect(container.textContent).not.toContain("Navigate:/onboarding");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("allows authenticated users with company access through to the board", async () => {
     mockAuthApi.getSession.mockResolvedValue({
       session: { id: "session-1", userId: "user-1" },

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -20,6 +20,9 @@ export type HealthStatus = {
   authReady?: boolean;
   bootstrapStatus?: "ready" | "bootstrap_pending";
   bootstrapInviteActive?: boolean;
+  // AgentDash: self-serve-bootstrap — first-user self-serve company creation.
+  selfServeBootstrap?: boolean;
+  instanceHasCompany?: boolean;
   features?: {
     companyDeletionEnabled?: boolean;
   };

--- a/ui/src/components/CloudAccessGate.tsx
+++ b/ui/src/components/CloudAccessGate.tsx
@@ -92,7 +92,18 @@ export function CloudAccessGate() {
     );
   }
 
+  // AgentDash: self-serve-bootstrap — when the env flag is on, a signed-in
+  // first user on a fresh instance is routed to the onboarding wizard to
+  // create the first company (and is promoted to instance_admin server-side
+  // on company creation) instead of the CLI bootstrap page. When the flag is
+  // off, the CLI BootstrapPendingPage is shown as before.
+  const selfServeBootstrap = healthQuery.data?.selfServeBootstrap === true;
+  const instanceHasCompany = healthQuery.data?.instanceHasCompany === true;
+
   if (isAuthenticatedMode && healthQuery.data?.bootstrapStatus === "bootstrap_pending") {
+    if (selfServeBootstrap && sessionQuery.data) {
+      return <Navigate to="/onboarding" replace />;
+    }
     return <BootstrapPendingPage hasActiveInvite={healthQuery.data.bootstrapInviteActive} />;
   }
 
@@ -107,6 +118,12 @@ export function CloudAccessGate() {
     !boardAccessQuery.data?.isInstanceAdmin &&
     (boardAccessQuery.data?.companyIds.length ?? 0) === 0
   ) {
+    // AgentDash: self-serve-bootstrap — on a fresh instance (flag on, no
+    // company yet) route the first user to the onboarding wizard instead of a
+    // dead-end. Once any company exists, keep invite-only "No company access".
+    if (selfServeBootstrap && !instanceHasCompany) {
+      return <Navigate to="/onboarding" replace />;
+    }
     return <NoBoardAccessPage />;
   }
 


### PR DESCRIPTION
## Why
Found while reviewing the live MSP-launch first-run experience on the Mac mini. Two structural FRE gaps blocked self-serve onboarding:
1. **Invited teammates needed an admin approval click** to join (the `auto_approve` invite column was dead — defined in the DB but read nowhere).
2. **The first user of a fresh instance couldn't self-serve** — they hit "Instance setup required: run `pnpm paperclipai auth bootstrap-ceo`" (a CLI step = the "admin overhead" we want to avoid).

## What

### Feature A — honor `auto_approve` on human company invites
- Add `invites.auto_approve` column (schema + migration `0084`) + `createCompanyInviteSchema` validator.
- Thread `autoApprove` through invite creation (service + admin & onboarding-v2 routes).
- Accept handler: when a **human** accepts an `auto_approve` invite, grant **active membership immediately** (mirrors the approve endpoint's human branch — same role/grants/tier-capacity guards) and record the join request as `approved`, instead of `pending_approval`. The 202 payload satisfies the UI's `isApprovedHumanJoinPayload` so the invitee lands straight in the workspace.

### Feature B — first-user self-serve bootstrap (env-gated, default OFF)
- New flag `AGENTDASH_SELF_SERVE_BOOTSTRAP=true`: on a fresh `authenticated` instance (no `instance_admin`, no company), the first real authenticated user creates the first company via the existing wizard **and** is promoted to `instance_admin` — no CLI.
- `access.promoteFirstInstanceAdmin`: advisory-locked, re-checks the admin count inside the transaction so **at most one** user wins the bootstrap under concurrent first-creates.
- `health` exposes `selfServeBootstrap` + `instanceHasCompany`; `CloudAccessGate` routes the first user to `/onboarding` instead of the CLI page / dead-end. **Unchanged** invite-only behavior once a company exists or the flag is off.

## Safety
- Feature B is **off by default** — existing deployments are unaffected. Enable per-instance via env.
- Feature A only changes behavior for invites explicitly created with `autoApprove: true` (defaults `false`).
- All existing accept/bootstrap guards (validity/expiry/revoke, allowedJoinTypes, already-member, human-only, tier/seat capacity, bootstrap_ceo early-return) run before the new branches.

## Review
Independent code review: **APPROVE** (0 critical/high). Hardened the bootstrap admin-promotion TOCTOU race (advisory-locked service method), added approve-endpoint parity for `approvedByUserId`, and a stronger eligibility-gate test. One documented Medium edge (a user with a pre-existing pending request from a *different* invite accepting an auto-approve invite leaves a harmless stale pending row; membership grant is idempotent).

## Tests
- `invite-accept-auto-approve` — auto_approve→active membership + approved join; non-auto→pending (embedded PG)
- `companies-routes-self-serve-bootstrap` — gated promotion: on/off/company-exists (incl. eligibility gate isolated from the 409 guard)
- `access-validators` — autoApprove default/explicit
- `App.test` (CloudAccessGate) — flag on→wizard, company-exists→dead-end, flag off→CLI page

## Verification
- `pnpm -r typecheck` ✅ all packages
- `pnpm test:run` ✅ 1361 passed / 0 genuine failures (2 unrelated suites hit the known embedded-PG startup-concurrency flake; both pass in isolation)
- `pnpm build` ✅

## Deploy note
The Mac mini runs a divergent lineage (`feat/cos-minimax-adapter-deploy`), not `main`. Per decision, this PR is based on `main`; converge the mini onto main before deploying these changes. To enable Feature B on the mini, set `AGENTDASH_SELF_SERVE_BOOTSTRAP=true` in `agentdash.env` and restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)