### PR TITLE
feat(fre): auto-approve toggle on invite-creation UI (default on) [no-prompt-update]

### DIFF
--- a/ui/src/api/access.ts
+++ b/ui/src/api/access.ts
@@ -268,6 +268,7 @@ export const accessApi = {
       humanRole?: HumanCompanyRole | null;
       defaultsPayload?: Record<string, unknown> | null;
       agentMessage?: string | null;
+      autoApprove?: boolean;
     } = {},
   ) =>
     api.post<CompanyInviteCreated>(`/companies/${companyId}/invites`, input),

--- a/ui/src/pages/CompanyInvites.test.tsx
+++ b/ui/src/pages/CompanyInvites.test.tsx
@@ -193,6 +193,7 @@ describe("CompanyInvites", () => {
       allowedJoinTypes: "human",
       humanRole: "viewer",
       agentMessage: null,
+      autoApprove: true,
     });
     expect(clipboardWriteTextMock).toHaveBeenCalledWith("https://paperclip.local/invite/new-token");
     expect(container.textContent).toContain("Latest invite link");
@@ -223,6 +224,55 @@ describe("CompanyInvites", () => {
     await flushReact();
 
     expect(revokeInviteMock).toHaveBeenCalledWith("invite-25");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("sends autoApprove=false when the auto-approve toggle is unchecked", async () => {
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <QueryClientProvider client={queryClient}>
+            <CompanyInvites />
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    await act(async () => {
+      const autoApproveCheckbox = container.querySelector(
+        'input[type="checkbox"]',
+      ) as HTMLInputElement | null;
+      // default is checked (auto-approve on); click toggles it off and notifies React
+      autoApproveCheckbox?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      autoApproveCheckbox?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flushReact();
+
+    const createButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Create invite",
+    );
+    await act(async () => {
+      createButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(createCompanyInviteMock).toHaveBeenCalledWith("company-1", {
+      allowedJoinTypes: "human",
+      humanRole: "operator",
+      agentMessage: null,
+      autoApprove: false,
+    });
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/CompanyInvites.tsx
+++ b/ui/src/pages/CompanyInvites.tsx
@@ -50,6 +50,10 @@ export function CompanyInvites() {
   const { pushToast } = useToast();
   const queryClient = useQueryClient();
   const [humanRole, setHumanRole] = useState<"owner" | "admin" | "operator" | "viewer">("operator");
+  // AgentDash: auto-approve invited teammates by default so they join the
+  // workspace instantly on accept (no admin approval click). Uncheck to fall
+  // back to the approval queue.
+  const [autoApprove, setAutoApprove] = useState(true);
   const [latestInviteUrl, setLatestInviteUrl] = useState<string | null>(null);
   const [latestInviteCopied, setLatestInviteCopied] = useState(false);
 
@@ -113,6 +117,7 @@ export function CompanyInvites() {
         allowedJoinTypes: "human",
         humanRole,
         agentMessage: null,
+        autoApprove,
       }),
     onSuccess: async (invite) => {
       setLatestInviteUrl(invite.inviteUrl);
@@ -224,8 +229,27 @@ export function CompanyInvites() {
           </div>
         </fieldset>
 
+        <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border px-4 py-4">
+          <input
+            type="checkbox"
+            checked={autoApprove}
+            onChange={(event) => setAutoApprove(event.target.checked)}
+            className="mt-1 h-4 w-4 border-border text-foreground"
+          />
+          <span className="min-w-0 space-y-1">
+            <span className="block text-sm font-medium">Auto-approve on accept</span>
+            <span className="block max-w-2xl text-sm text-muted-foreground">
+              {autoApprove
+                ? "The invitee joins the workspace immediately when they accept — no approval step."
+                : "The invitee's join request waits in the approval queue until an admin approves it."}
+            </span>
+          </span>
+        </label>
+
         <div className="rounded-lg border border-border px-4 py-3 text-sm text-muted-foreground">
-          Each invite link is single-use. The first successful use consumes the link and creates or reuses the matching join request before approval.
+          {autoApprove
+            ? "Each invite link is single-use. The first successful use consumes the link and admits the invitee with the chosen role."
+            : "Each invite link is single-use. The first successful use consumes the link and creates or reuses the matching join request before approval."}
         </div>
 
         <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Why
Follow-up to #386, which shipped the `auto_approve` invite flag server-side but left it API-only. This surfaces it in the Company Invites UI so admins can create frictionless teammate invites without touching the API.

## What
- **Company Invites** (`ui/src/pages/CompanyInvites.tsx`): new **"Auto-approve on accept"** checkbox, **default ON**. When on, the invitee joins the workspace instantly on accept (no approval click); unchecking falls back to the approval queue. Dynamic helper copy reflects the choice.
- `accessApi.createCompanyInvite` now accepts `autoApprove?: boolean` and threads it to `POST /companies/:companyId/invites` (already honored by the server from #386).

## Decision captured
Per request, implemented **both** asks as one: a **toggle** that **defaults to true** — frictionless by default, with control to opt back into approvals.

## Tests
`CompanyInvites.test.tsx`: default-on path asserts `autoApprove: true`; new test unchecks the toggle and asserts `autoApprove: false`.

## Verification
- `pnpm -r typecheck` ✅ all packages
- UI suite ✅ 768 passed (135 files)
- `pnpm build` ✅

(e2e will fail on the known Playwright browser-install infra flake — not this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)