### PR TITLE
chore(security): cherry-pick upstream token-redaction + per-company JWT keys

### DIFF
--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 
@@ -7,6 +8,7 @@ describe("agent local JWT", () => {
   const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
   const issuerEnv = "PAPERCLIP_AGENT_JWT_ISSUER";
   const audienceEnv = "PAPERCLIP_AGENT_JWT_AUDIENCE";
+  const disableLegacyFallbackEnv = "PAPERCLIP_AGENT_JWT_DISABLE_LEGACY_FALLBACK";
 
   const originalEnv = {
     secret: process.env[secretEnv],
@@ -14,6 +16,7 @@ describe("agent local JWT", () => {
     ttl: process.env[ttlEnv],
     issuer: process.env[issuerEnv],
     audience: process.env[audienceEnv],
+    disableLegacyFallback: process.env[disableLegacyFallbackEnv],
   };
 
   beforeEach(() => {
@@ -22,6 +25,7 @@ describe("agent local JWT", () => {
     process.env[ttlEnv] = "3600";
     delete process.env[issuerEnv];
     delete process.env[audienceEnv];
+    delete process.env[disableLegacyFallbackEnv];
     vi.useFakeTimers();
   });
 
@@ -37,6 +41,8 @@ describe("agent local JWT", () => {
     else process.env[issuerEnv] = originalEnv.issuer;
     if (originalEnv.audience === undefined) delete process.env[audienceEnv];
     else process.env[audienceEnv] = originalEnv.audience;
+    if (originalEnv.disableLegacyFallback === undefined) delete process.env[disableLegacyFallbackEnv];
+    else process.env[disableLegacyFallbackEnv] = originalEnv.disableLegacyFallback;
   });
 
   it("creates and verifies a token", () => {
@@ -96,5 +102,120 @@ describe("agent local JWT", () => {
     process.env[issuerEnv] = "paperclip";
     process.env[audienceEnv] = "paperclip-api";
     expect(verifyLocalAgentJwt(token!)).toBeNull();
+  });
+
+  it("does not verify a token across companies (per-company isolation)", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const tokenA = createLocalAgentJwt("agent-1", "company-A", "claude_local", "run-1");
+    expect(tokenA).not.toBeNull();
+
+    // A token whose body claims company-A must verify successfully under its
+    // own company-A derived key.
+    expect(verifyLocalAgentJwt(tokenA!)?.company_id).toBe("company-A");
+
+    // Tamper: forge a token by copying tokenA's header+signature and swapping
+    // the claim's company_id to company-B. The signature was bound to the
+    // company-A derived key over the original claims; once we re-encode with a
+    // different company_id (or rebind to company-B's key) verification must
+    // fail because the signature is over the original signing input.
+    const [headerB64, claimsB64, signature] = tokenA!.split(".");
+    const claims = JSON.parse(Buffer.from(claimsB64, "base64url").toString("utf8"));
+    claims.company_id = "company-B";
+    const tamperedClaimsB64 = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+    const tampered = `${headerB64}.${tamperedClaimsB64}.${signature}`;
+    expect(verifyLocalAgentJwt(tampered)).toBeNull();
+  });
+
+  it("accepts legacy tokens signed with the master secret (backward compat)", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const masterSecret = process.env[secretEnv]!;
+
+    // Hand-craft a token signed directly with the master secret, simulating a
+    // JWT issued before per-company derivation existed.
+    const now = Math.floor(Date.now() / 1000);
+    const header = { alg: "HS256", typ: "JWT" };
+    const claims = {
+      sub: "agent-legacy",
+      company_id: "company-legacy",
+      adapter_type: "claude_local",
+      run_id: "run-legacy",
+      iat: now,
+      exp: now + 3600,
+      iss: "paperclip",
+      aud: "paperclip-api",
+    };
+    const headerB64 = Buffer.from(JSON.stringify(header), "utf8").toString("base64url");
+    const claimsB64 = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+    const signingInput = `${headerB64}.${claimsB64}`;
+    const legacySig = createHmac("sha256", masterSecret).update(signingInput).digest("base64url");
+    const legacyToken = `${signingInput}.${legacySig}`;
+
+    const verified = verifyLocalAgentJwt(legacyToken);
+    expect(verified).toMatchObject({
+      sub: "agent-legacy",
+      company_id: "company-legacy",
+      adapter_type: "claude_local",
+      run_id: "run-legacy",
+    });
+  });
+
+  it("defaults TTL to 1h when PAPERCLIP_AGENT_JWT_TTL_SECONDS is unset", () => {
+    delete process.env[ttlEnv];
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+    const claims = verifyLocalAgentJwt(token!);
+    expect(claims).not.toBeNull();
+    expect(claims!.exp - claims!.iat).toBe(60 * 60);
+  });
+
+  // Helper: hand-craft a token signed with the raw master secret (legacy path).
+  function craftLegacyMasterSecretToken(masterSecret: string, companyId: string) {
+    const now = Math.floor(Date.now() / 1000);
+    const header = { alg: "HS256", typ: "JWT" };
+    const claims = {
+      sub: "agent-legacy",
+      company_id: companyId,
+      adapter_type: "claude_local",
+      run_id: "run-legacy",
+      iat: now,
+      exp: now + 3600,
+      iss: "paperclip",
+      aud: "paperclip-api",
+    };
+    const headerB64 = Buffer.from(JSON.stringify(header), "utf8").toString("base64url");
+    const claimsB64 = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+    const signingInput = `${headerB64}.${claimsB64}`;
+    const legacySig = createHmac("sha256", masterSecret).update(signingInput).digest("base64url");
+    return `${signingInput}.${legacySig}`;
+  }
+
+  it("accepts master-secret-signed tokens when PAPERCLIP_AGENT_JWT_DISABLE_LEGACY_FALLBACK is unset", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    delete process.env[disableLegacyFallbackEnv];
+    const legacyToken = craftLegacyMasterSecretToken(process.env[secretEnv]!, "company-legacy");
+    const verified = verifyLocalAgentJwt(legacyToken);
+    expect(verified).not.toBeNull();
+    expect(verified!.company_id).toBe("company-legacy");
+  });
+
+  it("rejects master-secret-signed tokens when PAPERCLIP_AGENT_JWT_DISABLE_LEGACY_FALLBACK is enabled", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env[disableLegacyFallbackEnv] = "true";
+    const legacyToken = craftLegacyMasterSecretToken(process.env[secretEnv]!, "company-legacy");
+    expect(verifyLocalAgentJwt(legacyToken)).toBeNull();
+  });
+
+  it("still verifies per-company-signed tokens when PAPERCLIP_AGENT_JWT_DISABLE_LEGACY_FALLBACK is enabled", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env[disableLegacyFallbackEnv] = "true";
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+    expect(token).not.toBeNull();
+    const verified = verifyLocalAgentJwt(token!);
+    expect(verified).toMatchObject({
+      sub: "agent-1",
+      company_id: "company-1",
+      adapter_type: "claude_local",
+      run_id: "run-1",
+    });
   });
 });

--- a/server/src/__tests__/redact-sensitive.test.ts
+++ b/server/src/__tests__/redact-sensitive.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { redactSensitive } from "../middleware/redact-sensitive.js";
+
+describe("redactSensitive", () => {
+  it("redacts a plaintext password field on a sign-in body", () => {
+    const body = { email: "user@example.com", password: "founding6gomez6croaking" };
+
+    const out = redactSensitive(body) as Record<string, unknown>;
+
+    expect(out.email).toBe("user@example.com");
+    expect(out.password).toBe("[REDACTED]");
+    expect((body as Record<string, unknown>).password).toBe("founding6gomez6croaking");
+  });
+
+  it("redacts password key regardless of casing", () => {
+    expect((redactSensitive({ Password: "x" }) as Record<string, unknown>).Password).toBe("[REDACTED]");
+    expect((redactSensitive({ PASSWORD: "x" }) as Record<string, unknown>).PASSWORD).toBe("[REDACTED]");
+  });
+
+  it("redacts known credential-shaped keys", () => {
+    const out = redactSensitive({
+      currentPassword: "a",
+      newPassword: "b",
+      access_token: "c",
+      refresh_token: "d",
+      api_key: "e",
+      authorization: "Bearer f",
+    }) as Record<string, string>;
+
+    for (const value of Object.values(out)) {
+      expect(value).toBe("[REDACTED]");
+    }
+  });
+
+  it("does not redact a bare `token` field — pagination cursors and CSRF tokens are not credentials", () => {
+    const out = redactSensitive({ token: "next-page-cursor", limit: 20 }) as Record<string, unknown>;
+
+    expect(out.token).toBe("next-page-cursor");
+    expect(out.limit).toBe(20);
+  });
+
+  it("recurses into nested objects and arrays", () => {
+    const out = redactSensitive({
+      user: { email: "user@example.com", password: "secret-pass" },
+      tokens: [{ access_token: "t1" }, { access_token: "t2" }],
+    }) as Record<string, unknown>;
+
+    expect((out.user as Record<string, unknown>).email).toBe("user@example.com");
+    expect((out.user as Record<string, unknown>).password).toBe("[REDACTED]");
+    const tokens = out.tokens as Array<Record<string, unknown>>;
+    expect(tokens[0].access_token).toBe("[REDACTED]");
+    expect(tokens[1].access_token).toBe("[REDACTED]");
+  });
+
+  it("leaves primitives and non-sensitive keys untouched", () => {
+    const body = { email: "a@b.c", name: "Alice", count: 7, active: true, missing: null };
+
+    expect(redactSensitive(body)).toEqual(body);
+  });
+
+  it("returns primitives unchanged", () => {
+    expect(redactSensitive("hello")).toBe("hello");
+    expect(redactSensitive(42)).toBe(42);
+    expect(redactSensitive(null)).toBe(null);
+    expect(redactSensitive(undefined)).toBe(undefined);
+  });
+
+  it("caps recursion depth so cycles do not pin the logger", () => {
+    const cycle: Record<string, unknown> = { name: "root" };
+    cycle.self = cycle;
+
+    expect(() => redactSensitive(cycle)).not.toThrow();
+  });
+
+  it("omits deeply-nested arrays at the depth cap instead of leaking null entries to JSON", () => {
+    // Build an object whose array field is reached at MAX_DEPTH. Recursing
+    // into the array elements would exceed the cap; without the array-level
+    // guard, `value.map` would produce `[undefined, ...]` which JSON.stringify
+    // renders as `[null, ...]`. Object properties at the same cap are
+    // already absent from the JSON output (JSON.stringify skips undefined
+    // values on objects), so this test pins the array path to the same
+    // contract: silently absent, not visible as nulls.
+    let payload: Record<string, unknown> = { values: [1, 2, 3] };
+    for (let i = 0; i < 5; i++) payload = { nested: payload };
+
+    const out = redactSensitive(payload);
+
+    const json = JSON.stringify(out);
+    expect(json).not.toContain("null");
+    expect(json).not.toContain("[1,2,3]");
+  });
+});

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -25,16 +25,39 @@ function parseNumber(value: string | undefined, fallback: number) {
   return Math.floor(parsed);
 }
 
+function parseBooleanEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
 function jwtConfig() {
   const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
   if (!secret) return null;
 
   return {
     secret,
-    ttlSeconds: parseNumber(process.env.PAPERCLIP_AGENT_JWT_TTL_SECONDS, 60 * 60 * 48),
+    ttlSeconds: parseNumber(process.env.PAPERCLIP_AGENT_JWT_TTL_SECONDS, 60 * 60),
     issuer: process.env.PAPERCLIP_AGENT_JWT_ISSUER ?? "paperclip",
     audience: process.env.PAPERCLIP_AGENT_JWT_AUDIENCE ?? "paperclip-api",
+    disableLegacyFallback: parseBooleanEnv(process.env.PAPERCLIP_AGENT_JWT_DISABLE_LEGACY_FALLBACK),
   };
+}
+
+/**
+ * Derive a per-company signing key from the master JWT secret and a companyId.
+ *
+ * In a multi-tenant deployment this ensures that a JWT signed for company A
+ * cannot be reused to authenticate as an agent in company B, even if the raw
+ * token leaks. The instance-wide master secret is never used to sign new
+ * tokens — it is retained only as a verification fallback so that tokens
+ * issued before this change continue to validate.
+ *
+ * The derivation domain-separates with the `jwt:` prefix so the same master
+ * secret can safely be reused for other HMAC purposes without key reuse.
+ */
+function deriveCompanySigningKey(masterSecret: string, companyId: string): string {
+  return createHmac("sha256", masterSecret).update(`jwt:${companyId}`).digest("hex");
 }
 
 function base64UrlEncode(value: string) {
@@ -87,7 +110,10 @@ export function createLocalAgentJwt(agentId: string, companyId: string, adapterT
   };
 
   const signingInput = `${base64UrlEncode(JSON.stringify(header))}.${base64UrlEncode(JSON.stringify(claims))}`;
-  const signature = signPayload(config.secret, signingInput);
+  // Sign with the per-company derived key so a leaked token cannot be reused
+  // across tenants.
+  const signingKey = deriveCompanySigningKey(config.secret, companyId);
+  const signature = signPayload(signingKey, signingInput);
 
   return `${signingInput}.${signature}`;
 }
@@ -104,20 +130,40 @@ export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
   const header = parseJson(base64UrlDecode(headerB64));
   if (!header || header.alg !== JWT_ALGORITHM) return null;
 
-  const signingInput = `${headerB64}.${claimsB64}`;
-  const expectedSig = signPayload(config.secret, signingInput);
-  if (!safeCompare(signature, expectedSig)) return null;
-
   const claims = parseJson(base64UrlDecode(claimsB64));
   if (!claims) return null;
 
+  const claimedCompanyId = typeof claims.company_id === "string" ? claims.company_id : null;
+  if (!claimedCompanyId) return null;
+
+  const signingInput = `${headerB64}.${claimsB64}`;
+  // Try the per-company derived key first (current tokens). Fall back to the
+  // raw master secret so tokens issued before per-company derivation existed
+  // continue to verify — this preserves backward compatibility for any
+  // outstanding tokens (TTL bounds the legacy window naturally).
+  //
+  // Operators should set `PAPERCLIP_AGENT_JWT_DISABLE_LEGACY_FALLBACK=true`
+  // approximately one JWT TTL (~1h by default, see PAPERCLIP_AGENT_JWT_TTL_SECONDS)
+  // after deploying per-company signing. Once set, the master-secret fallback
+  // is disabled and only tokens validating under the per-company derived key
+  // are accepted — closing the window in which a leaked master secret could
+  // be used to forge tokens with arbitrary future `exp` values for any tenant.
+  const perCompanyKey = deriveCompanySigningKey(config.secret, claimedCompanyId);
+  const perCompanySig = signPayload(perCompanyKey, signingInput);
+  let signatureOk = safeCompare(signature, perCompanySig);
+  if (!signatureOk && !config.disableLegacyFallback) {
+    const legacySig = signPayload(config.secret, signingInput);
+    signatureOk = safeCompare(signature, legacySig);
+  }
+  if (!signatureOk) return null;
+
   const sub = typeof claims.sub === "string" ? claims.sub : null;
-  const companyId = typeof claims.company_id === "string" ? claims.company_id : null;
   const adapterType = typeof claims.adapter_type === "string" ? claims.adapter_type : null;
   const runId = typeof claims.run_id === "string" ? claims.run_id : null;
   const iat = typeof claims.iat === "number" ? claims.iat : null;
   const exp = typeof claims.exp === "number" ? claims.exp : null;
-  if (!sub || !companyId || !adapterType || !runId || !iat || !exp) return null;
+  if (!sub || !adapterType || !runId || !iat || !exp) return null;
+  const companyId = claimedCompanyId;
 
   const now = Math.floor(Date.now() / 1000);
   if (exp < now) return null;

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -5,6 +5,7 @@ import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+import { redactSensitive } from "./redact-sensitive.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -69,21 +70,21 @@ export const httpLogger = pinoHttp({
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: ctx.reqBody,
-          reqParams: ctx.reqParams,
-          reqQuery: ctx.reqQuery,
+          reqBody: redactSensitive(ctx.reqBody),
+          reqParams: redactSensitive(ctx.reqParams),
+          reqQuery: redactSensitive(ctx.reqQuery),
         };
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = redactSensitive(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
-        props.reqParams = params;
+        props.reqParams = redactSensitive(params);
       }
       if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = query;
