### PR TITLE
feat(billing): agent-run quota model + config (AGE-120)

### DIFF
--- a/packages/db/src/schema/agent_runs.ts
+++ b/packages/db/src/schema/agent_runs.ts
@@ -1,0 +1,31 @@
+// AgentDash (AGE-119/AGE-120): agent-run metering table. Records each
+// discrete agent run for quota tracking. AGE-119 PR #384 adds this table
+// and the agentRunService; this file is included here so AGE-120 quota
+// computation can land independently. The migration will be deduped when
+// both PRs merge.
+import { pgTable, uuid, text, timestamp, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { agents } from "./agents.js";
+
+export const agentRuns = pgTable(
+  "agent_runs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    agentId: uuid("agent_id").notNull().references(() => agents.id),
+    status: text("status").notNull().default("completed"),
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
+    finishedAt: timestamp("finished_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyStartedIdx: index("agent_runs_company_started_idx").on(
+      table.companyId,
+      table.startedAt,
+    ),
+    companyAgentIdx: index("agent_runs_company_agent_idx").on(
+      table.companyId,
+      table.agentId,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -100,5 +100,7 @@ export { healAttempts, healEvents } from "./heal_attempts.js";
 export type { HealAttempt, HealEvent } from "./heal_attempts.js";
 // AgentDash: cold-signup re-engagement (#228)
 export { reengagementEmails } from "./reengagement-emails.js";
+// AgentDash: agent-run metering (AGE-119/AGE-120)
+export { agentRuns } from "./agent_runs.js";
 // AgentDash: Connectors (AGE-106)
 export { connections, connectorWorkspaceDefaults, agentConnectorOverrides } from "./connections.js";

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1010,6 +1010,12 @@ export function deriveCompanyEmailDomain(creatorEmail: string): string {
   return domain;
 }
 
+// AgentDash: Agent-run quota model (AGE-120)
+// Per-tier included run allotments. Pro allotment scales with paid seats.
+export const QUOTA_FREE_INCLUDED_RUNS = 50;
+export const QUOTA_PRO_BASE_INCLUDED_RUNS = 1_000;
+export const QUOTA_PRO_PER_SEAT_RUNS = 250;
+
 // AgentDash: Connectors (AGE-106)
 
 /** Owner types for connections — who initiated the connection. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -110,6 +110,10 @@ export {
   PLUGIN_API_ROUTE_CHECKOUT_POLICIES,
   PLUGIN_EVENT_TYPES,
   PLUGIN_BRIDGE_ERROR_CODES,
+  // AgentDash (AGE-120): agent-run quota model
+  QUOTA_FREE_INCLUDED_RUNS,
+  QUOTA_PRO_BASE_INCLUDED_RUNS,
+  QUOTA_PRO_PER_SEAT_RUNS,
   // AgentDash (AGE-55): FRE Plan B — domain-keyed companies
   FREE_MAIL_DOMAINS,
   deriveCompanyEmailDomain,

--- a/server/src/__tests__/quota-routes.test.ts
+++ b/server/src/__tests__/quota-routes.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock the quota service so we don't need a real DB
+vi.mock("../services/quota.js", () => ({
+  quotaService: vi.fn(),
+}));
+
+import { quotaService } from "../services/quota.js";
+import { quotaRoutes } from "../routes/quota.js";
+
+function createApp(mockGetQuota: any) {
+  vi.mocked(quotaService).mockReturnValue({
+    getQuota: mockGetQuota,
+  });
+
+  const app = express();
+  app.use(express.json());
+
+  // Inject actor middleware
+  app.use((req: any, _res: any, next: any) => {
+    req.actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["co-1"],
+      source: "session",
+    };
+    next();
+  });
+
+  app.use("/api", quotaRoutes({} as any));
+
+  // Error handler
+  app.use((err: any, _req: any, res: any, _next: any) => {
+    res.status(err.status ?? 500).json({ error: err.message });
+  });
+
+  return app;
+}
+
+describe("GET /api/companies/:companyId/quota", () => {
+  it("returns quota snapshot for a free workspace", async () => {
+    const snapshot = {
+      tier: "free",
+      includedRuns: 50,
+      usedRuns: 12,
+      remainingRuns: 38,
+      overageRuns: 0,
+      seatsCount: 0,
+      billingPeriodStart: "2026-06-01T00:00:00.000Z",
+      billingPeriodEnd: "2026-07-01T00:00:00.000Z",
+    };
+    const app = createApp(vi.fn().mockResolvedValue(snapshot));
+
+    const res = await request(app).get("/api/companies/co-1/quota");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(snapshot);
+  });
+
+  it("returns quota snapshot for a pro workspace with seats", async () => {
+    const snapshot = {
+      tier: "pro_active",
+      includedRuns: 2000,
+      usedRuns: 500,
+      remainingRuns: 1500,
+      overageRuns: 0,
+      seatsCount: 4,
+      billingPeriodStart: "2026-05-15T00:00:00.000Z",
+      billingPeriodEnd: "2026-06-15T00:00:00.000Z",
+    };
+    const app = createApp(vi.fn().mockResolvedValue(snapshot));
+
+    const res = await request(app).get("/api/companies/co-1/quota");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(snapshot);
+  });
+
+  it("returns 403 when actor is not in company", async () => {
+    const app = createApp(vi.fn());
+
+    const res = await request(app).get("/api/companies/co-other/quota");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when company not found", async () => {
+    const app = createApp(vi.fn().mockResolvedValue(null));
+
+    const res = await request(app).get("/api/companies/co-1/quota");
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/__tests__/quota-service.test.ts
+++ b/server/src/__tests__/quota-service.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { computeIncludedRuns } from "../services/quota.js";
+
+describe("computeIncludedRuns", () => {
+  it("returns 50 for free tier", () => {
+    expect(computeIncludedRuns("free", 0)).toBe(50);
+  });
+
+  it("returns 50 for free tier even if seats are somehow set", () => {
+    expect(computeIncludedRuns("free", 5)).toBe(50);
+  });
+
+  it("returns 1000 base for pro_active with 0 seats", () => {
+    expect(computeIncludedRuns("pro_active", 0)).toBe(1_000);
+  });
+
+  it("adds 250 per paid seat for pro_active", () => {
+    expect(computeIncludedRuns("pro_active", 1)).toBe(1_250);
+    expect(computeIncludedRuns("pro_active", 4)).toBe(2_000);
+    expect(computeIncludedRuns("pro_active", 10)).toBe(3_500);
+  });
+
+  it("returns pro allotment for pro_trial tier", () => {
+    expect(computeIncludedRuns("pro_trial", 1)).toBe(1_250);
+  });
+
+  it("returns free allotment for pro_canceled tier", () => {
+    // pro_canceled is NOT a live Pro tier, so it falls back to free
+    expect(computeIncludedRuns("pro_canceled", 5)).toBe(50);
+  });
+
+  it("returns free allotment for pro_past_due tier", () => {
+    expect(computeIncludedRuns("pro_past_due", 3)).toBe(50);
+  });
+
+  it("returns free allotment for unknown tier", () => {
+    expect(computeIncludedRuns("unknown_tier", 0)).toBe(50);
+  });
+
+  it("seat count adjustment changes pro allotment in real-time", () => {
+    // Simulates: workspace starts with 2 seats, upgrades to 5
+    const before = computeIncludedRuns("pro_active", 2);
+    const after = computeIncludedRuns("pro_active", 5);
+    expect(before).toBe(1_500); // 1000 + 2*250
+    expect(after).toBe(2_250);  // 1000 + 5*250
+    expect(after - before).toBe(750); // +3 seats * 250
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -55,6 +55,8 @@ import { onboardingV2Routes } from "./routes/onboarding-v2.js";
 import { billingRoutes } from "./routes/billing.js";
 import { assessRoutes } from "./routes/assess.js";
 import { agentResearchRoutes } from "./routes/agent-research.js";
+// AgentDash: Agent-run quota (AGE-120)
+import { quotaRoutes } from "./routes/quota.js";
 // AgentDash: Connectors (AGE-106)
 import { connectorRoutes } from "./routes/connectors.js";
 // AgentDash: goals-eval-hitl
@@ -261,6 +263,8 @@ export async function createApp(
   api.use("/onboarding", onboardingV2Routes(db));
   api.use(assessRoutes(db));
   api.use(agentResearchRoutes(db));
+  // AgentDash: Agent-run quota (AGE-120)
+  api.use(quotaRoutes(db));
   // AgentDash: Connectors (AGE-106)
   api.use(connectorRoutes(db));
   // AgentDash: goals-eval-hitl

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -96,6 +96,17 @@ Outputs from these helpers are draft recommendations for human review. Week-one 
 Free workspaces allow one human user and one agent, normally the Chief of Staff. If hiring an agent, inviting a teammate, approving a join request, importing a company package, or delegating setup work returns HTTP 402 with `seat_cap_exceeded` or `agent_cap_exceeded`, treat it as a plan-limit decision. Do not retry through another endpoint or create a workaround. Explain the blocked action to the board and ask them to upgrade or remove existing capacity first.
 <!-- /AgentDash: free-tier-capacity -->
 
+<!-- AgentDash: agent-run-quota — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Agent-run quota
+
+Each workspace has a monthly agent-run allotment based on plan tier:
+
+- **Free:** 50 runs/month
+- **Pro:** 1,000 base + 250 per paid seat (adjusts in real-time when seats change)
+
+Check remaining quota via `GET /api/companies/:companyId/quota`. The response includes `includedRuns`, `usedRuns`, `remainingRuns`, `overageRuns`, `seatsCount`, and the billing period window. When delegating work to reports, be aware of the workspace's remaining run budget. If `remainingRuns` reaches 0, inform the board and ask whether to continue into overage territory.
+<!-- /AgentDash: agent-run-quota -->
+
 <!-- AgentDash: connectors — DO NOT REMOVE OR REORDER THIS BLOCK -->
 ## Connectors & connections
 

--- a/server/src/onboarding-assets/chief_of_staff/AGENTS.md
+++ b/server/src/onboarding-assets/chief_of_staff/AGENTS.md
@@ -129,6 +129,17 @@ Outputs from these helpers are draft recommendations for human review. Week-one 
 Free workspaces allow one human user and one agent, normally you as Chief of Staff. If auto-hiring a reviewer, inviting a teammate or agent, approving a join request, importing a company package, or creating setup capacity returns HTTP 402 with `seat_cap_exceeded` or `agent_cap_exceeded`, treat it as a plan-limit decision. Do not retry through another endpoint or create a workaround. Surface the blocked action to the board and ask them to upgrade or remove existing capacity first.
 <!-- /AgentDash: free-tier-capacity -->
 
+<!-- AgentDash: agent-run-quota — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Agent-run quota
+
+Each workspace has a monthly agent-run allotment based on plan tier:
+
+- **Free:** 50 runs/month
+- **Pro:** 1,000 base + 250 per paid seat (adjusts in real-time when seats change)
+
+Check remaining quota via `GET /api/companies/:companyId/quota`. The response includes `includedRuns`, `usedRuns`, `remainingRuns`, `overageRuns`, `seatsCount`, and the billing period window. As Chief of Staff coordinating the review queue, monitor the workspace's run budget. If `remainingRuns` reaches 0, surface the quota state to the board before dispatching further agent work.
+<!-- /AgentDash: agent-run-quota -->
+
 <!-- AgentDash: connectors — DO NOT REMOVE OR REORDER THIS BLOCK -->
 ## Connectors & connections
 

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -64,6 +64,17 @@ Outputs from these helpers are draft recommendations for human review. Week-one 
 Free workspaces allow one human user and one agent, normally the Chief of Staff. If an API call returns HTTP 402 with `seat_cap_exceeded` or `agent_cap_exceeded`, do not retry through another endpoint or create a workaround. Comment on the Issue or CoS thread with the blocked action and ask the board to upgrade the workspace or remove existing capacity first. The API is the source of truth for current plan limits.
 <!-- /AgentDash: free-tier-capacity -->
 
+<!-- AgentDash: agent-run-quota — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Agent-run quota
+
+Each workspace has a monthly agent-run allotment based on plan tier:
+
+- **Free:** 50 runs/month
+- **Pro:** 1,000 base + 250 per paid seat (adjusts in real-time when seats change)
+
+Check remaining quota via `GET /api/companies/:companyId/quota`. The response includes `includedRuns`, `usedRuns`, `remainingRuns`, `overageRuns`, `seatsCount`, and the billing period window. If `remainingRuns` reaches 0, surface the quota state to the board rather than continuing to consume overage runs without acknowledgment.
+<!-- /AgentDash: agent-run-quota -->
+
 <!-- AgentDash: connectors — DO NOT REMOVE OR REORDER THIS BLOCK -->
 ## Connectors & connections
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -19,6 +19,8 @@ export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
 export { instanceSettingsRoutes } from "./instance-settings.js";
 export { instanceDatabaseBackupRoutes } from "./instance-database-backups.js";
+// AgentDash: Agent-run quota (AGE-120)
+export { quotaRoutes } from "./quota.js";
 // AgentDash: Connectors (AGE-106)
 export { connectorRoutes } from "./connectors.js";
 // AgentDash: goals-eval-hitl

--- a/server/src/routes/quota.ts
+++ b/server/src/routes/quota.ts
@@ -1,0 +1,24 @@
+// AgentDash (AGE-120): Agent-run quota API route.
+// GET /companies/:companyId/quota — returns the quota snapshot for the workspace.
+
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { quotaService } from "../services/quota.js";
+import { forbidden, notFound } from "../errors.js";
+
+export function quotaRoutes(db: Db) {
+  const router = Router();
+  const svc = quotaService(db);
+
+  router.get("/companies/:companyId/quota", async (req, res) => {
+    const { companyId } = req.params;
+    if (!req.actor?.companyIds?.includes(companyId)) {
+      throw forbidden("Not a member of this company");
+    }
+    const snapshot = await svc.getQuota(companyId);
+    if (!snapshot) throw notFound("Company not found");
+    res.json(snapshot);
+  });
+
+  return router;
+}

--- a/server/src/services/agent-creator-from-proposal.ts
+++ b/server/src/services/agent-creator-from-proposal.ts
@@ -131,6 +131,17 @@ Outputs from these helpers are draft recommendations for human review. Week-one 
 Free workspaces allow one human user and one agent, normally the Chief of Staff. If an API call returns HTTP 402 with \`seat_cap_exceeded\` or \`agent_cap_exceeded\`, do not retry through another endpoint or create a workaround. Comment on the Issue or CoS thread with the blocked action and ask the board to upgrade the workspace or remove existing capacity first. The API is the source of truth for current plan limits.
 <!-- /AgentDash: free-tier-capacity -->
 
+<!-- AgentDash: agent-run-quota — DO NOT REMOVE OR REORDER THIS BLOCK -->
+## Agent-run quota
+
+Each workspace has a monthly agent-run allotment based on plan tier:
+
+- **Free:** 50 runs/month
+- **Pro:** 1,000 base + 250 per paid seat (adjusts in real-time when seats change)
+
+Check remaining quota via \`GET /api/companies/:companyId/quota\`. The response includes \`includedRuns\`, \`usedRuns\`, \`remainingRuns\`, \`overageRuns\`, \`seatsCount\`, and the billing period window. If \`remainingRuns\` reaches 0, surface the quota state to the board rather than continuing to consume overage runs without acknowledgment.
+<!-- /AgentDash: agent-run-quota -->
+
 <!-- AgentDash: connectors — DO NOT REMOVE OR REORDER THIS BLOCK -->
 ## Connectors & connections
 

--- a/server/src/services/quota.ts
+++ b/server/src/services/quota.ts
@@ -1,0 +1,125 @@
+// AgentDash (AGE-120): Agent-run quota computation service.
+// Given a workspace (company), compute included runs, used runs, and overage
+// based on the company's plan tier and seat count.
+
+import { and, count, eq, gte, lt } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agentRuns, companies } from "@paperclipai/db";
+import {
+  QUOTA_FREE_INCLUDED_RUNS,
+  QUOTA_PRO_BASE_INCLUDED_RUNS,
+  QUOTA_PRO_PER_SEAT_RUNS,
+} from "@paperclipai/shared";
+import { isProLivePlanTier } from "./tier-policy.js";
+
+export interface QuotaSnapshot {
+  tier: string;
+  includedRuns: number;
+  usedRuns: number;
+  remainingRuns: number;
+  overageRuns: number;
+  seatsCount: number;
+  billingPeriodStart: string; // ISO date
+  billingPeriodEnd: string;   // ISO date
+}
+
+/**
+ * Compute the billing-month window for a company.
+ *
+ * For Pro companies with a `planPeriodEnd`, the billing month is the 30-day
+ * (approx) window ending at `planPeriodEnd`. For Free companies (or when
+ * planPeriodEnd is null), we use calendar-month UTC.
+ */
+function billingWindow(planPeriodEnd: Date | null, now = new Date()) {
+  if (planPeriodEnd && planPeriodEnd.getTime() > 0) {
+    // Work backward from periodEnd to find the current window.
+    // Stripe periods are typically monthly. We compute the start as
+    // one month before the period end.
+    const end = planPeriodEnd;
+    const start = new Date(end);
+    start.setUTCMonth(start.getUTCMonth() - 1);
+    // If we're past the period end (stale data), fall back to calendar month.
+    if (now >= end) {
+      return calendarMonthWindow(now);
+    }
+    return { start, end };
+  }
+  return calendarMonthWindow(now);
+}
+
+function calendarMonthWindow(now = new Date()) {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  return {
+    start: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
+    end: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)),
+  };
+}
+
+/**
+ * Compute the included-run allotment for a given tier and seat count.
+ */
+export function computeIncludedRuns(
+  planTier: string,
+  seatsPaid: number,
+): number {
+  if (isProLivePlanTier(planTier)) {
+    return QUOTA_PRO_BASE_INCLUDED_RUNS + seatsPaid * QUOTA_PRO_PER_SEAT_RUNS;
+  }
+  // team tier could be added later with a configurable pool
+  return QUOTA_FREE_INCLUDED_RUNS;
+}
+
+export function quotaService(db: Db) {
+  return {
+    /**
+     * Get the full quota snapshot for a company.
+     */
+    getQuota: async (companyId: string, now?: Date): Promise<QuotaSnapshot | null> => {
+      const company = await db
+        .select({
+          id: companies.id,
+          planTier: companies.planTier,
+          planSeatsPaid: companies.planSeatsPaid,
+          planPeriodEnd: companies.planPeriodEnd,
+        })
+        .from(companies)
+        .where(eq(companies.id, companyId))
+        .then((rows) => rows[0] ?? null);
+
+      if (!company) return null;
+
+      const tier = company.planTier ?? "free";
+      const seatsPaid = company.planSeatsPaid ?? 0;
+      const { start, end } = billingWindow(company.planPeriodEnd ?? null, now);
+
+      const includedRuns = computeIncludedRuns(tier, seatsPaid);
+
+      const [usedRow] = await db
+        .select({ used: count() })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.companyId, companyId),
+            gte(agentRuns.startedAt, start),
+            lt(agentRuns.startedAt, end),
+          ),
+        );
+
+      const usedRuns = usedRow?.used ?? 0;
+      const remainingRuns = Math.max(0, includedRuns - usedRuns);
+      const overageRuns = Math.max(0, usedRuns - includedRuns);
+
+      return {
+        tier,
+        includedRuns,
+        usedRuns,
+        remainingRuns,
+        overageRuns,
+        seatsCount: seatsPaid,
+        billingPeriodStart: start.toISOString(),
+        billingPeriodEnd: end.toISOString(),
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - AgentDash is a CoS-led, multi-human AI workspace with per-seat billing
> - The billing subsystem enforces Free/Pro tier limits on seats and agents
> - AGE-119 adds agent-run metering (tracking individual runs); AGE-120 builds on that to add quota allotments per tier
> - Without quotas, workspaces have no visibility into how many runs they've consumed relative to their plan
> - This PR adds per-tier included run allotments (Free: 50, Pro: 1,000 + 250/seat), a quota computation service, and a GET /companies/:companyId/quota API endpoint
> - The benefit is that workspaces can now see their run budget, usage, and remaining capacity, enabling agents to self-moderate when approaching limits

## What Changed

- **packages/shared/constants.ts**: Added `QUOTA_FREE_INCLUDED_RUNS` (50), `QUOTA_PRO_BASE_INCLUDED_RUNS` (1,000), `QUOTA_PRO_PER_SEAT_RUNS` (250)
- **packages/shared/index.ts**: Re-exported the three quota constants
- **packages/db/schema/agent_runs.ts**: Added `agent_runs` table schema (shared with AGE-119 PR #384 — will be deduped on merge)
- **packages/db/schema/index.ts**: Exported `agentRuns` from schema barrel
- **server/services/quota.ts**: `quotaService` with `getQuota()` — computes includedRuns, usedRuns, remainingRuns, overageRuns based on tier + seat count; `computeIncludedRuns()` pure function for allotment calculation
- **server/routes/quota.ts**: `GET /companies/:companyId/quota` — returns full quota snapshot with company-access guard
- **server/app.ts + routes/index.ts**: Wired quota route into the API router
- **4 AGENTS.md prompt surfaces**: Added `agent-run-quota` named block to default, ceo, chief_of_staff, and agent-creator-from-proposal templates

## Verification

```sh
pnpm -r typecheck     # All 23 packages pass
pnpm test:run         # 198 test files, 0 failures
pnpm build            # All packages build
```

New tests:
- `server/src/__tests__/quota-service.test.ts` — 9 tests covering computeIncludedRuns for all tiers (free, pro_active, pro_trial, pro_canceled, pro_past_due, unknown), seat scaling, and real-time seat adjustment
- `server/src/__tests__/quota-routes.test.ts` — 4 tests covering 200 (free + pro snapshots), 403 (wrong company), 404 (missing company)

## Risks

- **Low risk.** Additive-only: new service, route, and constants. No existing behavior changed.
- The `agent_runs` table schema is duplicated from AGE-119 (PR #384). When both merge, the schema file will be identical — no conflict expected. If AGE-119's schema diverges, a trivial reconciliation is needed.
- Billing-window computation uses `planPeriodEnd` from the company row. If `planPeriodEnd` is stale (past current date), the service falls back to calendar-month UTC window.

## Model Used

- **Provider:** Anthropic Claude
- **Model ID:** claude-opus-4-6
- **Capabilities:** Extended thinking, tool use, code execution
- **Context:** Full monorepo analysis via Claude Code CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge