### PR TITLE
feat(mcp): AgentDash company-provisioning + CoS onboarding tools (AGE-144)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -75,6 +75,29 @@ Write tools:
 - `paperclipApprovalDecision`
 - `paperclipAddApprovalComment`
 
+AgentDash onboarding / provisioning tools:
+
+These let an agent or human create and set up a workspace through the LLM-led
+Chief of Staff, reducing onboarding friction. They use the `agentdash*` prefix
+to stay distinct from the inherited `paperclip*` tools.
+
+- `agentdashBootstrapWorkspace` — provision a workspace for the authenticated
+  user (company + Chief of Staff agent + opening conversation). Lowest-friction
+  start; takes no input.
+- `agentdashListCompanies` — list accessible workspaces.
+- `agentdashGetCompany` — get a workspace by id.
+- `agentdashCreateCompany` — explicitly create a workspace (prefer
+  `agentdashBootstrapWorkspace` for full onboarding).
+- `agentdashCosChat` — send a message to a workspace's Chief of Staff (drives
+  the onboarding interview). The reply is generated asynchronously — read it
+  back with `agentdashReadConversation`.
+- `agentdashReadConversation` — read recent messages in a conversation.
+- `agentdashHireAgent` — hire an agent (e.g. one the Chief of Staff proposes).
+
+A typical zero-to-working-workspace flow: `agentdashBootstrapWorkspace` →
+`agentdashCosChat` (answer the CoS interview) → `agentdashReadConversation`
+(read the proposed plan) → `agentdashHireAgent` for each proposed agent.
+
 Escape hatch:
 
 - `paperclipApiRequest`

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -315,4 +315,86 @@ describe("paperclip MCP tools", () => {
 
     expect(response.content[0]?.text).toContain("must not contain '..'");
   });
+
+  // ---- AgentDash: onboarding / provisioning tools ----
+
+  it("agentdashBootstrapWorkspace POSTs to /onboarding/bootstrap", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ company: { id: "co-1" }, cosAgent: { id: "cos-1" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("agentdashBootstrapWorkspace");
+    const response = await tool.execute({});
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe("http://localhost:3100/api/onboarding/bootstrap");
+    expect(init.method).toBe("POST");
+    expect(response.content[0]?.text).toContain("cos-1");
+  });
+
+  it("agentdashCreateCompany POSTs to /companies with the company body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockJsonResponse({ id: "co-2" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("agentdashCreateCompany");
+    await tool.execute({ name: "Acme Co", description: "B2B SaaS" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe("http://localhost:3100/api/companies");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      name: "Acme Co",
+      description: "B2B SaaS",
+      budgetMonthlyCents: 0,
+    });
+  });
+
+  it("agentdashCosChat resolves the inbox then posts the message", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(mockJsonResponse({ id: "66666666-6666-4666-8666-666666666666" }))
+      .mockResolvedValueOnce(mockJsonResponse({ id: "msg-1", conversationId: "66666666-6666-4666-8666-666666666666" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("agentdashCosChat");
+    const response = await tool.execute({ message: "I run a B2B SaaS and want help with support" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [inboxUrl, inboxInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(inboxUrl)).toBe(
+      "http://localhost:3100/api/conversations/companies/11111111-1111-1111-1111-111111111111/inbox",
+    );
+    expect(inboxInit.method).toBe("GET");
+
+    const [postUrl, postInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(String(postUrl)).toBe(
+      "http://localhost:3100/api/conversations/66666666-6666-4666-8666-666666666666/messages",
+    );
+    expect(postInit.method).toBe("POST");
+    expect(JSON.parse(String(postInit.body))).toEqual({
+      body: "I run a B2B SaaS and want help with support",
+      companyId: "11111111-1111-1111-1111-111111111111",
+    });
+    expect(response.content[0]?.text).toContain("msg-1");
+  });
+
+  it("agentdashHireAgent POSTs to company agent-hires without companyId in the body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockJsonResponse({ id: "agent-9" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("agentdashHireAgent");
+    await tool.execute({ name: "Morgan", adapterType: "claude_code", role: "product_manager" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/companies/11111111-1111-1111-1111-111111111111/agent-hires",
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      name: "Morgan",
+      adapterType: "claude_code",
+      role: "product_manager",
+    });
+  });
 });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -4,6 +4,7 @@ import {
   askUserQuestionsPayloadSchema,
   checkoutIssueSchema,
   createApprovalSchema,
+  createCompanySchema,
   createIssueSchema,
   issueThreadInteractionContinuationPolicySchema,
   requestConfirmationPayloadSchema,
@@ -159,6 +160,28 @@ const apiRequestSchema = z.object({
   method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
   path: z.string().min(1),
   jsonBody: z.string().optional(),
+});
+
+// AgentDash: company-provisioning + CoS onboarding tool schemas.
+const cosChatToolSchema = z.object({
+  companyId: companyIdOptional,
+  message: z.string().min(1),
+});
+
+const readConversationToolSchema = z.object({
+  conversationId: z.string().uuid(),
+  limit: z.number().int().positive().max(200).optional(),
+});
+
+const hireAgentToolSchema = z.object({
+  companyId: companyIdOptional,
+  name: z.string().min(1),
+  adapterType: z.string().min(1),
+  role: z.string().optional(),
+  title: z.string().optional().nullable(),
+  capabilities: z.string().optional().nullable(),
+  desiredSkills: z.array(z.string().min(1)).optional(),
+  budgetMonthlyCents: z.number().int().nonnegative().optional(),
 });
 
 const workspaceRuntimeControlTargetSchema = z.object({
@@ -604,6 +627,75 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
           body: parseOptionalJson(jsonBody),
         });
       },
+    ),
+    // ---- AgentDash: company provisioning + Chief-of-Staff onboarding ----
+    // Lets agents/humans create and set up a workspace through the LLM-led CoS,
+    // reducing onboarding friction. Marked with the agentdash* prefix to keep
+    // these AgentDash extensions distinct from inherited paperclip* tools.
+    makeTool(
+      "agentdashBootstrapWorkspace",
+      "AgentDash: provision a workspace for the authenticated user — creates the company, a Chief of Staff agent, and the opening conversation. The lowest-friction way to start onboarding. Takes no input.",
+      z.object({}),
+      async () => client.requestJson("POST", "/onboarding/bootstrap", { body: {} }),
+    ),
+    makeTool(
+      "agentdashListCompanies",
+      "AgentDash: list the companies (workspaces) the authenticated actor can access",
+      z.object({}),
+      async () => client.requestJson("GET", "/companies"),
+    ),
+    makeTool(
+      "agentdashGetCompany",
+      "AgentDash: get a company (workspace) by id",
+      z.object({ companyId: companyIdOptional }),
+      async ({ companyId }) =>
+        client.requestJson("GET", `/companies/${client.resolveCompanyId(companyId)}`),
+    ),
+    makeTool(
+      "agentdashCreateCompany",
+      "AgentDash: explicitly create a new company (workspace). For full onboarding prefer agentdashBootstrapWorkspace, which also provisions a Chief of Staff.",
+      createCompanySchema,
+      async (body) => client.requestJson("POST", "/companies", { body }),
+    ),
+    makeTool(
+      "agentdashCosChat",
+      "AgentDash: send a message to a company's Chief of Staff (drives the onboarding interview). The CoS reply is generated asynchronously — call agentdashReadConversation shortly after to read it. Returns the posted message, including its conversationId.",
+      cosChatToolSchema,
+      async ({ companyId, message }) => {
+        const cid = client.resolveCompanyId(companyId);
+        const inbox = await client.requestJson<{ id: string }>(
+          "GET",
+          `/conversations/companies/${cid}/inbox`,
+        );
+        return client.requestJson(
+          "POST",
+          `/conversations/${encodeURIComponent(inbox.id)}/messages`,
+          { body: { body: message, companyId: cid } },
+        );
+      },
+    ),
+    makeTool(
+      "agentdashReadConversation",
+      "AgentDash: read recent messages in a conversation (e.g. to fetch the Chief of Staff's reply after agentdashCosChat)",
+      readConversationToolSchema,
+      async ({ conversationId, limit }) => {
+        const qs = limit ? `?limit=${limit}` : "";
+        return client.requestJson(
+          "GET",
+          `/conversations/${encodeURIComponent(conversationId)}/messages${qs}`,
+        );
+      },
+    ),
+    makeTool(
+      "agentdashHireAgent",
+      "AgentDash: hire an agent into a company (e.g. agents the Chief of Staff proposes during onboarding). adapterType selects the runtime (e.g. claude_code, hermes_local).",
+      hireAgentToolSchema,
+      async ({ companyId, ...body }) =>
+        client.requestJson(
+          "POST",
+          `/companies/${client.resolveCompanyId(companyId)}/agent-hires`,
+          { body },
+        ),
     ),
   ];
 }