+        props.reqQuery = redactSensitive(query);
       }
       if ((req as any).route?.path) {
         props.routePath = (req as any).route.path;

--- a/server/src/middleware/redact-sensitive.ts
+++ b/server/src/middleware/redact-sensitive.ts
@@ -1,0 +1,67 @@
+// Redaction for HTTP log payloads.
+//
+// `customProps` in logger.ts copies `req.body` / `req.params` / `req.query`
+// verbatim into the 4xx/5xx log lines so operators can diagnose. That means
+// Better Auth's `POST /api/auth/sign-in/email` body (which has the user's
+// plaintext password) and similar payloads (sign-up, reset-password, API
+// keys via Authorization header equivalents) end up on disk.
+//
+// This walker returns a shallow copy of the input with values for sensitive
+// keys replaced with the literal string "[REDACTED]". Recurses into nested
+// objects/arrays. Caps depth so a hostile or accidental cycle can't pin
+// the logger.
+
+const SENSITIVE_KEYS = new Set<string>([
+  "password",
+  "currentpassword",
+  "newpassword",
+  "passwordconfirmation",
+  "password_confirmation",
+  "passwordconfirm",
+  "password_confirm",
+  "confirmpassword",
+  "confirm_password",
+  "secret",
+  "client_secret",
+  "clientsecret",
+  "access_token",
+  "accesstoken",
+  "refresh_token",
+  "refreshtoken",
+  "id_token",
+  "idtoken",
+  "api_key",
+  "apikey",
+  "authorization",
+  "auth_token",
+  "authtoken",
+  "session_token",
+  "sessiontoken",
+  "private_key",
+  "privatekey",
+]);
+
+const MAX_DEPTH = 6;
+const REDACTED = "[REDACTED]";
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key.toLowerCase());
+}
+
+export function redactSensitive(value: unknown, depth = 0): unknown {
+  if (depth > MAX_DEPTH) return undefined;
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    if (depth + 1 > MAX_DEPTH) return undefined;
+    return value.map((entry) => redactSensitive(entry, depth + 1));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (isSensitiveKey(key)) {
+      out[key] = REDACTED;
+      continue;
+    }
+    out[key] = redactSensitive(entry, depth + 1);
+  }
+  return out;
+}


