### PR TITLE
fix(ci): align release workflow branch targeting with main (#349)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,14 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
     inputs:
       source_ref:
         description: Commit SHA, branch, or tag to publish as stable
         required: true
         type: string
-        default: master
+        default: main
       stable_date:
         description: Enter a UTC date in YYYY-MM-DD format, for example 2026-03-18. Do not enter a version string. The workflow will resolve that date to a stable version such as 2026.318.0, then 2026.318.1 for the next same-day stable.
         required: false


### PR DESCRIPTION
## Thinking Path

> - AgentDash is a fork of Paperclip that orchestrates AI agents for autonomous companies
> - The CI/release subsystem (`.github/workflows/release.yml`) drives canary releases and manual release dispatch
> - The release workflow targeted `master`, but the repo default branch is `main` — so the canary pipeline never auto-fired and manual dispatch defaulted to a non-existent branch
> - This needs fixing because release automation is dead until the branch names match the actual repo
> - This pull request switches both `push.branches` and the `workflow_dispatch` default `source_ref` from `master` to `main`
> - The benefit is that canary releases fire on every push to main and the manual dispatch form defaults to the correct branch

## What Changed

- `.github/workflows/release.yml`: `push.branches` `master` to `main`
- `.github/workflows/release.yml`: `workflow_dispatch` `source_ref.default` `master` to `main`

## Verification

- `git ls-remote --heads origin` shows `refs/heads/main` only — `master` does not exist on origin
- YAML structurally validated (`push.branches`, default)
- Peer workflows already aligned: `hermes-pr-audit`, `hermes-prompt-drift`, `agents-md-drift-check`, `upstream-digest` all target `main`

## Risks

- Low risk: file-only edit to a workflow definition. No code, no runtime, no schema changes. The next canary push to main validates it end-to-end.
- The same `master`/`main` mismatch exists in three other workflows (`pr.yml`, `docker.yml`, `refresh-lockfile.yml`) but is intentionally left out of scope here since issue #349 is specifically the release workflow. Those warrant their own cards if a unified sweep is desired.

## AgentDash Review

- **Upstream impact:** None — AgentDash-only fix to an AgentDash-owned workflow; upstream Paperclip release tooling is unaffected
- **Agent-facing prompt surfaces:** None — CI-only change, no agent prompt or runtime behavior touched
- **AgentDash-owned subsystem:** CI/release automation (`.github/workflows/release.yml`)

## Model Used

Provider: MiniMax (via Hermes kanban worker)
Model: MiniMax-M3
PR body conformed to PR-process policy by Claude (Anthropic, claude-opus-4-8, 1M context) during launch-readiness triage.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have filled out AgentDash Review with upstream impact, prompt-surface impact, and owned subsystem
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] If this is upstream-derived, I have followed `doc/UPSTREAM-POLICY.md` and recorded the upstream SHA/reason/verification
- [x] If this changes agent-facing behavior, I have updated all four prompt surfaces or explained why they do not apply
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #349
