### PR TITLE
fix(auth): honor documented x-agent-key header for agent auth

### DIFF
--- a/server/src/__tests__/agent-x-agent-key-auth.test.ts
+++ b/server/src/__tests__/agent-x-agent-key-auth.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { agentApiKeys, agents, boardApiKeys } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+
+// Table-aware db mock: routes select().from(table).where() to the configured rows,
+// regardless of call order, and no-ops update(). Mirrors the drizzle shape the
+// auth middleware + board-auth service use (.select().from().where().then()).
+function tableAwareDb(opts: {
+  boardRows?: unknown[];
+  agentKeyRows?: unknown[];
+  agentRows?: unknown[];
+}) {
+  const rowsFor = (table: unknown) => {
+    if (table === boardApiKeys) return opts.boardRows ?? [];
+    if (table === agentApiKeys) return opts.agentKeyRows ?? [];
+    if (table === agents) return opts.agentRows ?? [];
+    return [];
+  };
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => Promise.resolve(rowsFor(table)),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+  } as never;
+}
+
+const TOKEN = "agent-secret-token";
+const agentKeyRow = {
+  id: "key-1",
+  agentId: "agent-1",
+  companyId: "co-1",
+  keyHash: "ignored-by-mock",
+  revokedAt: null,
+};
+const activeAgent = { id: "agent-1", companyId: "co-1", status: "active" };
+
+function appWith(db: unknown) {
+  const app = express();
+  app.use(actorMiddleware(db as never, { deploymentMode: "authenticated" }));
+  app.get("/actor", (req, res) => res.json(req.actor));
+  return app;
+}
+
+describe("actorMiddleware x-agent-key header", () => {
+  it("authenticates an agent that sends its key via the documented x-agent-key header", async () => {
+    const app = appWith(
+      tableAwareDb({ boardRows: [], agentKeyRows: [agentKeyRow], agentRows: [activeAgent] }),
+    );
+    const res = await request(app).get("/actor").set("x-agent-key", TOKEN);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "co-1",
+      keyId: "key-1",
+      source: "agent_key",
+    });
+  });
+
+  it("still authenticates the same key via Authorization: Bearer (regression)", async () => {
+    const app = appWith(
+      tableAwareDb({ boardRows: [], agentKeyRows: [agentKeyRow], agentRows: [activeAgent] }),
+    );
+    const res = await request(app).get("/actor").set("authorization", `Bearer ${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "agent", agentId: "agent-1", source: "agent_key" });
+  });
+
+  it("does not grant access when neither header is present", async () => {
+    const app = appWith(tableAwareDb({ agentKeyRows: [agentKeyRow], agentRows: [activeAgent] }));
+    const res = await request(app).get("/actor");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "none" });
+  });
+
+  it("prefers an explicit Authorization: Bearer over x-agent-key when both are sent", async () => {
+    // Bearer present -> x-agent-key mapping is skipped; existing behavior is preserved.
+    const app = appWith(
+      tableAwareDb({ boardRows: [], agentKeyRows: [agentKeyRow], agentRows: [activeAgent] }),
+    );
+    const res = await request(app)
+      .get("/actor")
+      .set("authorization", `Bearer ${TOKEN}`)
+      .set("x-agent-key", "some-other-value");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "agent", agentId: "agent-1" });
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -40,7 +40,16 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const runIdHeader = normalizeRunId(req.header("x-paperclip-run-id"));
 
-    const authHeader = req.header("authorization");
+    let authHeader = req.header("authorization");
+    // AgentDash: honor the documented `x-agent-key` agent-auth header. Every onboarding
+    // AGENTS.md surface instructs agents to "send your agent key as the `x-agent-key`
+    // header on every request", but the server historically only read Authorization:
+    // Bearer — so agents that followed their own instructions 401'd. When no Bearer
+    // credential is present, map x-agent-key onto the same token validation path.
+    const agentKeyHeader = req.header("x-agent-key")?.trim();
+    if (agentKeyHeader && !authHeader?.toLowerCase().startsWith("bearer ")) {
+      authHeader = `Bearer ${agentKeyHeader}`;
+    }
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
       if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
         let session: BetterAuthSessionResult | null = null;


### PR DESCRIPTION
## Thinking Path

> - AgentDash is a fork of Paperclip that orchestrates AI agents for autonomous companies; agents authenticate their callbacks to the control plane to post comments and update issue status
> - The auth middleware (`server/src/middleware/auth.ts`) is the subsystem that validates agent credentials on every API request
> - Every agent prompt surface (default/ceo/chief_of_staff AGENTS.md + agent-creator-from-proposal.ts) tells agents to authenticate with the `x-agent-key` header, but the middleware only ever read `Authorization: Bearer` — so agents that followed their own instructions got 401 on every callback
> - This needs fixing because agents could call external MCP tools fine but could not write results back to AgentDash, breaking end-to-end autonomy (observed live on Meridian Pay: real Clockchain MCP calls succeeded but receipt comments 401'd)
> - This pull request maps the `x-agent-key` header onto the existing token-validation path when no `Authorization: Bearer` credential is present
> - The benefit is that all existing AGENTS.md guidance becomes correct with no prompt-surface churn, and agents reliably persist their work

## What Changed

- `server/src/middleware/auth.ts`: when no `Authorization: Bearer` credential is present, map the `x-agent-key` header onto the same token-validation path. An explicit `Authorization: Bearer` still takes precedence.
- `server/src/__tests__/agent-x-agent-key-auth.test.ts`: new test file covering the four auth permutations.

## Verification

```sh
pnpm -r typecheck   # green (all packages)
pnpm test:run       # green (exit 0)
pnpm build          # green (all packages)
```

New test `agent-x-agent-key-auth.test.ts` asserts:
- `x-agent-key` authenticates an agent
- `Authorization: Bearer` still authenticates the same key (regression)
- neither header → no access
- `Authorization: Bearer` takes precedence when both are sent

Not deployed to the live mini (requires rebuild + restart); the mini currently runs this as a working-tree patch.

## Risks

- Low risk and additive. Board / agent-key / agent-JWT validation logic is unchanged; only an alternate header source is consulted as a fallback.
- An explicit `Authorization: Bearer` still wins, so no existing caller behavior changes.
- No prompt-surface churn and no `agents-md-drift-check` impact, since the AGENTS.md guidance already documents `x-agent-key`.

## AgentDash Review

- **Upstream impact:** None — `x-agent-key` is AgentDash-specific agent auth; upstream Paperclip auth flow is untouched
- **Agent-facing prompt surfaces:** No change required — this PR makes the existing AGENTS.md `x-agent-key` guidance (all four surfaces) correct rather than adding new behavior
- **AgentDash-owned subsystem:** Agent authentication middleware (`server/src/middleware/auth.ts`)

## Model Used

Provider: Anthropic (Claude, via Claude Code CLI)
Model: claude-opus-4-8 (1M context) — extended thinking, tool use, code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have filled out AgentDash Review with upstream impact, prompt-surface impact, and owned subsystem
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] If this is upstream-derived, I have followed `doc/UPSTREAM-POLICY.md` and recorded the upstream SHA/reason/verification
- [x] If this changes agent-facing behavior, I have updated all four prompt surfaces or explained why they do not apply
- [x] I will address all Greptile and reviewer comments before requesting merge