### PR DESCRIPTION
Cherry-picks two bounded **security** fixes from Paperclip upstream (we are ~345 behind; cherry-pick per `doc/UPSTREAM-POLICY.md`), in preparation for public/multi-tenant exposure (see `doc/plans/2026-06-16-us-launch-plan.md`).

## Included

- **`bb7978327` fix(logger): redact passwords and tokens from HTTP error log lines** — directly relevant; we handle live tokens (MiniMax/Clockchain/board keys). Adds `server/src/middleware/redact-sensitive.ts` + wires it into `logger.ts`. (clean cherry-pick)
- **`70357b961` feat(security): per-company JWT signing keys for multi-tenant isolation** — hardens agent-auth JWT for multi-customer cloud. (clean cherry-pick)

Both applied with **no conflicts**. Verified: `pnpm --filter @paperclipai/server typecheck` (exit 0) + the two added test suites (20 tests pass).

## Deferred (NOT in this PR)

- **`05bcd3ce8` feat(security): plugin tables get company_id FK for tenant isolation** — the code + schema changes apply cleanly, but the migration diverges on our line: upstream's migration assumes a prior `plugin_entities_external_idx` *index* and recreates it as a `NULLS NOT DISTINCT` unique constraint. After renumbering the migration to our line (0087), 6/8 of its tests pass (company_id columns + cascade delete) but the **2 unique-index-semantics tests fail** because the `NULLS NOT DISTINCT` index doesn't materialize correctly against our schema history. Our drizzle (0.38.4) *does* support `nullsNotDistinct()`, so it's a migration/index-history reconciliation, not a version gap. This needs a deliberate port (fix the `DROP INDEX` premise + verify the unique index) — tracked as a follow-up rather than shipped with failing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)