### PR TITLE
fix(billing): correct Stripe current_period_end source + pin apiVersion

### DIFF
--- a/server/src/__tests__/entitlement-sync.test.ts
+++ b/server/src/__tests__/entitlement-sync.test.ts
@@ -161,6 +161,65 @@ describe("entitlementSync.dispatch", () => {
     );
   });
 
+  // AgentDash (P0.3): current_period_end source — Stripe API >= 2025-03-31
+  // moved current_period_end onto the subscription item. We must read from
+  // the item first so the quota billing window is not corrupted to epoch-1970.
+  it("derives planPeriodEnd from sub.items.data[0].current_period_end when present", async () => {
+    const companies = makeCompanies();
+    const ledger = makeLedger();
+    const sync = entitlementSync({ companies, ledger });
+
+    const itemPeriodEnd = Math.floor(new Date("2026-09-15").getTime() / 1000);
+    const sub = makeSubscription("active", {
+      // New API: top-level current_period_end absent; lives on the item.
+      current_period_end: undefined,
+      items: { data: [{ quantity: 4, current_period_end: itemPeriodEnd }] },
+    });
+    await sync.dispatch(makeEvent("customer.subscription.updated", sub));
+
+    expect(companies.update).toHaveBeenCalledWith(
+      "co-1",
+      expect.objectContaining({ planPeriodEnd: new Date(itemPeriodEnd * 1000) }),
+    );
+  });
+
+  it("prefers the item current_period_end over the legacy top-level field", async () => {
+    const companies = makeCompanies();
+    const ledger = makeLedger();
+    const sync = entitlementSync({ companies, ledger });
+
+    const itemPeriodEnd = Math.floor(new Date("2026-09-15").getTime() / 1000);
+    const legacyPeriodEnd = Math.floor(new Date("2026-06-01").getTime() / 1000);
+    const sub = makeSubscription("active", {
+      current_period_end: legacyPeriodEnd,
+      items: { data: [{ quantity: 4, current_period_end: itemPeriodEnd }] },
+    });
+    await sync.dispatch(makeEvent("customer.subscription.updated", sub));
+
+    expect(companies.update).toHaveBeenCalledWith(
+      "co-1",
+      expect.objectContaining({ planPeriodEnd: new Date(itemPeriodEnd * 1000) }),
+    );
+  });
+
+  it("falls back to the legacy top-level current_period_end when the item lacks it", async () => {
+    const companies = makeCompanies();
+    const ledger = makeLedger();
+    const sync = entitlementSync({ companies, ledger });
+
+    const legacyPeriodEnd = Math.floor(new Date("2026-06-01").getTime() / 1000);
+    const sub = makeSubscription("active", {
+      current_period_end: legacyPeriodEnd,
+      items: { data: [{ quantity: 4 }] },
+    });
+    await sync.dispatch(makeEvent("customer.subscription.updated", sub));
+
+    expect(companies.update).toHaveBeenCalledWith(
+      "co-1",
+      expect.objectContaining({ planPeriodEnd: new Date(legacyPeriodEnd * 1000) }),
+    );
+  });
+
   // AgentDash (#157): past_due tier mapping
   it("sets plan_tier=pro_past_due (NOT pro_active) when subscription status is past_due", async () => {
     const companies = makeCompanies();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -302,7 +302,11 @@ export async function createApp(
   let stripeSdk: any = stripeStubForDev();
   if (stripeKey) {
     const { default: Stripe } = await import("stripe");
-    stripeSdk = new Stripe(stripeKey);
+    // AgentDash (P0.3): pin the API version so a stripe-package upgrade can't
+    // silently shift webhook payload shapes underneath us (e.g. the
+    // current_period_end relocation in 2025-03-31). Matches the installed
+    // stripe@22 LatestApiVersion.
+    stripeSdk = new Stripe(stripeKey, { apiVersion: "2026-04-22.dahlia" });
   }
   // AgentDash (#160): tighter rate limit on /billing/* (abuse vector). The
   // /billing/webhook subpath is hit by Stripe's servers, not users, and must

--- a/server/src/services/entitlement-sync.ts
+++ b/server/src/services/entitlement-sync.ts
@@ -69,7 +69,14 @@ export function entitlementSync(deps: Deps) {
     if (!company) throw new Error(`No company for subscription ${sub.id}`);
     const planTier = STATUS_TO_TIER[sub.status] ?? "free";
     const planSeatsPaid = sub.items?.data?.[0]?.quantity ?? 0;
-    const planPeriodEnd = new Date((sub.current_period_end ?? 0) * 1000);
+    // AgentDash (P0.3): on Stripe API >= 2025-03-31, current_period_end moved
+    // OFF the subscription and ONTO the subscription item. Read from the item
+    // first, falling back to the legacy top-level field for older API versions
+    // / fixtures. Reading the wrong source yields epoch-1970 and corrupts the
+    // quota billing window (see server/src/services/quota.ts).
+    const periodEndSec =
+      sub.items?.data?.[0]?.current_period_end ?? sub.current_period_end ?? 0;
+    const planPeriodEnd = new Date(periodEndSec * 1000);
 
     // AgentDash (#249): read prior tier so we can fire the downgrade
     // notifier if this transition crosses pro-live → downgraded. Only if


### PR DESCRIPTION
## Thinking Path

> - Stripe's 2025-03-31 API release relocated `current_period_end` from the subscription object onto the subscription item. Our entitlement sync still read the top-level field, so on any account on the new API the value resolved to `undefined`, collapsed to `0`, and produced an epoch-1970 `planPeriodEnd`.
> - That corrupted `planPeriodEnd` feeds the quota billing window in `server/src/services/quota.ts`, so a 1970 date means the current billing period is always treated as expired — a silent, account-wide billing breakage that only manifests on real Stripe traffic, not our fixtures.
> - The root enabler was an unpinned SDK init (`new Stripe(stripeKey)`): a `stripe` package bump can shift webhook payload shapes underneath us with no code change. Pinning `apiVersion` makes the payload contract explicit and TypeScript-checked against the installed SDK.
> - Fix is therefore two-part: read `current_period_end` from the item first with a top-level fallback (forward- and backward-compatible), and pin the API version to the installed SDK's `LatestApiVersion` so the contract can't drift.

## What Changed

- `server/src/services/entitlement-sync.ts`: `planPeriodEnd` now derives from the first subscription item's `current_period_end`, falling back to the legacy top-level `current_period_end` and finally to `0`, reading the item-level field first and falling back to the legacy top-level field for older API versions and existing fixtures.
- `server/src/app.ts`: pinned the Stripe SDK init to `new Stripe(stripeKey, { apiVersion: "2026-04-22.dahlia" })`, matching `stripe@22.1.0`'s `LatestApiVersion` (`ApiVersion` constant in the installed package). TypeScript enforces this string against the SDK type.
- `server/src/__tests__/entitlement-sync.test.ts`: added three tests — derives `planPeriodEnd` from the item field when present, prefers the item field over the legacy top-level field, and falls back to the top-level field when the item lacks it.

## Verification

- `pnpm install` — pass (exit 0).
- `pnpm -r typecheck` — pass for all packages (server typecheck confirms the pinned `apiVersion` string satisfies the SDK's `LatestApiVersion` type).
- `pnpm test:run` — pass; the entitlement-sync suite runs 19 tests (16 prior + 3 new) all green.
- `pnpm build` — pass for all packages.

## Risks

- The pinned `apiVersion` string is coupled to `stripe@22.1.0`. A future `stripe` package upgrade that advances `LatestApiVersion` will fail `pnpm -r typecheck` on this literal, which is the intended forcing function — bump the literal alongside the package upgrade and re-verify webhook payload shapes.
- The item-first read assumes seat-based subscriptions carry the period on the first item; multi-item subscriptions would need per-item handling, but AgentDash's per-seat Pro plan uses a single item, so reading the first item is correct for current SKUs.

## AgentDash Review

- **Upstream impact:** None — both `entitlement-sync.ts` and the Stripe init block in `app.ts` are AgentDash-owned billing code (marked with `// AgentDash` issue tags); Paperclip upstream has no equivalent subscription entitlement layer, so there is no merge-conflict surface.
- **Agent-facing prompt surfaces:** None — this change touches Stripe webhook ingestion and SDK configuration only; it does not alter any of the four worker prompt surfaces (`onboarding-assets/{default,ceo,chief_of_staff}/AGENTS.md` or `agent-creator-from-proposal.ts`) and adds no new agent-facing endpoints, gates, or verdicts.
- **AgentDash-owned subsystem:** Subscription + billing — this directly repairs the entitlement sync that writes `planPeriodEnd`, which the quota subsystem (`server/src/services/quota.ts`) reads to compute the active billing window; correctness here is load-bearing for per-seat Pro metering.

## Model Used

Provider: Anthropic (Claude, via Claude Code CLI)
Model: claude-opus-4-8 (1M context) — extended thinking, tool use

## Checklist

- [x] `pnpm -r typecheck` passes
- [x] `pnpm test:run` passes (new entitlement-sync tests included)
- [x] `pnpm build` passes
- [x] Tests added for the billing-surface change
- [x] No changes to agent-facing prompt surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
