### PR TITLE
fix(access): enforce invite role ceiling to prevent privilege escalation

### DIFF
--- a/server/src/__tests__/invite-create-route.test.ts
+++ b/server/src/__tests__/invite-create-route.test.ts
@@ -13,14 +13,22 @@ const tierDepsMock = {
   },
 };
 
+// AgentDash: invite-role-ceiling (P0.5) — lets individual tests stub the
+// inviting actor's resolved company role for the role-ceiling checks.
+const getMembershipMock = vi.fn(
+  async (_companyId: string, _type: string, _userId: string) =>
+    null as { status: string; membershipRole: string } | null,
+);
+
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentInstructionRefreshService: () => ({ refreshForAgent: vi.fn(), refreshForRole: vi.fn() }),
     ISSUE_LIST_DEFAULT_LIMIT: 50,
     accessService: () => ({
       isInstanceAdmin: vi.fn(),
-      canUser: vi.fn(),
+      canUser: vi.fn(async () => true),
       hasPermission: vi.fn(),
+      getMembership: (...args: [string, string, string]) => getMembershipMock(...args),
     }),
     agentService: () => ({
       getById: vi.fn(),
@@ -93,7 +101,7 @@ function createDbStub() {
   return db;
 }
 
-async function createApp() {
+async function createApp(actor?: Record<string, unknown>) {
   const [{ accessRoutes }, { errorHandler }] = await Promise.all([
     import("../routes/access.js"),
     import("../middleware/index.js"),
@@ -101,7 +109,7 @@ async function createApp() {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
+    (req as any).actor = actor ?? {
       type: "board",
       source: "local_implicit",
       userId: null,
@@ -136,7 +144,19 @@ describe("POST /companies/:companyId/invites", () => {
     tierDepsMock.getCompany.mockResolvedValue({ planTier: "pro_active" });
     tierDepsMock.counts.humans.mockResolvedValue(0);
     tierDepsMock.counts.agents.mockResolvedValue(0);
+    getMembershipMock.mockReset();
+    getMembershipMock.mockResolvedValue(null);
   });
+
+  // A non-local board actor whose company role is resolved via getMembership.
+  function boardUserActor(userId = "actor-user") {
+    return {
+      type: "board",
+      source: "board_api_key",
+      userId,
+      companyIds: ["company-1"],
+    } as Record<string, unknown>;
+  }
 
   afterEach(() => {
     if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
@@ -222,5 +242,74 @@ describe("POST /companies/:companyId/invites", () => {
 
     expect(res.status).toBe(402);
     expect(res.body.code).toBe("seat_cap_exceeded");
+  });
+
+  // AgentDash: invite-role-ceiling (P0.5) — privilege-escalation guard.
+  describe("invite role ceiling", () => {
+    it("rejects an admin inviting an owner with 403", async () => {
+      getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "admin" });
+      const app = await createApp(boardUserActor());
+
+      const res = await request(app)
+        .post("/api/companies/company-1/invites")
+        .send({ allowedJoinTypes: "human", humanRole: "owner" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/role above your own/i);
+    });
+
+    it("allows an admin inviting an operator", async () => {
+      getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "admin" });
+      const app = await createApp(boardUserActor());
+
+      const res = await request(app)
+        .post("/api/companies/company-1/invites")
+        .send({ allowedJoinTypes: "human", humanRole: "operator" });
+
+      expect(res.status).toBe(201);
+    });
+
+    it("allows an admin inviting a viewer", async () => {
+      getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "admin" });
+      const app = await createApp(boardUserActor());
+
+      const res = await request(app)
+        .post("/api/companies/company-1/invites")
+        .send({ allowedJoinTypes: "human", humanRole: "viewer" });
+
+      expect(res.status).toBe(201);
+    });
+
+    it("allows an owner inviting an owner", async () => {
+      getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "owner" });
+      const app = await createApp(boardUserActor());
+
+      const res = await request(app)
+        .post("/api/companies/company-1/invites")
+        .send({ allowedJoinTypes: "human", humanRole: "owner" });
+
+      expect(res.status).toBe(201);
+    });
+
+    it("allows an owner inviting an admin", async () => {
+      getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "owner" });
+      const app = await createApp(boardUserActor());
+
+      const res = await request(app)
+        .post("/api/companies/company-1/invites")
+        .send({ allowedJoinTypes: "human", humanRole: "admin" });
+
+      expect(res.status).toBe(201);
+    });
+
+    it("still allows the local-implicit founding board owner to invite an owner", async () => {
+      const app = await createApp();
+
+      const res = await request(app)
+        .post("/api/companies/company-1/invites")
+        .send({ allowedJoinTypes: "human", humanRole: "owner" });
+
+      expect(res.status).toBe(201);
+    });
   });
 });

