### PR TITLE
fix(security): fail-closed Slack signature verification + urlencoded body parser

### DIFF
--- a/server/src/__tests__/slack-connector.test.ts
+++ b/server/src/__tests__/slack-connector.test.ts
@@ -1,9 +1,12 @@
 // AgentDash: Slack Connector (AGE-108) — unit tests
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
 import {
   verifySlackSignature,
   type SlackEventPayload,
 } from "../services/slack-connector.js";
+import { slackConnectorRoutes } from "../routes/slack-connector.js";
 import crypto from "node:crypto";
 
 // ---------------------------------------------------------------------------
@@ -202,5 +205,101 @@ describe("Slack default scopes", () => {
   it("includes user scopes for delegated identity", async () => {
     const { SLACK_USER_SCOPES } = await import("../services/slack-connector.js");
     expect(SLACK_USER_SCOPES).toContain("chat:write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slack connector route security tests (fail-closed + body parsing)
+// ---------------------------------------------------------------------------
+
+describe("Slack connector route security", () => {
+  const SIGNING_SECRET = "test_route_signing_secret_xyz";
+
+  // The events/interactions endpoints short-circuit (503/401) before any DB
+  // access, so a stub db is sufficient for these route-level checks.
+  const stubDb = {} as unknown as Parameters<typeof slackConnectorRoutes>[0];
+
+  function buildApp() {
+    const app = express();
+    // Mirror the parser stack registered in app.ts so rawBody is captured for
+    // both JSON and urlencoded payloads.
+    const captureRawBody = (req: express.Request, _res: express.Response, buf: Buffer) => {
+      (req as unknown as { rawBody: Buffer }).rawBody = buf;
+    };
+    app.use(express.json({ limit: "10mb", verify: captureRawBody }));
+    app.use(express.urlencoded({ extended: true, limit: "10mb", verify: captureRawBody }));
+    app.use("/api/connectors", slackConnectorRoutes(stubDb));
+    return app;
+  }
+
+  function makeSignature(secret: string, timestamp: string, body: string): string {
+    const sigBasestring = `v0:${timestamp}:${body}`;
+    return (
+      "v0=" +
+      crypto.createHmac("sha256", secret).update(sigBasestring, "utf8").digest("hex")
+    );
+  }
+
+  let originalSigningSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSigningSecret = process.env.SLACK_SIGNING_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSigningSecret === undefined) {
+      delete process.env.SLACK_SIGNING_SECRET;
+    } else {
+      process.env.SLACK_SIGNING_SECRET = originalSigningSecret;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("events endpoint fails closed with 503 when signing secret is unset", async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    const res = await request(buildApp())
+      .post("/api/connectors/slack/events")
+      .send({ type: "url_verification", challenge: "abc" });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("Slack connector not configured");
+  });
+
+  it("interactions endpoint fails closed with 503 when signing secret is unset", async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    const res = await request(buildApp())
+      .post("/api/connectors/slack/interactions")
+      .type("form")
+      .send({ payload: JSON.stringify({ type: "block_actions" }) });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("Slack connector not configured");
+  });
+
+  it("parses a urlencoded interactions request with a valid signature", async () => {
+    process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+
+    const payloadObj = {
+      type: "block_actions",
+      user: { id: "U123" },
+      channel: { id: "C123" },
+      actions: [{ action_id: "approve_send", value: "ref-1" }],
+    };
+    // Slack url-encodes the form body; replicate the exact wire bytes so the
+    // HMAC matches what verify() computes over rawBody.
+    const rawBody = `payload=${encodeURIComponent(JSON.stringify(payloadObj))}`;
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = makeSignature(SIGNING_SECRET, timestamp, rawBody);
+
+    const res = await request(buildApp())
+      .post("/api/connectors/slack/interactions")
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .set("x-slack-request-timestamp", timestamp)
+      .set("x-slack-signature", signature)
+      .send(rawBody);
+
+    // A valid signature + urlencoded body parses cleanly and is acked with 200.
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -168,12 +168,26 @@ export async function createApp(
 ) {
   const app = express();
 
+  // AgentDash: capture the raw request body so downstream webhook/connector
+  // routes (Stripe, Slack) can verify HMAC signatures. Shared by both the JSON
+  // and urlencoded parsers so the captured bytes are identical regardless of
+  // content-type. Each parser only handles its own content-type, so registering
+  // both is safe and non-overlapping.
+  const captureRawBody = (req: express.Request, _res: express.Response, buf: Buffer) => {
+    (req as unknown as { rawBody: Buffer }).rawBody = buf;
+  };
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",
-    verify: (req, _res, buf) => {
-      (req as unknown as { rawBody: Buffer }).rawBody = buf;
-    },
+    verify: captureRawBody,
+  }));
+  // AgentDash: Slack sends interactive-component callbacks as
+  // application/x-www-form-urlencoded with a `payload` JSON field. Without this
+  // parser req.body.payload and rawBody are undefined and every interaction 401s.
+  app.use(express.urlencoded({
+    extended: true,
+    limit: "10mb",
+    verify: captureRawBody,
   }));
   app.use(httpLogger);
   const privateHostnameGateEnabled = shouldEnablePrivateHostnameGuard({

--- a/server/src/routes/slack-connector.ts
+++ b/server/src/routes/slack-connector.ts
@@ -82,28 +82,34 @@ export function slackConnectorRoutes(db: Db) {
   router.post("/slack/events", async (req, res) => {
     const config = svc.getConfig();
 
-    // Verify Slack signature if signing secret is configured
-    if (config.signingSecret) {
-      const timestamp = req.headers["x-slack-request-timestamp"] as string | undefined;
-      const signature = req.headers["x-slack-signature"] as string | undefined;
-      const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    // AgentDash: security — FAIL CLOSED. If no signing secret is configured we
+    // cannot verify that requests genuinely originate from Slack, so we must
+    // reject everything rather than process forged payloads. Mirrors the Stripe
+    // webhook guard in billing.ts.
+    if (!config.signingSecret) {
+      res.status(503).json({ error: "Slack connector not configured" });
+      return;
+    }
 
-      if (!timestamp || !signature || !rawBody) {
-        res.status(401).json({ error: "Missing Slack signature headers" });
-        return;
-      }
+    const timestamp = req.headers["x-slack-request-timestamp"] as string | undefined;
+    const signature = req.headers["x-slack-signature"] as string | undefined;
+    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
 
-      const isValid = verifySlackSignature(
-        config.signingSecret,
-        timestamp,
-        rawBody.toString("utf8"),
-        signature,
-      );
+    if (!timestamp || !signature || !rawBody) {
+      res.status(401).json({ error: "Missing Slack signature headers" });
+      return;
+    }
 
-      if (!isValid) {
-        res.status(401).json({ error: "Invalid Slack signature" });
-        return;
-      }
+    const isValid = verifySlackSignature(
+      config.signingSecret,
+      timestamp,
+      rawBody.toString("utf8"),
+      signature,
+    );
+
+    if (!isValid) {
+      res.status(401).json({ error: "Invalid Slack signature" });
+      return;
     }
 
     const payload = req.body as SlackEventPayload;
@@ -151,28 +157,31 @@ export function slackConnectorRoutes(db: Db) {
   router.post("/slack/interactions", async (req, res) => {
     const config = svc.getConfig();
 
-    // Verify Slack signature
-    if (config.signingSecret) {
-      const timestamp = req.headers["x-slack-request-timestamp"] as string | undefined;
-      const signature = req.headers["x-slack-signature"] as string | undefined;
-      const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    // AgentDash: security — FAIL CLOSED. See /slack/events above.
+    if (!config.signingSecret) {
+      res.status(503).json({ error: "Slack connector not configured" });
+      return;
+    }
 
-      if (!timestamp || !signature || !rawBody) {
-        res.status(401).json({ error: "Missing Slack signature headers" });
-        return;
-      }
+    const timestamp = req.headers["x-slack-request-timestamp"] as string | undefined;
+    const signature = req.headers["x-slack-signature"] as string | undefined;
+    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
 
-      const isValid = verifySlackSignature(
-        config.signingSecret,
-        timestamp,
-        rawBody.toString("utf8"),
-        signature,
-      );
+    if (!timestamp || !signature || !rawBody) {
+      res.status(401).json({ error: "Missing Slack signature headers" });
+      return;
+    }
 
-      if (!isValid) {
-        res.status(401).json({ error: "Invalid Slack signature" });
-        return;
-      }
+    const isValid = verifySlackSignature(
+      config.signingSecret,
+      timestamp,
+      rawBody.toString("utf8"),
+      signature,
+    );
+
+    if (!isValid) {
+      res.status(401).json({ error: "Invalid Slack signature" });
+      return;
     }
 
     // Slack sends interactions as form-encoded with a `payload` JSON field


### PR DESCRIPTION
## Thinking Path

> - Started from the launch-blocker report: the Slack Events and Interactions endpoints both gated HMAC verification behind `if (config.signingSecret)`, which means an unset secret silently disabled all signature checks and let anyone POST forged payloads — the textbook fail-open vulnerability.
> - Cross-referenced the Stripe webhook guard in `server/src/routes/billing.ts`, which already establishes the fail-closed precedent (503 when the secret is missing) and confirmed the same pattern should apply to Slack so the codebase stays consistent.
> - Traced why interactions were dead even with a secret: `app.ts` only registered `express.json` with a rawBody-capturing verify hook, but Slack posts interactions as `application/x-www-form-urlencoded`, so both `req.body.payload` and `rawBody` were undefined and every interaction 401'd before the handler could run.
> - Decided to extract the rawBody capture into a shared `captureRawBody` function used by both the JSON and urlencoded parsers, since each parser only consumes its own content-type and the captured bytes must be identical for HMAC verification to match.

## What Changed

- `server/src/routes/slack-connector.ts`: both `/slack/events` and `/slack/interactions` now fail closed — when `config.signingSecret` is falsy they respond `503 { error: "Slack connector not configured" }` and return before parsing any payload. The signature-header presence and HMAC validity checks are now unconditional rather than nested inside the secret guard.
- `server/src/app.ts`: added `express.urlencoded({ extended: true, limit: "10mb", verify })` immediately after `express.json`, with a shared `captureRawBody` verify function so both parsers populate `rawBody` for downstream signature verification.
- `server/src/__tests__/slack-connector.test.ts`: added route-level tests mounting the real router via supertest — asserting 503 fail-closed on both endpoints when the secret is unset, and that a urlencoded interactions request with a valid signature parses `req.body.payload` and acks 200.

## Verification

- `pnpm install` — pass
- `pnpm -r typecheck` — pass (all packages)
- `pnpm test:run` — pass (full suite green, exit 0; new slack route tests included)
- `pnpm build` — pass (all packages, exit 0)

## Risks

- If `SLACK_SIGNING_SECRET` is not set in an environment where Slack is expected to work, both endpoints will now return 503 instead of silently accepting requests. This is the intended behavior and matches the Stripe guard, but operators must ensure the secret is configured before enabling Slack — otherwise inbound events and interactive callbacks will be rejected.
- The new `express.urlencoded` parser is global. It only handles `application/x-www-form-urlencoded` bodies and does not affect JSON routes, so the blast radius is limited to form-encoded requests, which previously had no parser at all.

## AgentDash Review

- **Upstream impact:** `app.ts` is a Paperclip core file; the change is an additive `express.urlencoded` registration alongside the existing `express.json` and an extracted verify helper, so it is a small, isolated, low-conflict surface that should rebase cleanly against upstream.
- **Agent-facing prompt surfaces:** none touched — this is HTTP transport and signature verification for the Slack connector; no worker prompts, `AGENTS.md` files, or agent-creation surfaces are modified, so the four-prompt-surface convention does not apply here.
- **AgentDash-owned subsystem:** the Slack connector (`server/src/routes/slack-connector.ts`, AGE-108) is 100% AgentDash-owned, so the fail-closed change carries no upstream-merge coupling and is fully within our maintenance scope.

## Model Used

Provider: Anthropic (Claude, via Claude Code CLI)
Model: claude-opus-4-8 (1M context) — extended thinking, tool use

## Checklist

- [x] Both Slack endpoints fail closed (503) when the signing secret is unset
- [x] Signature header + HMAC checks run unconditionally when the secret is present
- [x] `express.urlencoded` registered so interactions bodies and rawBody parse correctly
- [x] Tests added for 503 fail-closed and urlencoded signature parsing
- [x] `pnpm -r typecheck`, `pnpm test:run`, `pnpm build` all green