### PR DESCRIPTION
Closes AGE-144.

## Thinking Path
> - The monorepo already ships an MCP server (packages/mcp-server) with paperclip* tools for issues/approvals/agents, but nothing to create or set up a workspace — that is the onboarding-friction gap.
> - The lowest-friction fix is thin wrappers over the existing control-plane REST API, reusing the existing bearer board-key auth, rather than new transport or duplicated business logic.
> - Tools are prefixed agentdash* so they sit alongside inherited paperclip* tools without modifying them, keeping upstream merges clean.

## What Changed
Added seven agentdash* tools to packages/mcp-server/src/tools.ts:
- agentdashBootstrapWorkspace (POST /onboarding/bootstrap) — provisions company + Chief of Staff + conversation.
- agentdashListCompanies / agentdashGetCompany / agentdashCreateCompany.
- agentdashCosChat — resolves the company inbox, then posts a message (CoS reply is async).
- agentdashReadConversation — reads recent conversation messages.
- agentdashHireAgent (POST /companies/:id/agent-hires).

README documents the tools and the zero-to-workspace flow. Four unit tests added.

## Verification
- pnpm --filter @paperclipai/mcp-server test — 15/15 pass (11 existing + 4 new).
- pnpm --filter @paperclipai/mcp-server typecheck — clean.
- pnpm --filter @paperclipai/mcp-server build — clean.
- Endpoint paths/methods/bodies verified against the control-plane routes; conversationId is uuid-validated and encodeURIComponent-escaped.

## Risks
Low — change is purely additive (+197 lines, no edits to existing tools). The new write tools share the same blast radius as existing paperclip* write tools (a leaked board key could provision workspaces). Live end-to-end verification against a running server is human-gated on the Mac mini.

## AgentDash Review
**Upstream impact:** No upstream files touched; agentdash* tools are additive alongside inherited paperclip* tools.
**Agent-facing prompt surfaces:** Not modified; this adds MCP tools, not worker prompts or AGENTS.md surfaces.
**AgentDash-owned subsystem:** packages/mcp-server tool registry (createToolDefinitions) and its README.

## Model Used
Provider: Anthropic via Claude Code
Model: Claude Opus 4.8 (1M context)

## Checklist
- [x] Unit tests added and passing (15/15)
- [x] Package typecheck and build green
- [x] Additive only — no edits to inherited paperclip* tools
- [x] Linear issue linked (AGE-144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