--- a/server/src/__tests__/join-approval-tier-route.test.ts
+++ b/server/src/__tests__/join-approval-tier-route.test.ts
@@ -9,6 +9,11 @@ const notifyHireApprovedMock = vi.fn().mockResolvedValue(undefined);
 const seatSyncMock = vi.fn().mockResolvedValue(undefined);
 const ensureMembershipMock = vi.fn().mockResolvedValue(undefined);
 const setPrincipalGrantsMock = vi.fn().mockResolvedValue(undefined);
+// AgentDash: invite-role-ceiling (P0.5) — resolves the approver's company role.
+const getMembershipMock = vi.fn(
+  async (_companyId: string, _type: string, _userId: string) =>
+    null as { status: string; membershipRole: string } | null,
+);
 const agentCreateMock = vi.fn();
 const agentListMock = vi.fn();
 const tierDepsMock = {
@@ -23,10 +28,11 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     accessService: () => ({
       isInstanceAdmin: vi.fn(),
-      canUser: vi.fn(),
+      canUser: vi.fn(async () => true),
       hasPermission: vi.fn(),
       ensureMembership: ensureMembershipMock,
       setPrincipalGrants: setPrincipalGrantsMock,
+      getMembership: (...args: [string, string, string]) => getMembershipMock(...args),
     }),
     agentService: () => ({
       list: agentListMock,
@@ -84,25 +90,25 @@ function joinRequestRow(overrides: Partial<JoinRequestRow>): JoinRequestRow {
   };
 }
 
-function inviteRow() {
+function inviteRow(defaultsPayload: Record<string, unknown> | null = null) {
   return {
     id: "invite-1",
     companyId: "company-1",
     inviteType: "company_join",
     allowedJoinTypes: "both",
-    defaultsPayload: null,
+    defaultsPayload,
   };
 }
 
 function createDbStub(
   joinRequest: JoinRequestRow,
-  options: { lockedJoinRequest?: JoinRequestRow } = {},
+  options: { lockedJoinRequest?: JoinRequestRow; inviteDefaultsPayload?: Record<string, unknown> | null } = {},
 ) {
   const selectQueue: unknown[][] = [
     [joinRequest],
-    [inviteRow()],
+    [inviteRow(options.inviteDefaultsPayload)],
     [options.lockedJoinRequest ?? joinRequest],
-    [inviteRow()],
+    [inviteRow(options.inviteDefaultsPayload)],
   ];
   const db: any = {
     execute: vi.fn().mockResolvedValue([]),
@@ -128,7 +134,7 @@ function createDbStub(
   return db;
 }
 
-async function createApp(db: unknown) {
+async function createApp(db: unknown, actor?: Record<string, unknown>) {
   const [{ accessRoutes }, { errorHandler }] = await Promise.all([
     import("../routes/access.js"),
     import("../middleware/error-handler.js"),
@@ -136,7 +142,7 @@ async function createApp(db: unknown) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
+    (req as any).actor = actor ?? {
       type: "board",
       source: "local_implicit",
       userId: "owner-1",
@@ -178,7 +184,19 @@ describe("POST /companies/:companyId/join-requests/:requestId/approve Free tier 
       role: "general",
       status: "idle",
     });
+    getMembershipMock.mockReset();
+    getMembershipMock.mockResolvedValue(null);
   });
+
+  // A non-local board actor whose company role is resolved via getMembership.
+  function boardUserActor(userId = "approver-user") {
+    return {
+      type: "board",
+      source: "board_api_key",
+      userId,
+      companyIds: ["company-1"],
+    } as Record<string, unknown>;
+  }
 
   afterEach(() => {
     if (originalStripeSecretKey === undefined) delete process.env.STRIPE_SECRET_KEY;
@@ -272,5 +290,49 @@ describe("POST /companies/:companyId/join-requests/:requestId/approve Free tier 
     expect(tierDepsMock.counts.humans).not.toHaveBeenCalled();
     expect(ensureMembershipMock).not.toHaveBeenCalled();
     expect(db.update).not.toHaveBeenCalled();
+  });
+
+  // AgentDash: invite-role-ceiling (P0.5) — privilege-escalation guard.
+  it("rejects an admin approving a join request that would grant owner with 403", async () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    process.env.AGENTDASH_BILLING_DISABLED = "true";
+    getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "admin" });
+    const db = createDbStub(
+      joinRequestRow({ requestType: "human" }),
+      { inviteDefaultsPayload: { human: { role: "owner" } } },
+    );
+    const app = await createApp(db, boardUserActor());
+
+    const res = await request(app)
+      .post("/api/companies/company-1/join-requests/join-1/approve")
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/role above your own/i);
+    expect(ensureMembershipMock).not.toHaveBeenCalled();
+  });
+
+  it("allows an admin approving a join request that grants operator", async () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    process.env.AGENTDASH_BILLING_DISABLED = "true";
+    getMembershipMock.mockResolvedValue({ status: "active", membershipRole: "admin" });
+    const db = createDbStub(
+      joinRequestRow({ requestType: "human" }),
+      { inviteDefaultsPayload: { human: { role: "operator" } } },
+    );
+    const app = await createApp(db, boardUserActor());
+
+    const res = await request(app)
+      .post("/api/companies/company-1/join-requests/join-1/approve")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(ensureMembershipMock).toHaveBeenCalledWith(
+      "company-1",
+      "user",
+      "user-2",
+      "operator",
+      "active",
+    );
   });
 });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1080,6 +1080,30 @@ async function resolveActorHumanRole(
   return normalizeHumanRole(membership.membershipRole, "operator");
 }
 
+// AgentDash: invite-role-ceiling (P0.5) — prevent privilege escalation. A
+// human actor may only invite or approve a role at or below their own company
+// role. Board owners, local-implicit actors, and instance admins resolve to
+// "owner" via resolveActorHumanRole and so retain full ability. Agent actors
+// are gated by permission grants (users:invite / joins:approve), not human
+// role ranks, so they are exempt here — assertCompanyPermission already
+// authorized them.
+async function assertInviteRoleCeiling(
+  req: Request,
+  access: ReturnType<typeof accessService>,
+  companyId: string,
+  requestedRole: HumanCompanyMembershipRole | null,
+): Promise<void> {
+  if (!requestedRole) return;
+  if (req.actor.type === "agent") return;
+  const actorRole = await resolveActorHumanRole(req, access, companyId);
+  if (!actorRole) {
+    throw forbidden("Only active company members can invite users.");
+  }
+  if (humanRoleRank[requestedRole] > humanRoleRank[actorRole]) {
+    throw forbidden("You cannot invite a role above your own company role.");
+  }
+}
+
 async function getProtectedMemberReason(
   req: Request,
   access: ReturnType<typeof accessService>,
@@ -2982,6 +3006,15 @@ export function accessRoutes(
       const companyId = req.params.companyId as string;
       await assertCompanyPermission(req, companyId, "users:invite");
       const allowedJoinTypes = req.body.allowedJoinTypes as TierInviteJoinType;
+      // AgentDash: invite-role-ceiling (P0.5) — an admin must not be able to
+      // invite/auto-approve an owner. The effective human role mirrors
+      // createCompanyInviteForCompany: agent-only invites carry no human role,
+      // otherwise null defaults to "operator".
+      const requestedHumanRole: HumanCompanyMembershipRole | null =
+        allowedJoinTypes === "agent"
+          ? null
+          : normalizeHumanRole(req.body.humanRole ?? "operator", "operator");
+      await assertInviteRoleCeiling(req, access, companyId, requestedHumanRole);
       const inviteResult = await withTierCapacityForInviteWrite(
         companyId,
         allowedJoinTypes,
@@ -4001,6 +4034,9 @@ export function accessRoutes(
             const membershipRole = resolveHumanInviteRole(
               lockedInvite.defaultsPayload as Record<string, unknown> | null,
             );
+            // AgentDash: invite-role-ceiling (P0.5) — approving a join request
+            // must not grant a role above the approver's own company role.
+            await assertInviteRoleCeiling(req, txAccess, companyId, membershipRole);
             await txAccess.ensureMembership(
               companyId,
               "user",


### PR DESCRIPTION
## Thinking Path

> - The reported launch-blocker (P0.5) is a privilege-escalation hole: `POST /companies/:companyId/invites` passed `humanRole` straight through to `createCompanyInviteForCompany` with `autoApprove`, and the join-request approve path granted whatever role the invite carried, neither checking the value against the acting member's own role. An `admin` could thus mint or auto-approve an `owner`.
> - Rather than invent new comparison logic, I reused the file's existing `humanRoleRank` rank map and `resolveActorHumanRole` helper — the same machinery `getProtectedMemberReason` already uses for member removal — so the ceiling direction (higher rank means more privilege) stays consistent across the file.
> - The hard edge was not breaking legitimate flows: local-implicit founders, instance admins, and board owners already resolve to `owner` via `resolveActorHumanRole`, and agent actors are authorized by permission grants (`users:invite` / `joins:approve`) not by human role rank. I made the new check exempt agents and treat those board actors as full-privilege, then proved both directions with tests.
> - I deliberately did not add a ceiling to the invite-accept path: the accepting user only receives the role baked into the invite at creation time, which the creation-side ceiling already constrains. The two enforcement points (create + approve) cover every path where a role is chosen by a privileged actor.

## What Changed

- `server/src/routes/access.ts`: added `assertInviteRoleCeiling(req, access, companyId, requestedRole)`. It returns early for null roles and for agent actors (gated by grants), otherwise resolves the actor's company role via `resolveActorHumanRole` and rejects with `forbidden(...)` when the requested role's rank in `humanRoleRank` exceeds the actor's rank.
- Wired the ceiling into the `POST /companies/:companyId/invites` handler: the effective requested human role is computed the same way `createCompanyInviteForCompany` does (agent-only invites carry no human role; null defaults to `operator`) and checked before the invite is created.
- Wired the ceiling into the `POST /companies/:companyId/join-requests/:requestId/approve` transaction: the role resolved from the invite defaults is checked against the approver before `ensureMembership` runs.
- Tests in `invite-create-route.test.ts` and `join-approval-tier-route.test.ts`: stubbed `getMembership` to drive the actor's resolved role and added cases for admin->owner (403), admin->operator/viewer (ok), owner->owner/admin (ok), founder board owner (ok), join-approve->owner (403), and join-approve->operator (ok).

## Verification

- `pnpm install` — passed (pre-existing plugin-sdk bin warnings only).
- `pnpm -r typecheck` — passed for all packages (server, ui, cli, shared, db, adapters, plugins).
- `pnpm test:run` — passed, exit 0; full suite incl. the largest batch at 1549 passed / 9 skipped and the two touched files at 17 passed; no failing test files.
- `pnpm build` — passed, exit 0 (pre-existing duplicate-key warning in root package.json, unrelated to this change).
- Targeted run of `invite-create-route.test.ts` + `join-approval-tier-route.test.ts`: 17 passed.

## Risks

- A misconfigured actor whose membership cannot be resolved now gets a 403 on invite/approve instead of silently proceeding; this is the intended fail-closed behavior but could surface as a "permission denied" for an actor with a broken membership row. Mitigated because board owners, local-implicit founders, and instance admins short-circuit to `owner` before the membership lookup.
- The check is additive and placed after the existing permission gate, so it cannot widen access; worst case is over-restriction, which the owner/founder test cases guard against.

## AgentDash Review

- **Upstream impact:** `server/src/routes/access.ts` is an AgentDash-modified core route; the change is additive (a new helper plus two call sites) and introduces no new conflict surface beyond what AgentDash already owns in this file, so future upstream cherry-picks are unaffected.
- **Agent-facing prompt surfaces:** none touched — no changes to `server/src/onboarding-assets/**/AGENTS.md` or `agent-creator-from-proposal.ts`; agent actors are explicitly exempted from the ceiling because they are authorized by permission grants, so no agent workflow or prompt contract changes.
- **AgentDash-owned subsystem:** this hardens the AgentDash multi-human access-control layer (company memberships, invites, join-request auto-approve) which is AgentDash-owned; it preserves the invariant that approval gates cannot grant a role above the approver's own.

## Model Used

Provider: Anthropic (Claude, via Claude Code CLI)
Model: claude-opus-4-8 (1M context) — extended thinking, tool use

## Checklist

- [x] `pnpm -r typecheck` passes
- [x] `pnpm test:run` passes (exit 0, no failing files)
- [x] `pnpm build` passes
- [x] Access-control tests added for both the invite and join-approve ceiling
- [x] Existing owner-invites-admin and founder-board flows verified intact
